### PR TITLE
Prevent car charging if Powerwall needs to charge

### DIFF
--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -108,16 +108,14 @@ class TeslaPowerwall2:
     # Return generation value
     return float(self.generatedW)
 
-  def getPWValues(self):
-
+  def getPWJson(self, path):
     # Fetch the specified URL from Powerwall and return the data
     self.fetchFailed = False
 
     # Get a login token, if password authentication is enabled
     self.doPowerwallLogin()
 
-    url = "https://" + self.serverIP + ":" + self.serverPort
-    url += "/api/meters/aggregates"
+    url = "https://" + self.serverIP + ":" + self.serverPort + path
     headers = {}
 
     # Send authentication token if password authentication is enabled
@@ -130,44 +128,19 @@ class TeslaPowerwall2:
     try:
         r = self.requests.get(url, headers = headers, timeout=self.timeout, verify=False)
     except self.requests.exceptions.ConnectionError as e:
-        self.debugLog(4, "Error connecting to Tesla Powerwall 2 to fetch solar data")
+        self.debugLog(4, "Error connecting to Tesla Powerwall 2 to fetch " + path)
         self.debugLog(10, str(e))
         self.fetchFailed = True
         return False
 
     r.raise_for_status()
     return r.json()
+
+  def getPWValues(self):
+    return self.getPWJson("/api/meters/aggregates")
 
   def getSOE(self):
-
-    # Fetch the specified URL from Powerwall and return the data
-    self.fetchFailed = False
-
-    # Get a login token, if password authentication is enabled
-    self.doPowerwallLogin()
-
-    url = "https://" + self.serverIP + ":" + self.serverPort
-    url += "/api/system_status/soe"
-    headers = {}
-
-    # Send authentication token if password authentication is enabled
-    if ((self.password is not None) and (self.tokenProvider == "basic")):
-      headers['Authorization'] = "Bearer " + self.token
-    else:
-      self.debugLog(1, "Error: Powerwall password is set, but no token method matches.")
-      self.debugLog(1, "Token method reported by Powerwall is " + str(self.tokenProvider))
-
-    try:
-        r = self.requests.get(url, headers = headers, timeout=self.timeout, verify=False)
-    except self.requests.exceptions.ConnectionError as e:
-        self.debugLog(4, "Error connecting to Tesla Powerwall 2 to fetch charge state")
-        self.debugLog(10, str(e))
-        self.fetchFailed = True
-        return False
-
-    r.raise_for_status()
-    return r.json()
-
+    return self.getPWJson("/api/system_status/soe")
 
   def startPowerwall(self):
     # This function will instruct the powerwall to run.

--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -5,7 +5,7 @@ class TeslaPowerwall2:
   import requests
   import time
 
-  batteryLevel    = 0
+  batteryLevel    = 100
   cacheTime       = 60
   config          = None
   configConfig    = None
@@ -17,6 +17,7 @@ class TeslaPowerwall2:
   gridStatus      = False
   importW         = 0
   exportW         = 0
+  minSOE          = 90
   lastFetch       = 0
   password        = None
   serverIP        = None
@@ -43,6 +44,7 @@ class TeslaPowerwall2:
     self.serverIP          = self.configPowerwall.get('serverIP', None)
     self.serverPort        = self.configPowerwall.get('serverPort','443')
     self.password          = self.configPowerwall.get('password', None)
+    self.minSOE            = self.configPowerwall.get('minBatteryLevel', 90)
 
   def debugLog(self, minlevel, message):
     if (self.debugLevel >= minlevel):
@@ -104,6 +106,11 @@ class TeslaPowerwall2:
 
     # Perform updates if necessary
     self.update()
+
+    if ( self.batteryLevel < self.minSOE ):
+      # Battery is below threshold; keep all generation for PW charging
+      self.debugLog(5, "Powerwall2 energy level below target. Skipping getGeneration")
+      return 0
 
     # Return generation value
     return float(self.generatedW)

--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -5,6 +5,7 @@ class TeslaPowerwall2:
   import requests
   import time
 
+  batteryLevel    = 0
   cacheTime       = 60
   config          = None
   configConfig    = None
@@ -137,6 +138,37 @@ class TeslaPowerwall2:
     r.raise_for_status()
     return r.json()
 
+  def getSOE(self):
+
+    # Fetch the specified URL from Powerwall and return the data
+    self.fetchFailed = False
+
+    # Get a login token, if password authentication is enabled
+    self.doPowerwallLogin()
+
+    url = "https://" + self.serverIP + ":" + self.serverPort
+    url += "/api/system_status/soe"
+    headers = {}
+
+    # Send authentication token if password authentication is enabled
+    if ((self.password is not None) and (self.tokenProvider == "basic")):
+      headers['Authorization'] = "Bearer " + self.token
+    else:
+      self.debugLog(1, "Error: Powerwall password is set, but no token method matches.")
+      self.debugLog(1, "Token method reported by Powerwall is " + str(self.tokenProvider))
+
+    try:
+        r = self.requests.get(url, headers = headers, timeout=self.timeout, verify=False)
+    except self.requests.exceptions.ConnectionError as e:
+        self.debugLog(4, "Error connecting to Tesla Powerwall 2 to fetch charge state")
+        self.debugLog(10, str(e))
+        self.fetchFailed = True
+        return False
+
+    r.raise_for_status()
+    return r.json()
+
+
   def startPowerwall(self):
     # This function will instruct the powerwall to run.
     # This is needed after getting a login token for v1.15 and above
@@ -182,6 +214,13 @@ class TeslaPowerwall2:
         self.voltage = int(value['site']['instant_average_voltage'])
       else:
         # Fetch failed to obtain values
+        self.fetchFailed = True
+
+      value = self.getSOE()
+
+      if (value):
+        self.batteryLevel = float(value['percentage'])
+      else:
         self.fetchFailed = True
 
       # Update last fetch time


### PR DESCRIPTION
I was thinking about different ways to structure this, and realized that the simplest way to make `check_green_energy()` return zero when the Powerwall battery is depleted is simply not to report any generation.  `check_green_energy()` will conclude the house is consuming more than it's generating, and not allow any car charging.

Note that this does cause a slight error if the solar system is oversized versus the Powerwall and is currently producing more power than the Powerwall could absorb.  This seems like an acceptable error case.

This change does three major things:
- Generalizes the `GetPWValues()` method to fetch arbitrary paths from the PW API, replacing `GetPWValues()` with a call to this function with a particular path
- Fetches the PW charge level as part of each update
- Returns zero from getGeneration() if the Powerwall charge state is below a configurable threshold (by default, 90%)

**IMPORTANT NOTE:**  I don't have a working setup yet, so this is totally untested code.  Please get someone with a Powerwall system to try this before merging.  (I'm supposed to get my system in February, so I'll try it then if no one else has.)

Fixes #12.