### PR TITLE
PHP 7.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ install:
 	sudo usermod -a -G www-data pi
 	
 	sudo cp html/* /var/www/html/
-	cp TWCManager.py /usr/bin/
+	sudo cp TWCManager.py /usr/bin/
 
 	# Create configuration directory
-	mkdir /etc/twcmanager
-	cp etc/twcmanager/config.json /etc/twcmanager/
+	sudo mkdir /etc/twcmanager
+	sudo cp etc/twcmanager/config.json /etc/twcmanager/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 install:
 
 	sudo apt-get update
-	sudo apt-get install -y lighttpd php7.0-cgi screen git python3-pip
+	sudo apt-get install -y lighttpd php7.3-cgi screen git python3-pip
 	pip3 install pyserial
 	pip3 install sysv_ipc
 	sudo lighty-enable-mod fastcgi-php ; exit 0


### PR DESCRIPTION
7.0 is not available on a fresh install of Raspbian.  `make install` seems to work properly with PHP 7.3, however.