### PR TITLE
Support remote debugging

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -51,6 +51,11 @@ from lib.TWCManager.TWCMaster import TWCMaster
 from lib.TWCManager.Vehicle.TeslaAPI import CarApi
 from lib.TWCManager.Vehicle.TeslaAPI import CarApiVehicle
 
+if 'DEBUG_SECRET' in os.environ:
+    import ptvsd
+    ptvsd.enable_attach(os.environ['DEBUG_SECRET'])
+    ptvsd.wait_for_attach()
+
 ##########################
 # Load Configuration File
 config = None


### PR DESCRIPTION
Should be zero net effect on regular runs, but this will enable a debugger not running on the Pi to attach to and trace the live instance.