### PR TITLE
Fix chargelimit

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -366,8 +366,8 @@ class TWCMaster:
       return 0
 
   def getNormalChargeLimit(self, ID):
-    if 'chargeLimits' in self.settings and ID in self.settings['chargeLimits']:
-        return (True, self.settings['chargeLimits'][ID] )
+    if 'chargeLimits' in self.settings and str(ID) in self.settings['chargeLimits']:
+        return (True, self.settings['chargeLimits'][str(ID)] )
     return (False, None)
 
   def getSerial(self):
@@ -555,8 +555,8 @@ class TWCMaster:
     self.backgroundTasksLock.release()
 
   def removeNormalChargeLimit(self, ID):
-    if( 'chargeLimits' in self.settings and ID in self.settings['chargeLimits'] ):
-      del self.settings['chargeLimits'][ID]
+    if( 'chargeLimits' in self.settings and str(ID) in self.settings['chargeLimits'] ):
+      del self.settings['chargeLimits'][str(ID)]
       self.saveSettings()
 
   def resetChargeNowAmps(self):
@@ -569,7 +569,7 @@ class TWCMaster:
     if( not 'chargeLimits' in self.settings ):
       self.settings['chargeLimits'] = dict()
 
-    self.settings['chargeLimits'][ID] = limit
+    self.settings['chargeLimits'][str(ID)] = limit
     self.saveSettings()
 
   def saveSettings(self):

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -11,7 +11,7 @@ class CarApi:
   carApiTokenExpireTime = time.time()
   carApiLastStartOrStopChargeTime = 0
   carApiLastChargeLimitApplyTime = 0
-  lastChargeLimitApplied = -1
+  lastChargeLimitApplied = 0
   carApiVehicles      = []
   config              = None
   debugLevel          = 0


### PR DESCRIPTION
Finally found my nagging bugs.

- Using the vehicle ID as the dictionary key works as long as the dictionary stays in memory, but once it round-trips through the JSON file, the dictionary keys are strings.  Since the vehicle object keeps its ID as an integer, that tripped up basically any attempt to find "outside" chargelimits.  This coerces the ID to a string any time it interacts with the dictionary, so the round-trip through JSON doesn't change anything.
- Using -1 as the default value for the last-set limit means that if the system starts in a policy where it should remove any limits set by policy, it won't, because it thinks it already did that.  Starting the value at 0, which can never be passed in, ensures that it always attempts to apply the new limit at startup.

Now, may these be the last roadblocks to this code working properly!