### PR TITLE
Fix permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,4 @@ ifeq (,$(wildcard /etc/twcmanager/config.json))
 	$(SUDO) cp etc/twcmanager/config.json /etc/twcmanager/
 endif
 	$(SUDO) chown root:pi /etc/twcmanager -R
+	$(SUDO) chmod 775 /etc/twcmanager

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ endif
 
 	$(SUDO) cp html/* /var/www/html/
 	$(SUDO) chown -R www-data:www-data /var/www/html
-	$(SUDO) chmod -R 665 /var/www/html
+	$(SUDO) chmod -R 665 /var/www/html/*
+	$(SUDO) chmod 775 /var/www/html
 	$(SUDO) usermod -a -G www-data pi
 
 	# Install TWCManager packages


### PR DESCRIPTION
Double check on a clean system, but I believe that the directories need execute permissions to access the files inside them, even if the files themselves don't need to be executed.