### PR TITLE
Car properties

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -520,8 +520,7 @@ class TWCMaster:
         module = None
         if pieces[1] in self.modules:
           module = self.getModuleByName(pieces[1])
-          if pieces[2] in vars(module):
-            return getattr(module,pieces[2])
+          return getattr(module,pieces[2],value)
 
     # None of the macro conditions matched, return the value as is
     return value

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -762,6 +762,17 @@ class TeslaAPI:
     self.carApiLastStartOrStopChargeTime = self.time.time()
     return True
 
+  @property
+  def numCarsAtHome(self):
+      return len([car for car in self.carApiVehicles if car.atHome])
+
+  @property
+  def minBatteryLevelAtHome(self):
+      return min(
+          [car.batteryLevel for car in self.carApiVehicles if car.atHome],
+          default=10000
+      )
+
 class CarApiVehicle:
 
     import time

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -795,7 +795,7 @@ class CarApiVehicle:
     stopAskingToStartCharging = False
     stopTryingToApplyLimit = False
 
-    batteryLevel = -1
+    batteryLevel = 10000
     chargeLimit  = -1
     lat = 10000
     lon = 10000


### PR DESCRIPTION
Based on #57; includes a fix that was keeping properties from being exposed to `policyValue()`.  Exposes some properties that might be useful.

Separately, we should think about documenting a list of properties people might want to reference from their policy configs.  Right now, you have to crawl (or write) the code to know these are there.