### PR TITLE
Check battery from property

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -170,6 +170,8 @@ def background_tasks_thread():
             carapi.applyChargeLimit(limit=carapi.lastChargeLimitApplied, checkArrival=True)
         elif(task['cmd'] == 'checkDeparture'):
             carapi.applyChargeLimit(limit=carapi.lastChargeLimitApplied, checkDeparture=True)
+        elif(task['cmd'] == 'checkCharge'):
+            carapi.updateChargeAtHome()
 
         # Delete task['cmd'] from backgroundTasksCmds such that
         # queue_background_task() can queue another task['cmd'] in the future.

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -121,6 +121,10 @@
         # you will need to un-comment it to have it take effect.
         #"minChargeLevel": 10,
 
+        # The cloudUpdateInterval determines how often to poll certain
+        # data retrieved from the Tesla API to evaluate policy.
+        "cloudUpdateInterval": 1800,
+
         # These parameters enable you to specify different charge limits
         # for different charging policies.  The car's 'outside' limit
         # will be restored whenever GPS indicates the car has left home.

--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -44,6 +44,7 @@ class TeslaPowerwall2:
     self.password          = self.configPowerwall.get('password', None)
     self.minSOE            = self.configPowerwall.get('minBatteryLevel', 90)
     self.cloudID           = self.configPowerwall.get('cloudID', None)
+    self.cloudCacheTime    = self.configConfig.get('cloudUpdateInterval',1800)
     self.httpSession       = self.requests.session()
     if self.status and self.debugLevel < 11:
       # PW uses self-signed certificates; squelch warnings

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -12,6 +12,8 @@ class TeslaAPI:
   carApiLastStartOrStopChargeTime = 0
   carApiLastChargeLimitApplyTime = 0
   lastChargeLimitApplied = 0
+  lastChargeCheck     = 0
+  chargeUpdateInterval = 1800
   carApiVehicles      = []
   config              = None
   debugLevel          = 0
@@ -40,6 +42,7 @@ class TeslaAPI:
         self.config = master.config
         self.debugLevel = self.config['config']['debugLevel']
         self.minChargeLevel = self.config['config']['minChargeLevel']
+        self.chargeUpdateInterval = self.config['config'].get('cloudUpdateInterval', 1800)
     except KeyError:
         pass
 
@@ -674,6 +677,9 @@ class TeslaAPI:
                     continue
 
             vehicle.stopTryingToApplyLimit = vehicle.apply_charge_limit(limit)
+    
+    if checkArrival:
+        self.updateChargeAtHome()
 
   def debugLog(self, minlevel, message):
     if (self.debugLevel >= minlevel):
@@ -762,12 +768,20 @@ class TeslaAPI:
     self.carApiLastStartOrStopChargeTime = self.time.time()
     return True
 
+  def updateChargeAtHome(self):
+    for car in self.carApiVehicles:
+        if car.atHome:
+            car.update_charge(wake=False)
+    self.lastChargeCheck = self.time.time()
+
   @property
   def numCarsAtHome(self):
       return len([car for car in self.carApiVehicles if car.atHome])
 
   @property
   def minBatteryLevelAtHome(self):
+      if self.time.time() - self.lastChargeCheck > self.chargeUpdateInterval:
+          self.updateChargeAtHome()
       return min(
           [car.batteryLevel for car in self.carApiVehicles if car.atHome],
           default=10000


### PR DESCRIPTION
As I was thinking through failure scenarios for my new policies, I realized that nothing will prompt the TeslaAPI module to check/recheck what the battery level is except when a policy is selected which applies a charge limit.  This change fixes that from a couple directions:

- The `checkArrival` background task triggered when a car first plugs in will fetch the battery level for all cars found to be at home.
- Accessing the `minBatteryLevelAtHome` property of TeslaAPI will occasionally (every 30 minutes, controllable by new variable) refresh the battery level of all cars known to be at home, but without waking the car first.  Net result, it won't wake any sleeping car, but will get updated info from cars that happen to be awake.
    - New variable is also used to control the frequency of Storm Watch checks
- There's a new background task which isn't actually used anywhere in the code, but can be used as the background task for any policy where the criteria depend on the battery level.  This will actively track the battery level while charging, enabling the policy to no longer match when the target battery level has been hit.