### PR TITLE
Logging

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -365,8 +365,11 @@ class TWCMaster:
 
   def getNormalChargeLimit(self, ID):
     if 'chargeLimits' in self.settings and str(ID) in self.settings['chargeLimits']:
-        return (True, self.settings['chargeLimits'][str(ID)] )
-    return (False, None)
+        result = self.settings['chargeLimits'][str(ID)]
+        if type(result) is int:
+          result = (result, 0)
+        return (True,) + result
+    return (False, None, None)
 
   def getSlaveByID(self, twcid):
     return self.slaveTWCs[twcid]
@@ -569,11 +572,11 @@ class TWCMaster:
     self.settings['chargeNowAmps'] = 0
     self.settings['chargeNowTimeEnd'] = 0
 
-  def saveNormalChargeLimit(self, ID, limit):
+  def saveNormalChargeLimit(self, ID, outsideLimit, lastApplied):
     if( not 'chargeLimits' in self.settings ):
       self.settings['chargeLimits'] = dict()
 
-    self.settings['chargeLimits'][str(ID)] = limit
+    self.settings['chargeLimits'][str(ID)] = (outsideLimit, lastApplied)
     self.saveSettings()
 
   def saveSettings(self):

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -763,7 +763,9 @@ class TWCMaster:
 
             # Yes, we will now enforce policy
             self.debugLog(7, "TWCMaster ", f("All policy conditions have matched. Policy chosen is {colored(policy['name'], 'red')}"))
-            self.active_policy = str(policy['name'])
+            if self.active_policy != str(policy['name']):
+              self.debugLog(1, "TWCMaster ", f("New policy selected; changing to {colored(policy['name'], 'red')}"))
+              self.active_policy = str(policy['name'])
 
             # Determine which value to set the charging to
             if (policy['charge_amps'] == "value"):

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -368,7 +368,7 @@ class TWCMaster:
         result = self.settings['chargeLimits'][str(ID)]
         if type(result) is int:
           result = (result, 0)
-        return (True,) + result
+        return (True, result[0], result[1])
     return (False, None, None)
 
   def getSlaveByID(self, twcid):

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -668,7 +668,7 @@ class TeslaAPI:
                 if limit != -1:
                     self.master.debugLog(2, "TeslaAPI  ", vehicle.name + ' has departed')
                 if( vehicle.apply_charge_limit(target) ):
-                    self.master.debugLog(2, "TeslaAPI  ", 'Restoring ' + vehicle.name + ' to charge limit ' + str(target))
+                    self.master.debugLog(2, "TeslaAPI  ", 'Restoring ' + vehicle.name + ' to charge limit ' + str(target) + '%')
                     self.master.removeNormalChargeLimit(vehicle.ID)
                     vehicle.stopTryingToApplyLimit = True
             else:
@@ -684,7 +684,7 @@ class TeslaAPI:
                     continue
 
             if vehicle.apply_charge_limit(limit):
-                self.master.debugLog(2, "TeslaAPI  ", 'Set ' + vehicle.name + ' to charge limit ' + str(limit))
+                self.master.debugLog(2, "TeslaAPI  ", 'Set ' + vehicle.name + ' to charge limit of ' + str(limit) + '%')
                 vehicle.stopTryingToApplyLimit = True
 
   def getCarApiBearerToken(self):

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -457,7 +457,7 @@ class TeslaAPI:
 
     for vehicle in self.getCarApiVehicles():
         if(charge and vehicle.stopAskingToStartCharging):
-            self.master.debugLog(8, "TeslaAPI  ", "Don't charge vehicle " + vehicle.name
+            self.master.debugLog(8, "TeslaAPI  ", "Don't charge " + vehicle.name
                       + " because vehicle.stopAskingToStartCharging == True")
             continue
 
@@ -574,7 +574,7 @@ class TeslaAPI:
                             # Remember, this only means at least one car in the
                             # list wants us to stop asking and we don't know
                             # which car in the list is connected to our TWC.
-                            self.master.debugLog(1, "TeslaAPI  ", 'Vehicle ' + vehicle.name
+                            self.master.debugLog(1, "TeslaAPI  ", vehicle.name
                                       + ' is done charging or already trying to charge.  Stop asking to start charging.')
                             vehicle.stopAskingToStartCharging = True
                         else:

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -687,10 +687,15 @@ class TeslaAPI:
                         self.master.removeNormalChargeLimit(vehicle.ID)
             else:
                 vehicle.stopTryingToApplyLimit = True
-        elif vehicle.apply_charge_limit(limit):
-            self.master.debugLog(2, "TeslaAPI  ", 'Set ' + vehicle.name + ' to charge limit of ' + str(limit) + '%')
-            vehicle.stopTryingToApplyLimit = True
-            self.master.saveNormalChargeLimit(vehicle.ID, outside, limit)
+        else:
+            if vehicle.chargeLimit != limit:
+                if( vehicle.apply_charge_limit(limit) ):
+                    self.master.debugLog(2, "TeslaAPI  ", 'Set ' + vehicle.name + ' to charge limit of ' + str(limit) + '%')
+                    vehicle.stopTryingToApplyLimit = True
+                    self.master.saveNormalChargeLimit(vehicle.ID, outside, limit)
+            else:
+                vehicle.stopTryingToApplyLimit = True
+                self.master.saveNormalChargeLimit(vehicle.ID, outside, limit)
 
     if checkArrival:
         self.updateChargeAtHome()

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -665,6 +665,8 @@ class TeslaAPI:
         if( limit == -1 or (located and not vehicle.atHome) ):
             # We're removing any applied limit
             if(found):
+                if limit != -1:
+                    self.master.debugLog(2, "TeslaAPI  ", vehicle.name + ' has departed')
                 if( vehicle.apply_charge_limit(target) ):
                     self.master.debugLog(2, "TeslaAPI  ", 'Restoring ' + vehicle.name + ' to charge limit ' + str(target))
                     self.master.removeNormalChargeLimit(vehicle.ID)
@@ -674,6 +676,7 @@ class TeslaAPI:
         else:
             # We're applying a new limit
             if( not found ):
+                self.master.debugLog(2, "TeslaAPI  ", vehicle.name + ' has arrived')
                 if( vehicle.update_charge() ):
                     self.master.saveNormalChargeLimit(vehicle.ID, vehicle.chargeLimit)
                 else:

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -634,7 +634,7 @@ class TeslaAPI:
     #   - We think the car is at home and we've been asked to check for departures
     #   - We think the car is at home and we notice it gone
     #   - We think the car is away from home and we've been asked to check for arrivals
-    # 
+    #
     # We do NOT opportunistically check for arrivals, because that would be a
     # continuous API poll.
     for vehicle in self.carApiVehicles:
@@ -643,7 +643,7 @@ class TeslaAPI:
                 limit != self.lastChargeLimitApplied or
                 checkDeparture or
                 (vehicle.update_location(wake=False) and not vehicle.atHome))) or
-            (not wasAtHome and limit != -1 and checkArrival)):
+            (not wasAtHome and checkArrival)):
             vehicle.stopTryingToApplyLimit = False
 
     if(self.car_api_available(applyLimit = True) == False):

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -177,13 +177,13 @@ class TeslaAPI:
                     # Vehicle is in a state (complete or charging) already
                     # which doesn't make sense for us to keep requesting it
                     # to start charging, so we will stop.
-                    self.master.debugLog(11, "TeslaAPI  ", "Don't repeatedly request API to charge vehicle "
-                        + str(vehicle.ID) + ", because vehicle.stopAskingToStartCharging "
+                    self.master.debugLog(11, "TeslaAPI  ", "Don't repeatedly request API to charge "
+                        + vehicle.name + ", because vehicle.stopAskingToStartCharging "
                         + " == True - it has already been requested.")
                     continue
 
                 if(applyLimit == True and vehicle.stopTryingToApplyLimit):
-                    self.master.debugLog(8, "TeslaAPI  ", "Don't wake vehicle " + str(vehicle.ID)
+                    self.master.debugLog(11, "TeslaAPI  ", "Don't wake " + vehicle.name
                               + " to set the charge limit - it has already been set")
                     continue
 
@@ -191,7 +191,7 @@ class TeslaAPI:
                     # It's been under carApiErrorRetryMins minutes since the car
                     # API generated an error on this vehicle. Don't send it more
                     # commands yet.
-                    self.master.debugLog(11, "TeslaAPI  ", "Don't send commands to vehicle " + str(vehicle.ID)
+                    self.master.debugLog(11, "TeslaAPI  ", "Don't send commands to " + vehicle.name
                               + " because it returned an error in the last "
                               + str(self.getCarApiErrorRetryMins()) + " minutes.")
                     continue
@@ -454,7 +454,7 @@ class TeslaAPI:
 
     for vehicle in self.getCarApiVehicles():
         if(charge and vehicle.stopAskingToStartCharging):
-            self.master.debugLog(8, "TeslaAPI  ", "Don't charge vehicle " + str(vehicle.ID)
+            self.master.debugLog(8, "TeslaAPI  ", "Don't charge vehicle " + vehicle.name
                       + " because vehicle.stopAskingToStartCharging == True")
             continue
 
@@ -481,7 +481,7 @@ class TeslaAPI:
 
             if(not vehicle.atHome):
                 # Vehicle is not at home, so don't change its charge state.
-                self.master.debugLog(1, "TeslaAPI  ", 'Vehicle ID ' + str(vehicle.ID) +
+                self.master.debugLog(1, "TeslaAPI  ", vehicle.name +
                           ' is not at home.  Do not ' + startOrStop + ' charge.')
                 continue
 
@@ -509,7 +509,7 @@ class TeslaAPI:
                 pass
 
             try:
-                self.master.debugLog(4, "TeslaAPI  ", 'Car API TWC ID: ' + str(vehicle.ID) + ": " + startOrStop + ' charge response' + str(apiResponseDict))
+                self.master.debugLog(4, "TeslaAPI  ", vehicle.name + ": " + startOrStop + ' charge response' + str(apiResponseDict))
                 # Responses I've seen in apiResponseDict:
                 # Car is done charging:
                 #   {'response': {'result': False, 'reason': 'complete'}}
@@ -571,7 +571,7 @@ class TeslaAPI:
                             # Remember, this only means at least one car in the
                             # list wants us to stop asking and we don't know
                             # which car in the list is connected to our TWC.
-                            self.master.debugLog(1, "TeslaAPI  ", 'Vehicle ' + str(vehicle.ID)
+                            self.master.debugLog(1, "TeslaAPI  ", 'Vehicle ' + vehicle.name
                                       + ' is done charging or already trying to charge.  Stop asking to start charging.')
                             vehicle.stopAskingToStartCharging = True
                         else:
@@ -822,7 +822,7 @@ class CarApiVehicle:
         if(self.carapi.getCarApiRetryRemaining(self.lastErrorTime)):
             # It's been under carApiErrorRetryMins minutes since the car API
             # generated an error on this vehicle. Return that car is not ready.
-            self.master.debugLog(8, "TeslaAPI  ", 'Vehicle ' + str(self.ID)
+            self.master.debugLog(8, "TeslaAPI  ", self.name
                     + ' not ready because of recent lastErrorTime '
                     + str(self.lastErrorTime))
             return False
@@ -837,7 +837,7 @@ class CarApiVehicle:
             # was issued.  Times I've tested: 1:35, 1:57, 2:30
             return True
 
-        self.carapi.master.debugLog(8, "TeslaVehic", 'Vehicle ' + str(self.ID) + " not ready because it wasn't woken in the last 2 minutes.")
+        self.carapi.master.debugLog(8, "TeslaVehic", self.name + " not ready because it wasn't woken in the last 2 minutes.")
         return False
 
     def get_car_api(self, url, wake=True):
@@ -903,7 +903,7 @@ class CarApiVehicle:
                 # This catches cases like trying to access
                 # apiResponseDict['response'] when 'response' doesn't exist in
                 # apiResponseDict.
-                self.carapi.master.debugLog(1, "TeslaVehic", "ERROR: Can't access vehicle status " + str(self.ID) + \
+                self.carapi.master.debugLog(1, "TeslaVehic", "ERROR: Can't access vehicle status for " + self.name + \
                           ".  Will try again later.")
                 self.lastErrorTime = self.time.time()
                 return (False, None)


### PR DESCRIPTION
Assorted minor improvements:

- The vehicle object now keeps each car's `display_name` for use in logging
- Log at level 1 when the policy changes
- Log the following at level 2:
  - Vehicle arrival/departure
  - Changes in charge limits due to policy changes, arrival, or departure

(This does have a small conflict with #61; the resolution is straightforward, or I can fix one after the other merges, as you prefer.)