### PR TITLE
Policy latch

### DIFF
--- a/docs/PolicyCustomization.md
+++ b/docs/PolicyCustomization.md
@@ -66,6 +66,8 @@ The values in a policy definition are:
   effect (optional)
 - `background_task`:  A background task to be run periodically while the policy
   is in effect (optional)
+- `latch_period`:  If the conditions for this policy are ever matched, treat
+  them as matched for this many minutes, even if they change. (optional)
 
 ### Policy Values
 


### PR DESCRIPTION
One of my new policies checks the Powerwall battery level, which has an obvious-in-retrospect flaw:  If you're right at that battery level (or drain to it after selecting the policy), then you'll oscillate around it:  Turn the policy on for 30 seconds, deplete the battery slightly, turn the policy off for a while, recharge the battery above it, then turn the policy on....

This lets you set a latch period on a custom policy, such that if the conditions for the policy *ever* evaluate true, the policy is treated as true for that number of minutes.  Earlier policies can still pre-empt it, but the latched policy will not evaluate false until the time is up.  Technically, this still oscillates, but you can dampen the period of oscillation.