### PR TITLE
Minor cleanup

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -465,13 +465,10 @@ class TWCMaster:
 
   def num_cars_charging_now(self):
 
-    carsCharging = 0
-    for slaveTWC in self.getSlaveTWCs():
-        if(slaveTWC.reportedAmpsActual >= 1.0):
-            carsCharging += 1
-            self.debugLog(10, "TWCMaster ", "Number of cars charging now: " + str(carsCharging))
-            for module in self.getModulesByType('Status'):
-              module['ref'].setStatus(slaveTWC.TWCID, "cars_charging", "carsCharging", carsCharging)
+    carsCharging = len([slaveTWC for slaveTWC in self.getSlaveTWCs() if slaveTWC.reportedAmpsActual >= 1.0])
+    self.debugLog(10, "TWCMaster ", "Number of cars charging now: " + str(carsCharging))
+    for module in self.getModulesByType('Status'):
+      module['ref'].setStatus(slaveTWC.TWCID, "cars_charging", "carsCharging", carsCharging)
     return carsCharging
 
   def policyValue(self, value):

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -465,6 +465,16 @@ class TWCMaster:
 
   def num_cars_charging_now(self):
 
+    carsCharging = 0
+    for slaveTWC in self.getSlaveTWCs():
+        charging = 1 if slaveTWC.reportedAmpsActual >= 1.0 else 0
+        carsCharging += charging
+        for module in self.getModulesByType('Status'):
+          module['ref'].setStatus(slaveTWC.TWCID, "cars_charging", "carsCharging", charging)
+    self.debugLog(10, "TWCMaster ", "Number of cars charging now: " + str(carsCharging))
+    return carsCharging
+
+
     carsCharging = len([slaveTWC for slaveTWC in self.getSlaveTWCs() if slaveTWC.reportedAmpsActual >= 1.0])
     self.debugLog(10, "TWCMaster ", "Number of cars charging now: " + str(carsCharging))
     for module in self.getModulesByType('Status'):

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -452,14 +452,7 @@ class TWCSlave:
         desiredAmpsOffered = self.master.getMaxAmpsToDivideAmongSlaves()
 
         if (numCarsCharging > 0):
-            for slaveTWC in self.master.getSlaveTWCs():
-                if(slaveTWC.TWCID != self.TWCID):
-                    # To avoid exceeding maxAmpsToDivideAmongSlaves, we must
-                    # subtract the actual amps being used by this TWC from the amps
-                    # we will offer.
-                    desiredAmpsOffered -= slaveTWC.reportedAmpsActual
-                    if(slaveTWC.reportedAmpsActual >= 1.0):
-                        numCarsCharging += 1
+            desiredAmpsOffered -= sum(slaveTWC.reportedAmpsActual for slaveTWC in self.master.getSlaveTWCs() if slaveTWC.TWCID != self.TWCID)
 
             # Allocate this slave a fraction of maxAmpsToDivideAmongSlaves divided
             # by the number of cars actually charging.


### PR DESCRIPTION
The old code only printed/updated the value of `num_cars_charging_now` if it was non-zero, but then prints it counting up every time.  This would cause the reported value to be very jerky, even if it's actually steady.

Using a list comprehension means you report a correct value, once.  (Note this does mean it will also print zero values now; I think they do need to be reported to the status module, but I can condition the print if you want.)