### PR TITLE
Flex current

### DIFF
--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -95,6 +95,12 @@
         # not needed and can be set to 0
         "greenEnergyAmpsOffset": 0,
 
+        # If green energy dips below the target charge amount while already charging,
+        # how much extra current should be drawn to keep charging?  This avoids frequently
+        # stopping and starting charging on a day with variable solar output, at the cost
+        # of drawing energy from sources other than solar.
+        "greenEnergyFlexAmps": 0,
+
         # In some environments, the consumption meter value that we obtain will
         # include the charger's consumption, whilst others will not.
         # This switch, if set to true, will subtract the charger's load from the

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -9,46 +9,51 @@ from ww import f
 # Global reference to master
 master = None
 
+
 class ThreadingSimpleServer(ThreadingMixIn, HTTPServer):
-  pass
+    pass
+
 
 class HTTPControl:
 
-  configConfig = {}
-  configHTTP   = {}
-  debugLevel   = 1
-  httpPort     = 8080
-  master       = None
-  status       = False
+    configConfig = {}
+    configHTTP = {}
+    debugLevel = 1
+    httpPort = 8080
+    master = None
+    status = False
 
-  def __init__(self, master):
+    def __init__(self, master):
 
-    self.master = master
-    try:
-      self.configConfig = master.config['config']
-    except KeyError:
-      self.configConfig = {}
-    try:
-      self.configHTTP   = master.config['control']['HTTP']
-    except KeyError:
-      self.configHTTP   = {}
-    self.debugLevel   = self.configConfig.get('debugLevel', 1)
-    self.httpPort     = self.configHTTP.get('listenPort', 8080)
-    self.status       = self.configHTTP.get('enabled', False)
+        self.master = master
+        try:
+            self.configConfig = master.config["config"]
+        except KeyError:
+            self.configConfig = {}
+        try:
+            self.configHTTP = master.config["control"]["HTTP"]
+        except KeyError:
+            self.configHTTP = {}
+        self.debugLevel = self.configConfig.get("debugLevel", 1)
+        self.httpPort = self.configHTTP.get("listenPort", 8080)
+        self.status = self.configHTTP.get("enabled", False)
 
-    if (self.status):
-      httpd = ThreadingSimpleServer(("", self.httpPort), HTTPControlHandler)
-      self.master.debugLog(1, "HTTPCtrl  ", "Serving at port: " + str(self.httpPort))
-      threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        if self.status:
+            httpd = ThreadingSimpleServer(("", self.httpPort), HTTPControlHandler)
+            self.master.debugLog(
+                1, "HTTPCtrl  ", "Serving at port: " + str(self.httpPort)
+            )
+            threading.Thread(target=httpd.serve_forever, daemon=True).start()
+
 
 class HTTPControlHandler(BaseHTTPRequestHandler):
 
-  fields                = {}
+    fields = {}
 
-  def do_css(self):
+    def do_css(self):
 
-    page = "<style>"
-    page += """
+        page = "<style>"
+        page += """
       table.darkTable {
         font-family: 'Arial Black', Gadget, sans-serif;
         border: 2px solid #000000;
@@ -91,11 +96,11 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
       }
       
       """
-    page += "</style>"
-    return page
+        page += "</style>"
+        return page
 
-  def do_chargeSchedule(self):
-    page = """
+    def do_chargeSchedule(self):
+        page = """
     <table class='table table-borderless'>
       <thead>
         <th scope='col'>&nbsp;</th>
@@ -108,15 +113,15 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
         <th scope='col'>Sat</th>
       </thead>
       <tbody>"""
-    for i in (x for y in (range(6, 24), range(0,5)) for x in y):
-      page += "<tr><th scope='row'>%02d</th><td>&nbsp;</td></tr>" % (i)
-    page += "</tbody>"
-    page += "</table>"
+        for i in (x for y in (range(6, 24), range(0, 5)) for x in y):
+            page += "<tr><th scope='row'>%02d</th><td>&nbsp;</td></tr>" % (i)
+        page += "</tbody>"
+        page += "</table>"
 
-    return page
+        return page
 
-  def do_jsrefresh(self):
-    page = """
+    def do_jsrefresh(self):
+        page = """
       // Only refresh the main page if the browser window has focus, and if
       // the input form does not have focus
       <script language = 'JavaScript'>
@@ -144,10 +149,10 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
           }
       }
       </script> """
-    return page
+        return page
 
-  def do_navbar(self):
-    page = """
+    def do_navbar(self):
+        page = """
     <p>&nbsp;</p>
     <p>&nbsp;</p>
     <nav class='navbar fixed-top navbar-dark bg-dark' role='navigation'>
@@ -175,10 +180,10 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
       </ul>
       <span class="navbar-text">v1.1.8</span>
     </nav>"""
-    return page
+        return page
 
-  def do_get_settings(self):
-    page = """
+    def do_get_settings(self):
+        page = """
     <html>
     <head><title>Settings</title></head>
     <body>
@@ -188,15 +193,15 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
           <th>Stop Charging Method</th>
           <td>
   <select name='chargeStopMode'>"""
-    page += '<option value="1" '
-    if (master.settings.get('chargeStopMode', "1") == "1"):
-      page += "selected"
-    page += ">Tesla API</option>"
-    page += '<option value="2" '
-    if (master.settings.get('chargeStopMode', "1") == "2"):
-      page += "selected"
-    page += ">Stop Responding to Slaves</option>"
-    page += """
+        page += '<option value="1" '
+        if master.settings.get("chargeStopMode", "1") == "1":
+            page += "selected"
+        page += ">Tesla API</option>"
+        page += '<option value="2" '
+        if master.settings.get("chargeStopMode", "1") == "2":
+            page += "selected"
+        page += ">Stop Responding to Slaves</option>"
+        page += """
   </select>
           </td>
         </tr>
@@ -209,269 +214,274 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
     </body>
     </html>
     """
-    return page
+        return page
 
-  def do_GET(self):
-    global master
-    url = urllib.parse.urlparse(self.path)
+    def do_GET(self):
+        global master
+        url = urllib.parse.urlparse(self.path)
 
-    if (url.path == '/' or 
-        url.path == '/apiacct/True' or 
-        url.path == '/apiacct/False'):
-      self.send_response(200)
-      self.send_header('Content-type','text/html')
-      self.end_headers()
+        if (
+            url.path == "/"
+            or url.path == "/apiacct/True"
+            or url.path == "/apiacct/False"
+        ):
+            self.send_response(200)
+            self.send_header("Content-type", "text/html")
+            self.end_headers()
 
-      # Send the html message
-      page = "<html><head>"
-      page += "<title>TWCManager</title>"
-      page += "<meta name='viewport' content='width=device-width, initial-scale=1'>"
-      page += "<link rel='stylesheet' href='https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css' integrity='sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T' crossorigin='anonymous'>"
-      page += self.do_css()
-      page += self.do_jsrefresh()
-      page += "</head>"
-      page += "<body>"
-      page += self.do_navbar()
-      page += "<table border='0' padding='0' margin='0'><tr>"
-      page += "<td valign='top'>"
+            # Send the html message
+            page = "<html><head>"
+            page += "<title>TWCManager</title>"
+            page += (
+                "<meta name='viewport' content='width=device-width, initial-scale=1'>"
+            )
+            page += "<link rel='stylesheet' href='https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css' integrity='sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T' crossorigin='anonymous'>"
+            page += self.do_css()
+            page += self.do_jsrefresh()
+            page += "</head>"
+            page += "<body>"
+            page += self.do_navbar()
+            page += "<table border='0' padding='0' margin='0'><tr>"
+            page += "<td valign='top'>"
 
-      if (url.path == '/apiacct/False'):
-        page += "<font color='red'><b>Failed to log in to Tesla Account. Please check username and password and try again.</b></font>"
+            if url.path == "/apiacct/False":
+                page += "<font color='red'><b>Failed to log in to Tesla Account. Please check username and password and try again.</b></font>"
 
-      if (not master.teslaLoginAskLater and url.path != '/apiacct/True'):
-        page += self.request_teslalogin()
+            if not master.teslaLoginAskLater and url.path != "/apiacct/True":
+                page += self.request_teslalogin()
 
-      if (url.path == '/apiacct/True'):
-        page += "<b>Thank you, successfully fetched Tesla API token."
+            if url.path == "/apiacct/True":
+                page += "<b>Thank you, successfully fetched Tesla API token."
 
-      page += self.show_status()
+            page += self.show_status()
 
-      page += "</table>"
-      page += "</body>"
-      page += "</table>"
-      page += "</html>"
+            page += "</table>"
+            page += "</body>"
+            page += "</table>"
+            page += "</html>"
 
-      self.wfile.write(page.encode("utf-8"))
-      return
+            self.wfile.write(page.encode("utf-8"))
+            return
 
-    if (url.path == '/settings'):
-      self.send_response(200)
-      self.send_header('Content-type','text/html')
-      self.end_headers()
-      page = self.do_get_settings()
-      self.wfile.write(page.encode("utf-8"))
-      return
+        if url.path == "/settings":
+            self.send_response(200)
+            self.send_header("Content-type", "text/html")
+            self.end_headers()
+            page = self.do_get_settings()
+            self.wfile.write(page.encode("utf-8"))
+            return
 
-    if (url.path == '/tesla-login'):
-      # For security, these details should be submitted via a POST request
-      # Send a 405 Method Not Allowed in response.
-      self.send_response(405)
-      page = "This function may only be requested via the POST HTTP method."
-      self.wfile.write(page.encode("utf-8"))
-      return
+        if url.path == "/tesla-login":
+            # For security, these details should be submitted via a POST request
+            # Send a 405 Method Not Allowed in response.
+            self.send_response(405)
+            page = "This function may only be requested via the POST HTTP method."
+            self.wfile.write(page.encode("utf-8"))
+            return
 
-    # All other routes missed, return 404
-    self.send_response(404)
+        # All other routes missed, return 404
+        self.send_response(404)
 
-  def do_POST(self):
-    global master
+    def do_POST(self):
+        global master
 
-    # Parse URL
-    url = urllib.parse.urlparse(self.path)
+        # Parse URL
+        url = urllib.parse.urlparse(self.path)
 
-    # Parse POST parameters
-    self.fields.clear()
-    length = int(self.headers.get('content-length'))
-    field_data = self.rfile.read(length)
-    self.fields = urllib.parse.parse_qs(str(field_data))
+        # Parse POST parameters
+        self.fields.clear()
+        length = int(self.headers.get("content-length"))
+        field_data = self.rfile.read(length)
+        self.fields = urllib.parse.parse_qs(str(field_data))
 
-    if (url.path == '/settings/save'):
-      # User has submitted settings.
-      # Call dedicated function
-      self.process_settings()
-      return
+        if url.path == "/settings/save":
+            # User has submitted settings.
+            # Call dedicated function
+            self.process_settings()
+            return
 
-    if (url.path == '/tesla-login'):
-      # User has submitted Tesla login.
-      # Pass it to the dedicated process_teslalogin function
-      self.process_teslalogin()
-      return
+        if url.path == "/tesla-login":
+            # User has submitted Tesla login.
+            # Pass it to the dedicated process_teslalogin function
+            self.process_teslalogin()
+            return
 
-    # All other routes missed, return 404
-    self.send_response(404)
-    self.end_headers()
-    self.wfile.write(''.encode("utf-8"))
-    return
+        # All other routes missed, return 404
+        self.send_response(404)
+        self.end_headers()
+        self.wfile.write("".encode("utf-8"))
+        return
 
-  def process_settings(self):
+    def process_settings(self):
 
-      # Write settings
-      for key in self.fields:
-        keya = str(key).replace("b'","")
-        vala = self.fields[key][0].replace("'", "")
-        master.settings[keya] = vala
-      master.saveSettings()
+        # Write settings
+        for key in self.fields:
+            keya = str(key).replace("b'", "")
+            vala = self.fields[key][0].replace("'", "")
+            master.settings[keya] = vala
+        master.saveSettings()
 
-      # Redirect to the index page
-      self.send_response(302)
-      self.send_header('Location', '/')
-      self.end_headers()
-      self.wfile.write(''.encode("utf-8"))
-      return
+        # Redirect to the index page
+        self.send_response(302)
+        self.send_header("Location", "/")
+        self.end_headers()
+        self.wfile.write("".encode("utf-8"))
+        return
 
-  def process_teslalogin(self):
-    # Check if we are skipping Tesla Login submission
+    def process_teslalogin(self):
+        # Check if we are skipping Tesla Login submission
 
-    if (not master.teslaLoginAskLater):
-      later = False
-      try:
-        later = len(self.fields['later'])
-      except KeyError as e:
-        later = False
+        if not master.teslaLoginAskLater:
+            later = False
+            try:
+                later = len(self.fields["later"])
+            except KeyError as e:
+                later = False
 
-      if (later):
-        master.teslaLoginAskLater = True
+            if later:
+                master.teslaLoginAskLater = True
 
-    if (not master.teslaLoginAskLater):
-      # Connect to Tesla API
+        if not master.teslaLoginAskLater:
+            # Connect to Tesla API
 
-      carapi = self.master.getModuleByName("TeslaAPI")
-      carapi.setCarApiLastErrorTime(0)
-      ret = carapi.car_api_available(self.fields['email'][0],self.fields['password'][0])
+            carapi = self.master.getModuleByName("TeslaAPI")
+            carapi.setCarApiLastErrorTime(0)
+            ret = carapi.car_api_available(
+                self.fields["email"][0], self.fields["password"][0]
+            )
 
-      # Redirect to an index page with output based on the return state of
-      # the function
-      self.send_response(302)
-      self.send_header('Location', '/apiacct/' + str(ret))
-      self.end_headers()
-      self.wfile.write(''.encode("utf-8"))
-      return
-    else:
-      # User has asked to skip Tesla Account submission for this session
-      # Redirect back to /
-      self.send_response(302)
-      self.send_header('Location', '/')
-      self.end_headers()
-      self.wfile.write(''.encode("utf-8"))
-      return
+            # Redirect to an index page with output based on the return state of
+            # the function
+            self.send_response(302)
+            self.send_header("Location", "/apiacct/" + str(ret))
+            self.end_headers()
+            self.wfile.write("".encode("utf-8"))
+            return
+        else:
+            # User has asked to skip Tesla Account submission for this session
+            # Redirect back to /
+            self.send_response(302)
+            self.send_header("Location", "/")
+            self.end_headers()
+            self.wfile.write("".encode("utf-8"))
+            return
 
-  def request_teslalogin(self):
-    page = "<form action='/tesla-login' method='POST'>"
-    page += "<p>Enter your email and password to allow TWCManager to start and "
-    page += "stop Tesla vehicles you own from charging. These credentials are "
-    page += "sent once to Tesla and are not stored. Credentials must be entered "
-    page += "again if no cars are connected to this charger for over 45 days."
-    page += "</p>"
-    page += "<input type=hidden name='page' value='tesla-login' />"
-    page += "<p>"
-    page += "<table>"
-    page += "<tr><td>Tesla Account E-Mail:</td>"
-    page += "<td><input type='text' name='email' value='' onFocus='formHasFocus()' onBlur='formNoFocus()'></td></tr>"
-    page += "<tr><td>Password:</td>"
-    page += "<td><input type='password' name='password' onFocus='formHasFocus()' onBlur='formNoFocus()'></td></tr>"
-    page += "<tr><td><input type='submit' name='submit' value='Log In'></td>"
-    page += "<td><input type='submit' name='later' value='Ask Me Later'></td>"
-    page += "</tr>"
-    page += "</table>"
-    page += "</p>"
-    page += "</form>"
-    return page
+    def request_teslalogin(self):
+        page = "<form action='/tesla-login' method='POST'>"
+        page += "<p>Enter your email and password to allow TWCManager to start and "
+        page += "stop Tesla vehicles you own from charging. These credentials are "
+        page += "sent once to Tesla and are not stored. Credentials must be entered "
+        page += "again if no cars are connected to this charger for over 45 days."
+        page += "</p>"
+        page += "<input type=hidden name='page' value='tesla-login' />"
+        page += "<p>"
+        page += "<table>"
+        page += "<tr><td>Tesla Account E-Mail:</td>"
+        page += "<td><input type='text' name='email' value='' onFocus='formHasFocus()' onBlur='formNoFocus()'></td></tr>"
+        page += "<tr><td>Password:</td>"
+        page += "<td><input type='password' name='password' onFocus='formHasFocus()' onBlur='formNoFocus()'></td></tr>"
+        page += "<tr><td><input type='submit' name='submit' value='Log In'></td>"
+        page += "<td><input type='submit' name='later' value='Ask Me Later'></td>"
+        page += "</tr>"
+        page += "</table>"
+        page += "</p>"
+        page += "</form>"
+        return page
 
-  def show_status(self):
-    global master
+    def show_status(self):
+        global master
 
-    page = "<table width = '100%'><tr width = '100%'><td width='30%'>"
-    page += "<table class='table table-dark' width='100%'>"
-    page += "<tr><th>Amps to share across all TWCs:</th>"
-    page += "<td>" + str(master.getMaxAmpsToDivideAmongSlaves()) + "</td>"
-    page += "<td>amps</td></tr>"
+        page = "<table width = '100%'><tr width = '100%'><td width='30%'>"
+        page += "<table class='table table-dark' width='100%'>"
+        page += "<tr><th>Amps to share across all TWCs:</th>"
+        page += "<td>" + str(master.getMaxAmpsToDivideAmongSlaves()) + "</td>"
+        page += "<td>amps</td></tr>"
 
-    page += "<tr><th>Current Generation</th>"
-    page += "<td>" + str(master.getGeneration()) + "</td>"
-    page += "<td>watts</td>"
-    genamps = 0
-    if (master.getGeneration()):
-      genamps = (master.getGeneration()/240)
-    page += "<td>" + str(genamps)+"</td><td>amps</td></tr>"
+        page += "<tr><th>Current Generation</th>"
+        page += "<td>" + str(master.getGeneration()) + "</td>"
+        page += "<td>watts</td>"
+        genamps = 0
+        if master.getGeneration():
+            genamps = master.getGeneration() / 240
+        page += "<td>" + str(genamps) + "</td><td>amps</td></tr>"
 
-    page += "<tr><th>Current Consumption</th>"
-    page += "<td>" + str(master.getConsumption()) + "</td>"
-    page += "<td>watts</td>"
-    conamps = 0
-    if (master.getConsumption()):
-      conamps = (master.getConsumption()/240)
-    page += "<td>" + str(conamps)+"</td><td>amps</td></tr>"
+        page += "<tr><th>Current Consumption</th>"
+        page += "<td>" + str(master.getConsumption()) + "</td>"
+        page += "<td>watts</td>"
+        conamps = 0
+        if master.getConsumption():
+            conamps = master.getConsumption() / 240
+        page += "<td>" + str(conamps) + "</td><td>amps</td></tr>"
 
-    page += "<tr><th>Current Charger Load</th>"
-    page += "<td>" + str(master.getChargerLoad()) + "</td>"
-    page += "<td>watts</td>"
-    page += "</tr>"
+        page += "<tr><th>Current Charger Load</th>"
+        page += "<td>" + str(master.getChargerLoad()) + "</td>"
+        page += "<td>watts</td>"
+        page += "</tr>"
 
-    page += "<tr><th>Number of Cars Charging</th>"
-    page += "<td>" + str(master.num_cars_charging_now()) + "</td>"
-    page += "<td>cars</td></tr></table></td>"
+        page += "<tr><th>Number of Cars Charging</th>"
+        page += "<td>" + str(master.num_cars_charging_now()) + "</td>"
+        page += "<td>cars</td></tr></table></td>"
 
-    page += "<td width='30%'>"
-    page += "<table class='table table-dark' width='100%'>"
-    page += "<tr><th>Scheduled Charging Amps</th>"
-    page += "<td>" + str(master.getScheduledAmpsMax()) + "</td></tr>"
+        page += "<td width='30%'>"
+        page += "<table class='table table-dark' width='100%'>"
+        page += "<tr><th>Scheduled Charging Amps</th>"
+        page += "<td>" + str(master.getScheduledAmpsMax()) + "</td></tr>"
 
-    page += "<tr><th>Scheduled Charging Start Hour</th>"
-    page += "<td>" + str(master.getScheduledAmpsStartHour()) + "</td></tr>"
+        page += "<tr><th>Scheduled Charging Start Hour</th>"
+        page += "<td>" + str(master.getScheduledAmpsStartHour()) + "</td></tr>"
 
-    page += "<tr><th>Scheduled Charging End Hour</th>"
-    page += "<td>" + str(master.getScheduledAmpsEndHour()) + "</td>"
-    page += "</tr>"
+        page += "<tr><th>Scheduled Charging End Hour</th>"
+        page += "<td>" + str(master.getScheduledAmpsEndHour()) + "</td>"
+        page += "</tr>"
 
-    page += "<tr><th>Resume Tracking Green Energy at</th>"
-    page += "<td>" + str(master.getHourResumeTrackGreenEnergy()) + "</td>"
-    page += "</tr>"
-    page += "</table></td>"
+        page += "<tr><th>Resume Tracking Green Energy at</th>"
+        page += "<td>" + str(master.getHourResumeTrackGreenEnergy()) + "</td>"
+        page += "</tr>"
+        page += "</table></td>"
 
-    page += "<td width = '40%' rowspan = '3'>"
-    page += self.do_chargeSchedule()
-    page += "</td></tr>"
-    page += "<tr><td>"
-    page += self.show_twcs()
-    page += "</td></tr>"
+        page += "<td width = '40%' rowspan = '3'>"
+        page += self.do_chargeSchedule()
+        page += "</td></tr>"
+        page += "<tr><td>"
+        page += self.show_twcs()
+        page += "</td></tr>"
 
-    # Handle overflow from calendar
-    page += "<tr><td>&nbsp;</td></tr></table>"
-    return page
+        # Handle overflow from calendar
+        page += "<tr><td>&nbsp;</td></tr></table>"
+        return page
 
-  def show_twcs(self):
-    global master
+    def show_twcs(self):
+        global master
 
-    page = "<table class='darkTable'>\n"
-    page += "<thead><tr>"
-    page += "<th>TWC ID</th>"
-    page += "<th>State</th>"
-    page += "<th>Version</th>"
-    page += "<th>Max Amps</th>"
-    page += "<th>Amps Offered</th>"
-    page += "<th>Amps In Use</th>"
-    page += "<th>Last Heartbeat</th>"
-    page += "</tr></thead>\n"
-    lastAmpsTotal = 0
-    maxAmpsTotal = 0
-    totalAmps = 0
-    for slaveTWC in master.getSlaveTWCs():
-      page += "<tr>"
-      page += "<td>%02X%02X</td>" % (slaveTWC.TWCID[0], slaveTWC.TWCID[1])
-      page += "<td>" + str(slaveTWC.reportedState) + "</td>"
-      page += "<td>" + str(slaveTWC.protocolVersion) + "</td>"
-      page += "<td>%.2f</td>" % float(slaveTWC.maxAmps)
-      maxAmpsTotal += float(slaveTWC.maxAmps)
-      page += "<td>%.2f</td>" % float(slaveTWC.lastAmpsOffered)
-      lastAmpsTotal += float(slaveTWC.lastAmpsOffered)
-      page += "<td>%.2f</td>" % float(slaveTWC.reportedAmpsActual)
-      totalAmps += float(slaveTWC.reportedAmpsActual)
-      page += "<td>%.2f sec</td>" % float(time.time() - slaveTWC.timeLastRx)
-      page += "</tr>\n"
-    page += "<tr><td><b>Total</b><td>&nbsp;</td><td>&nbsp;</td>"
-    page += "<td>%.2f</td>" % float(maxAmpsTotal)
-    page += "<td>%.2f</td>" % float(lastAmpsTotal)
-    page += "<td>%.2f</td>" % float(totalAmps)
-    page += "</tr></table>\n"
-    return page
-
+        page = "<table class='darkTable'>\n"
+        page += "<thead><tr>"
+        page += "<th>TWC ID</th>"
+        page += "<th>State</th>"
+        page += "<th>Version</th>"
+        page += "<th>Max Amps</th>"
+        page += "<th>Amps Offered</th>"
+        page += "<th>Amps In Use</th>"
+        page += "<th>Last Heartbeat</th>"
+        page += "</tr></thead>\n"
+        lastAmpsTotal = 0
+        maxAmpsTotal = 0
+        totalAmps = 0
+        for slaveTWC in master.getSlaveTWCs():
+            page += "<tr>"
+            page += "<td>%02X%02X</td>" % (slaveTWC.TWCID[0], slaveTWC.TWCID[1])
+            page += "<td>" + str(slaveTWC.reportedState) + "</td>"
+            page += "<td>" + str(slaveTWC.protocolVersion) + "</td>"
+            page += "<td>%.2f</td>" % float(slaveTWC.maxAmps)
+            maxAmpsTotal += float(slaveTWC.maxAmps)
+            page += "<td>%.2f</td>" % float(slaveTWC.lastAmpsOffered)
+            lastAmpsTotal += float(slaveTWC.lastAmpsOffered)
+            page += "<td>%.2f</td>" % float(slaveTWC.reportedAmpsActual)
+            totalAmps += float(slaveTWC.reportedAmpsActual)
+            page += "<td>%.2f sec</td>" % float(time.time() - slaveTWC.timeLastRx)
+            page += "</tr>\n"
+        page += "<tr><td><b>Total</b><td>&nbsp;</td><td>&nbsp;</td>"
+        page += "<td>%.2f</td>" % float(maxAmpsTotal)
+        page += "<td>%.2f</td>" % float(lastAmpsTotal)
+        page += "<td>%.2f</td>" % float(totalAmps)
+        page += "</tr></table>\n"
+        return page

--- a/lib/TWCManager/Control/MQTTControl.py
+++ b/lib/TWCManager/Control/MQTTControl.py
@@ -1,101 +1,108 @@
 class MQTTControl:
 
-  import paho.mqtt.client as mqtt
-  import _thread
+    import paho.mqtt.client as mqtt
+    import _thread
 
-  brokerIP        = None
-  brokerPort      = 1883
-  client          = None
-  config          = None
-  configConfig    = None
-  configMQTT      = None
-  connectionState = 0
-  debugLevel      = 0
-  master          = None
-  password        = None
-  status          = False
-  serverTLS       = False
-  topicPrefix     = None
-  username        = None
-  
-  def __init__(self, master):
-    self.config         = master.config
-    try:
-      self.configConfig = self.config['config']
-    except KeyError:
-      self.configConfig = {}
-    try:
-      self.configMQTT   = self.config['control']['MQTT']
-    except KeyError:
-      self.configMQTT   = {}
-    self.debugLevel     = self.configConfig.get('debugLevel', 0)
-    self.status         = self.configMQTT.get('enabled', False)
-    self.brokerIP       = self.configMQTT.get('brokerIP', None)
-    self.master         = master
-    self.topicPrefix    = self.configMQTT.get('topicPrefix', None)
-    self.username       = self.configMQTT.get('username', None)
-    self.password       = self.configMQTT.get('password', None)
+    brokerIP = None
+    brokerPort = 1883
+    client = None
+    config = None
+    configConfig = None
+    configMQTT = None
+    connectionState = 0
+    debugLevel = 0
+    master = None
+    password = None
+    status = False
+    serverTLS = False
+    topicPrefix = None
+    username = None
 
-    # Subscribe to the specified topic prefix, and process incoming messages
-    # to determine if they represent control messages
-    self.debugLog(10, "Attempting to Connect")
-    if (self.brokerIP):
-      self.client = self.mqtt.Client("MQTTCtrl")
-      if (self.username and self.password):
-        self.client.username_pw_set(self.username, self.password)
-      self.client.on_connect = self.mqttConnect
-      self.client.on_message = self.mqttMessage
-      self.client.on_subscribe = self.mqttSubscribe
-      try:
-        self.client.connect_async(self.brokerIP, port=self.brokerPort, keepalive=30)
-      except ConnectionRefusedError as e:
-        self.debugLog(4, "Error connecting to MQTT Broker")
-        self.debugLog(10, str(e))
-        return False
-      except OSError as e:
-        self.debugLog(4, "Error connecting to MQTT Broker")
-        self.debugLog(10, str(e))
-        return False
+    def __init__(self, master):
+        self.config = master.config
+        try:
+            self.configConfig = self.config["config"]
+        except KeyError:
+            self.configConfig = {}
+        try:
+            self.configMQTT = self.config["control"]["MQTT"]
+        except KeyError:
+            self.configMQTT = {}
+        self.debugLevel = self.configConfig.get("debugLevel", 0)
+        self.status = self.configMQTT.get("enabled", False)
+        self.brokerIP = self.configMQTT.get("brokerIP", None)
+        self.master = master
+        self.topicPrefix = self.configMQTT.get("topicPrefix", None)
+        self.username = self.configMQTT.get("username", None)
+        self.password = self.configMQTT.get("password", None)
 
-      self.connectionState = 1
-      self.client.loop_start()
+        # Subscribe to the specified topic prefix, and process incoming messages
+        # to determine if they represent control messages
+        self.debugLog(10, "Attempting to Connect")
+        if self.brokerIP:
+            self.client = self.mqtt.Client("MQTTCtrl")
+            if self.username and self.password:
+                self.client.username_pw_set(self.username, self.password)
+            self.client.on_connect = self.mqttConnect
+            self.client.on_message = self.mqttMessage
+            self.client.on_subscribe = self.mqttSubscribe
+            try:
+                self.client.connect_async(
+                    self.brokerIP, port=self.brokerPort, keepalive=30
+                )
+            except ConnectionRefusedError as e:
+                self.debugLog(4, "Error connecting to MQTT Broker")
+                self.debugLog(10, str(e))
+                return False
+            except OSError as e:
+                self.debugLog(4, "Error connecting to MQTT Broker")
+                self.debugLog(10, str(e))
+                return False
 
-    else:
-      self.debugLog(4, "MQTTControl enabled but no brokerIP specified.")
+            self.connectionState = 1
+            self.client.loop_start()
 
-  def debugLog(self, minlevel, message):
-    if (self.debugLevel >= minlevel):
-      print(colored(self.master.time_now() + " ", 'yellow') + \
-            colored("MQTTCtrl:   ", 'green') + f("({minlevel}) {message}"))
+        else:
+            self.debugLog(4, "MQTTControl enabled but no brokerIP specified.")
 
-  def mqttConnect(self, client, userdata, flags, rc):
-    self.debugLog(5, "MQTT Connected.")
-    self.debugLog(5, "Subscribe to " + self.topicPrefix + "/#")
-    res = self.client.subscribe(self.topicPrefix + "/#", qos=0)
-    self.debugLog(5, "Res: " + str(res))
+    def debugLog(self, minlevel, message):
+        if self.debugLevel >= minlevel:
+            print(
+                colored(self.master.time_now() + " ", "yellow")
+                + colored("MQTTCtrl:   ", "green")
+                + f("({minlevel}) {message}")
+            )
 
-  def mqttMessage(self, client, userdata, message):
+    def mqttConnect(self, client, userdata, flags, rc):
+        self.debugLog(5, "MQTT Connected.")
+        self.debugLog(5, "Subscribe to " + self.topicPrefix + "/#")
+        res = self.client.subscribe(self.topicPrefix + "/#", qos=0)
+        self.debugLog(5, "Res: " + str(res))
 
-    # Takes an MQTT message which has a message body of the following format:
-    # [Amps to charge at],[Seconds to charge for]
-    # eg. 24,3600
-    if (message.topic == self.topicPrefix + "/control/chargeNow"):
-      payload = str(message.payload.decode("utf-8"))
-      self.debugLog(3, "MQTT Message called chargeNow with payload " + payload)
-      plsplit = payload.split(",", 1)
-      if (len(plsplit) == 2):
-        self.master.setChargeNowAmps(int(plsplit[0]))
-        self.master.setChargeNowTimeEnd(int(plsplit[1]))
-      else:
-        self.debugLog(1, "MQTT chargeNow command failed: Incorrect number of parameters")
+    def mqttMessage(self, client, userdata, message):
 
-    if (message.topic == self.topicPrefix + "/control/chargeNowEnd"):
-      self.debugLog(3, "MQTT Message called chargeNowEnd")
-      self.master.resetChargeNowAmps()
+        # Takes an MQTT message which has a message body of the following format:
+        # [Amps to charge at],[Seconds to charge for]
+        # eg. 24,3600
+        if message.topic == self.topicPrefix + "/control/chargeNow":
+            payload = str(message.payload.decode("utf-8"))
+            self.debugLog(3, "MQTT Message called chargeNow with payload " + payload)
+            plsplit = payload.split(",", 1)
+            if len(plsplit) == 2:
+                self.master.setChargeNowAmps(int(plsplit[0]))
+                self.master.setChargeNowTimeEnd(int(plsplit[1]))
+            else:
+                self.debugLog(
+                    1, "MQTT chargeNow command failed: Incorrect number of parameters"
+                )
 
-    if (message.topic == self.topicPrefix + "/control/stop"):
-      self.debugLog(3, "MQTT Message called Stop")
-      self._thread.interrupt_main()
+        if message.topic == self.topicPrefix + "/control/chargeNowEnd":
+            self.debugLog(3, "MQTT Message called chargeNowEnd")
+            self.master.resetChargeNowAmps()
 
-  def mqttSubscribe(self, client, userdata, mid, granted_qos):
-    self.debugLog(1, "Subscribe operation completed with mid " + str(mid))
+        if message.topic == self.topicPrefix + "/control/stop":
+            self.debugLog(3, "MQTT Message called Stop")
+            self._thread.interrupt_main()
+
+    def mqttSubscribe(self, client, userdata, mid, granted_qos):
+        self.debugLog(1, "Subscribe operation completed with mid " + str(mid))

--- a/lib/TWCManager/Control/WebIPCControl.py
+++ b/lib/TWCManager/Control/WebIPCControl.py
@@ -4,265 +4,413 @@ import sysv_ipc
 import time
 import math
 
+
 class WebIPCControl:
 
-  config       = None
-  configConfig = None
-  debugLevel   = 0
-  master       = None
-  webIPCkey    = None
-  webIPCqueue  = None
+    config = None
+    configConfig = None
+    debugLevel = 0
+    master = None
+    webIPCkey = None
+    webIPCqueue = None
 
-  def __init__(self, master):
-    self.config     = master.config
-    try:
-      self.configConfig = master.config['config']
-    except KeyError:
-      self.configConfig = {}
-    self.debugLevel     = self.configConfig.get('debugLevel', 0)
-    self.master         = master
+    def __init__(self, master):
+        self.config = master.config
+        try:
+            self.configConfig = master.config["config"]
+        except KeyError:
+            self.configConfig = {}
+        self.debugLevel = self.configConfig.get("debugLevel", 0)
+        self.master = master
 
-    # Create an IPC (Interprocess Communication) message queue that we can
-    # periodically check to respond to queries from the TWCManager web interface.
-    #
-    # These messages will contain commands like "start charging at 10A" or may ask
-    # for information like "how many amps is the solar array putting out".
-    #
-    # The message queue is identified by a numeric key. This script and the web
-    # interface must both use the same key. The "ftok" function facilitates creating
-    # such a key based on a shared piece of information that is not likely to
-    # conflict with keys chosen by any other process in the system.
-    #
-    # ftok reads the inode number of the file or directory pointed to by its first
-    # parameter. This file or dir must already exist and the permissions on it don't
-    # seem to matter. The inode of a particular file or dir is fairly unique but
-    # doesn't change often so it makes a decent choice for a key.  We use the parent
-    # directory of the TWCManager script.
-    #
-    # The second parameter to ftok is a single byte that adds some additional
-    # uniqueness and lets you create multiple queues linked to the file or dir in
-    # the first param. We use 'T' for Tesla.
-    #
-    # If you can't get this to work, you can also set key = <some arbitrary number>
-    # and in the web interface, use the same arbitrary number. While that could
-    # conflict with another process, it's very unlikely to.
-    self.webIPCkey = sysv_ipc.ftok(self.config['config']['settingsPath'], ord('T'), True)
+        # Create an IPC (Interprocess Communication) message queue that we can
+        # periodically check to respond to queries from the TWCManager web interface.
+        #
+        # These messages will contain commands like "start charging at 10A" or may ask
+        # for information like "how many amps is the solar array putting out".
+        #
+        # The message queue is identified by a numeric key. This script and the web
+        # interface must both use the same key. The "ftok" function facilitates creating
+        # such a key based on a shared piece of information that is not likely to
+        # conflict with keys chosen by any other process in the system.
+        #
+        # ftok reads the inode number of the file or directory pointed to by its first
+        # parameter. This file or dir must already exist and the permissions on it don't
+        # seem to matter. The inode of a particular file or dir is fairly unique but
+        # doesn't change often so it makes a decent choice for a key.  We use the parent
+        # directory of the TWCManager script.
+        #
+        # The second parameter to ftok is a single byte that adds some additional
+        # uniqueness and lets you create multiple queues linked to the file or dir in
+        # the first param. We use 'T' for Tesla.
+        #
+        # If you can't get this to work, you can also set key = <some arbitrary number>
+        # and in the web interface, use the same arbitrary number. While that could
+        # conflict with another process, it's very unlikely to.
+        self.webIPCkey = sysv_ipc.ftok(
+            self.config["config"]["settingsPath"], ord("T"), True
+        )
 
-    # Use the key to create a message queue with read/write access for all users.
-    self.webIPCqueue = sysv_ipc.MessageQueue(self.webIPCkey, sysv_ipc.IPC_CREAT, 0o666)
-    if(self.webIPCqueue == None):
-        self.master.debugLog(1, "WebIPCCtrl", "ERROR: Can't create Interprocess Communication message queue to communicate with web interface.")
+        # Use the key to create a message queue with read/write access for all users.
+        self.webIPCqueue = sysv_ipc.MessageQueue(
+            self.webIPCkey, sysv_ipc.IPC_CREAT, 0o666
+        )
+        if self.webIPCqueue == None:
+            self.master.debugLog(
+                1,
+                "WebIPCCtrl",
+                "ERROR: Can't create Interprocess Communication message queue to communicate with web interface.",
+            )
 
-    # After the IPC message queue is created, if you type 'sudo ipcs -q' on the
-    # command like, you should see something like:
-    # ------ Message Queues --------
-    # key        msqid      owner      perms      used-bytes   messages
-    # 0x5402ed16 491520     pi         666        0            0
-    #
-    # If you want to get rid of all queues,
-    # reboot or type 'sudo ipcrm -a msg'.
-    # ones you didn't create or you may crash another process.
-    # Find more details in IPC here:
-    # http://www.onlamp.com/pub/a/php/2004/05/13/shared_memory.html
+        # After the IPC message queue is created, if you type 'sudo ipcs -q' on the
+        # command like, you should see something like:
+        # ------ Message Queues --------
+        # key        msqid      owner      perms      used-bytes   messages
+        # 0x5402ed16 491520     pi         666        0            0
+        #
+        # If you want to get rid of all queues,
+        # reboot or type 'sudo ipcrm -a msg'.
+        # ones you didn't create or you may crash another process.
+        # Find more details in IPC here:
+        # http://www.onlamp.com/pub/a/php/2004/05/13/shared_memory.html
 
-  def trim_pad(self, s:bytearray, makeLen):
-    # Trim or pad s with zeros so that it's makeLen length.
-    while(len(s) < makeLen):
-        s += b'\x00'
+    def trim_pad(self, s: bytearray, makeLen):
+        # Trim or pad s with zeros so that it's makeLen length.
+        while len(s) < makeLen:
+            s += b"\x00"
 
-    if(len(s) > makeLen):
-        s = s[0:makeLen]
+        if len(s) > makeLen:
+            s = s[0:makeLen]
 
-    return s
+        return s
 
-  def processIPC(self):
+    def processIPC(self):
 
-    ########################################################################
-    # See if there's any message from the web interface.
-    # If the message is longer than msgMaxSize, MSG_NOERROR tells it to
-    # return what it can of the message and discard the rest.
-    # When no message is available, IPC_NOWAIT tells msgrcv to return
-    # msgResult = 0 and $! = 42 with description 'No message of desired
-    # type'.
-    # If there is an actual error, webMsgResult will be -1.
-    # On success, webMsgResult is the length of webMsgPacked.
-    try:
-        webMsgRaw = self.webIPCqueue.receive(False, 2)
-        if(len(webMsgRaw[0]) > 0):
-            webMsgType = webMsgRaw[1]
-            unpacked = struct.unpack('=LH', webMsgRaw[0][0:6])
-            webMsgTime = unpacked[0]
-            webMsgID = unpacked[1]
-            webMsg = webMsgRaw[0][6:len(webMsgRaw[0])]
+        ########################################################################
+        # See if there's any message from the web interface.
+        # If the message is longer than msgMaxSize, MSG_NOERROR tells it to
+        # return what it can of the message and discard the rest.
+        # When no message is available, IPC_NOWAIT tells msgrcv to return
+        # msgResult = 0 and $! = 42 with description 'No message of desired
+        # type'.
+        # If there is an actual error, webMsgResult will be -1.
+        # On success, webMsgResult is the length of webMsgPacked.
+        try:
+            webMsgRaw = self.webIPCqueue.receive(False, 2)
+            if len(webMsgRaw[0]) > 0:
+                webMsgType = webMsgRaw[1]
+                unpacked = struct.unpack("=LH", webMsgRaw[0][0:6])
+                webMsgTime = unpacked[0]
+                webMsgID = unpacked[1]
+                webMsg = webMsgRaw[0][6 : len(webMsgRaw[0])]
 
-            webMsgRedacted = webMsg
-            # Hide car password in web request to send password to Tesla
-            m = re.search(b'^(carApiEmailPassword=[^\n]+\n)', webMsg, re.MULTILINE)
-            if(m):
-                webMsgRedacted = m.group(1) + b'[HIDDEN]'
+                webMsgRedacted = webMsg
+                # Hide car password in web request to send password to Tesla
+                m = re.search(b"^(carApiEmailPassword=[^\n]+\n)", webMsg, re.MULTILINE)
+                if m:
+                    webMsgRedacted = m.group(1) + b"[HIDDEN]"
 
-            self.master.debugLog(1, "WebIPCCtrl", "Web query: '" + str(webMsgRedacted) + "', id " + str(webMsgID) + ", time " + str(webMsgTime) + ", type " + str(webMsgType))
-            webResponseMsg = ''
-            numPackets = 0
-            slaveTWCRoundRobin = self.master.getSlaveTWCs()
-            if(webMsg == b'getStatus'):
-                needCarApiBearerToken = False
-                if(self.master.getModuleByName("TeslaAPI").getCarApiBearerToken() == ''):
-                    for i in range(0, self.master.countSlaveTWC()):
-                        if(slaveTWCRoundRobin[i].protocolVersion == 2):
-                            needCarApiBearerToken = True
+                self.master.debugLog(
+                    1,
+                    "WebIPCCtrl",
+                    "Web query: '"
+                    + str(webMsgRedacted)
+                    + "', id "
+                    + str(webMsgID)
+                    + ", time "
+                    + str(webMsgTime)
+                    + ", type "
+                    + str(webMsgType),
+                )
+                webResponseMsg = ""
+                numPackets = 0
+                slaveTWCRoundRobin = self.master.getSlaveTWCs()
+                if webMsg == b"getStatus":
+                    needCarApiBearerToken = False
+                    if (
+                        self.master.getModuleByName("TeslaAPI").getCarApiBearerToken()
+                        == ""
+                    ):
+                        for i in range(0, self.master.countSlaveTWC()):
+                            if slaveTWCRoundRobin[i].protocolVersion == 2:
+                                needCarApiBearerToken = True
 
-                webResponseMsg = (
-                    "%.2f" % (self.master.getMaxAmpsToDivideAmongSlaves()) +
-                    '`' + "%.2f" % (self.config['config']['wiringMaxAmpsAllTWCs']) +
-                    '`' + "%.2f" % (self.config['config']['minAmpsPerTWC']) +
-                    '`' + "%.2f" % (self.master.getChargeNowAmps()) +
-                    '`' + str(self.master.getNonScheduledAmpsMax()) +
-                    '`' + str(self.master.getScheduledAmpsMax()) +
-                    '`' + "%02d:%02d" % (int(self.master.getScheduledAmpsStartHour()),
-                                         int((self.master.getScheduledAmpsStartHour() % 1) * 60)) +
-                    '`' + "%02d:%02d" % (int(self.master.getScheduledAmpsEndHour()),
-                                         int((self.master.getScheduledAmpsEndHour() % 1) * 60)) +
-                    '`' + str(self.master.getScheduledAmpsDaysBitmap()) +
-                    '`' + "%02d:%02d" % (int(self.master.getHourResumeTrackGreenEnergy()),
-                                         int((self.master.getHourResumeTrackGreenEnergy() % 1) * 60)) +
-                    # Send 1 if we need an email/password entered for car api, otherwise send 0
-                    '`' + ('1' if needCarApiBearerToken else '0') +
-                    '`' + str(self.master.countSlaveTWC())
+                    webResponseMsg = (
+                        "%.2f" % (self.master.getMaxAmpsToDivideAmongSlaves())
+                        + "`"
+                        + "%.2f" % (self.config["config"]["wiringMaxAmpsAllTWCs"])
+                        + "`"
+                        + "%.2f" % (self.config["config"]["minAmpsPerTWC"])
+                        + "`"
+                        + "%.2f" % (self.master.getChargeNowAmps())
+                        + "`"
+                        + str(self.master.getNonScheduledAmpsMax())
+                        + "`"
+                        + str(self.master.getScheduledAmpsMax())
+                        + "`"
+                        + "%02d:%02d"
+                        % (
+                            int(self.master.getScheduledAmpsStartHour()),
+                            int((self.master.getScheduledAmpsStartHour() % 1) * 60),
+                        )
+                        + "`"
+                        + "%02d:%02d"
+                        % (
+                            int(self.master.getScheduledAmpsEndHour()),
+                            int((self.master.getScheduledAmpsEndHour() % 1) * 60),
+                        )
+                        + "`"
+                        + str(self.master.getScheduledAmpsDaysBitmap())
+                        + "`"
+                        + "%02d:%02d"
+                        % (
+                            int(self.master.getHourResumeTrackGreenEnergy()),
+                            int((self.master.getHourResumeTrackGreenEnergy() % 1) * 60),
+                        )
+                        +
+                        # Send 1 if we need an email/password entered for car api, otherwise send 0
+                        "`"
+                        + ("1" if needCarApiBearerToken else "0")
+                        + "`"
+                        + str(self.master.countSlaveTWC())
                     )
 
-                for i in range(0, self.master.countSlaveTWC()):
+                    for i in range(0, self.master.countSlaveTWC()):
+                        webResponseMsg += (
+                            "`"
+                            + "%02X%02X"
+                            % (
+                                self.master.getSlaveTWCID(i)[0],
+                                self.master.getSlaveTWCID(i)[1],
+                            )
+                            + "~"
+                            + str(slaveTWCRoundRobin[i].maxAmps)
+                            + "~"
+                            + "%.2f" % (slaveTWCRoundRobin[i].reportedAmpsActual)
+                            + "~"
+                            + str(slaveTWCRoundRobin[i].lastAmpsOffered)
+                            + "~"
+                            + str(slaveTWCRoundRobin[i].reportedState)
+                        )
+
+                elif webMsg[0:20] == b"setNonScheduledAmps=":
+                    m = re.search(b"([-0-9]+)", webMsg[19 : len(webMsg)])
+                    if m:
+                        self.master.setNonScheduledAmpsMax(int(m.group(1)))
+
+                        # Save nonScheduledAmpsMax to SD card so the setting
+                        # isn't lost on power failure or script restart.
+                        self.master.saveSettings()
+                elif webMsg[0:17] == b"setScheduledAmps=":
+                    m = re.search(
+                        b"([-0-9]+)\nstartTime=([-0-9]+):([0-9]+)\nendTime=([-0-9]+):([0-9]+)\ndays=([0-9]+)",
+                        webMsg[17 : len(webMsg)],
+                        re.MULTILINE,
+                    )
+                    if m:
+                        self.master.setScheduledAmpsMax(int(m.group(1)))
+                        self.master.setScheduledAmpsStartHour(
+                            int(m.group(2)) + (int(m.group(3)) / 60)
+                        )
+                        self.master.setScheduledAmpsEndHour(
+                            int(m.group(4)) + (int(m.group(5)) / 60)
+                        )
+                        self.master.setScheduledAmpsDaysBitmap(int(m.group(6)))
+                        self.master.saveSettings()
+                elif webMsg[0:30] == b"setResumeTrackGreenEnergyTime=":
+                    m = re.search(
+                        b"([-0-9]+):([0-9]+)", webMsg[30 : len(webMsg)], re.MULTILINE
+                    )
+                    if m:
+                        self.master.setHourResumeTrackGreenEnergy(
+                            int(m.group(1)) + (int(m.group(2)) / 60)
+                        )
+                        self.master.saveSettings()
+                elif webMsg[0:11] == b"sendTWCMsg=":
+                    m = re.search(
+                        b"([0-9a-fA-F]+)", webMsg[11 : len(webMsg)], re.MULTILINE
+                    )
+                    if m:
+                        twcMsg = self.trim_pad(
+                            bytearray.fromhex(m.group(1).decode("ascii")),
+                            15
+                            if self.master.countSlaveTWC() == 0
+                            or slaveTWCRoundRobin[0].protocolVersion == 2
+                            else 13,
+                        )
+                        if (twcMsg[0:2] == b"\xFC\x19") or (twcMsg[0:2] == b"\xFC\x1A"):
+                            print(
+                                "\n*** ERROR: Web interface requested sending command:\n"
+                                + self.master.hex_str(twcMsg)
+                                + "\nwhich could permanently disable the TWC.  Aborting.\n"
+                            )
+                        elif twcMsg[0:2] == b"\xFB\xE8":
+                            print(
+                                "\n*** ERROR: Web interface requested sending command:\n"
+                                + self.master.hex_str(twcMsg)
+                                + "\nwhich could crash the TWC.  Aborting.\n"
+                            )
+                        else:
+                            self.master.lastTWCResponseMsg = bytearray()
+                            self.master.getModuleByName("RS485").send(twcMsg)
+                elif webMsg == b"getLastTWCMsgResponse":
+                    if (
+                        self.master.lastTWCResponseMsg != None
+                        and self.master.lastTWCResponseMsg != b""
+                    ):
+                        webResponseMsg = self.master.hex_str(
+                            self.master.lastTWCResponseMsg
+                        )
+                    else:
+                        webResponseMsg = "None"
+                elif webMsg[0:20] == b"carApiEmailPassword=":
+                    m = re.search(
+                        b"([^\n]+)\n([^\n]+)", webMsg[20 : len(webMsg)], re.MULTILINE
+                    )
+                    if m:
+                        self.master.queue_background_task(
+                            {
+                                "cmd": "carApiEmailPassword",
+                                "email": m.group(1).decode("ascii"),
+                                "password": m.group(2).decode("ascii"),
+                            }
+                        )
+                elif webMsg[0:23] == b"setMasterHeartbeatData=":
+                    m = re.search(
+                        b"([0-9a-fA-F]*)", webMsg[23 : len(webMsg)], re.MULTILINE
+                    )
+                    if m:
+                        if len(m.group(1)) > 0:
+                            overrideMasterHeartbeatData = self.trim_pad(
+                                bytearray.fromhex(m.group(1).decode("ascii")),
+                                9 if slaveTWCRoundRobin[0].protocolVersion == 2 else 7,
+                            )
+                        else:
+                            overrideMasterHeartbeatData = b""
+                elif webMsg == b"chargeNow":
+                    self.master.setChargeNowAmps(
+                        self.master.config["config"]["wiringMaxAmpsAllTWCs"]
+                    )
+                    self.master.setChargeNowTimeEnd(60 * 60 * 24)
+                    self.master.saveSettings()
+                elif webMsg == b"chargeNowCancel":
+                    self.master.resetChargeNowAmps()
+                elif webMsg == b"dumpState":
+                    # dumpState commands are used for debugging. They are called
+                    # using a web page:
+                    # http://(Pi address)/index.php?submit=1&dumpState=1
+                    carapi = self.master.getModuleByName("TeslaAPI")
+                    webResponseMsg = (
+                        "time="
+                        + str(time.time())
+                        + ", fakeMaster="
+                        + str(self.config["config"]["fakeMaster"])
+                        + ", rs485Adapter="
+                        + self.config["config"]["rs485adapter"]
+                        + ", baud="
+                        + str(self.config["config"]["baud"])
+                        + ", wiringMaxAmpsAllTWCs="
+                        + str(self.config["config"]["wiringMaxAmpsAllTWCs"])
+                        + ", wiringMaxAmpsPerTWC="
+                        + str(self.config["config"]["wiringMaxAmpsPerTWC"])
+                        + ", minAmpsPerTWC="
+                        + str(self.config["config"]["minAmpsPerTWC"])
+                        + ", greenEnergyAmpsOffset="
+                        + str(self.config["config"]["greenEnergyAmpsOffset"])
+                        + ", debugLevel="
+                        + str(self.config["config"]["debugLevel"])
+                        + "\n"
+                    )
                     webResponseMsg += (
-                        '`' + "%02X%02X" % (self.master.getSlaveTWCID(i)[0],
-                                            self.master.getSlaveTWCID(i)[1]) +
-                        '~' + str(slaveTWCRoundRobin[i].maxAmps) +
-                        '~' + "%.2f" % (slaveTWCRoundRobin[i].reportedAmpsActual) +
-                        '~' + str(slaveTWCRoundRobin[i].lastAmpsOffered) +
-                        '~' + str(slaveTWCRoundRobin[i].reportedState))
+                        "carApiLastStartOrStopChargeTime="
+                        + str(
+                            time.strftime(
+                                "%m-%d-%y %H:%M:%S",
+                                time.localtime(carapi.getLastStartOrStopChargeTime()),
+                            )
+                        )
+                        + "\ncarApiLastErrorTime="
+                        + str(
+                            time.strftime(
+                                "%m-%d-%y %H:%M:%S",
+                                time.localtime(carapi.getCarApiLastErrorTime()),
+                            )
+                        )
+                        + "\ncarApiTokenExpireTime="
+                        + str(
+                            time.strftime(
+                                "%m-%d-%y %H:%M:%S",
+                                time.localtime(carapi.getCarApiTokenExpireTime()),
+                            )
+                        )
+                        + "\n"
+                    )
 
-            elif(webMsg[0:20] == b'setNonScheduledAmps='):
-                m = re.search(b'([-0-9]+)', webMsg[19:len(webMsg)])
-                if(m):
-                    self.master.setNonScheduledAmpsMax(int(m.group(1)))
+                    for vehicle in carapi.getCarApiVehicles():
+                        webResponseMsg += str(vehicle.__dict__) + "\n"
 
-                    # Save nonScheduledAmpsMax to SD card so the setting
-                    # isn't lost on power failure or script restart.
-                    self.master.saveSettings()
-            elif(webMsg[0:17] == b'setScheduledAmps='):
-                m = re.search(b'([-0-9]+)\nstartTime=([-0-9]+):([0-9]+)\nendTime=([-0-9]+):([0-9]+)\ndays=([0-9]+)', \
-                              webMsg[17:len(webMsg)], re.MULTILINE)
-                if(m):
-                    self.master.setScheduledAmpsMax(int(m.group(1)))
-                    self.master.setScheduledAmpsStartHour(int(m.group(2)) + (int(m.group(3)) / 60))
-                    self.master.setScheduledAmpsEndHour(int(m.group(4)) + (int(m.group(5)) / 60))
-                    self.master.setScheduledAmpsDaysBitmap(int(m.group(6)))
-                    self.master.saveSettings()
-            elif(webMsg[0:30] == b'setResumeTrackGreenEnergyTime='):
-                m = re.search(b'([-0-9]+):([0-9]+)', webMsg[30:len(webMsg)], re.MULTILINE)
-                if(m):
-                    self.master.setHourResumeTrackGreenEnergy(int(m.group(1)) + (int(m.group(2)) / 60))
-                    self.master.saveSettings()
-            elif(webMsg[0:11] == b'sendTWCMsg='):
-                m = re.search(b'([0-9a-fA-F]+)', webMsg[11:len(webMsg)], re.MULTILINE)
-                if(m):
-                    twcMsg = self.trim_pad(bytearray.fromhex(m.group(1).decode('ascii')), 15 if self.master.countSlaveTWC() == 0 \
-                                      or slaveTWCRoundRobin[0].protocolVersion == 2 else 13)
-                    if((twcMsg[0:2] == b'\xFC\x19') or (twcMsg[0:2] == b'\xFC\x1A')):
-                        print("\n*** ERROR: Web interface requested sending command:\n"
-                              + self.master.hex_str(twcMsg)
-                              + "\nwhich could permanently disable the TWC.  Aborting.\n")
-                    elif((twcMsg[0:2] == b'\xFB\xE8')):
-                        print("\n*** ERROR: Web interface requested sending command:\n"
-                              + self.master.hex_str(twcMsg)
-                              + "\nwhich could crash the TWC.  Aborting.\n")
-                    else:
-                        self.master.lastTWCResponseMsg = bytearray();
-                        self.master.getModuleByName("RS485").send(twcMsg)
-            elif(webMsg == b'getLastTWCMsgResponse'):
-                if(self.master.lastTWCResponseMsg != None and self.master.lastTWCResponseMsg != b''):
-                    webResponseMsg = self.master.hex_str(self.master.lastTWCResponseMsg)
+                    webResponseMsg += "slaveTWCRoundRobin:\n"
+                    for slaveTWC in self.master.getSlaveTWCs():
+                        webResponseMsg += str(slaveTWC.__dict__) + "\n"
+
+                    numPackets = math.ceil(len(webResponseMsg) / 290)
+                elif webMsg[0:14] == b"setDebugLevel=":
+                    m = re.search(b"([-0-9]+)", webMsg[14 : len(webMsg)], re.MULTILINE)
+                    if m:
+                        self.config["config"]["debugLevel"] = int(m.group(1))
                 else:
-                    webResponseMsg = 'None'
-            elif(webMsg[0:20] == b'carApiEmailPassword='):
-                m = re.search(b'([^\n]+)\n([^\n]+)', webMsg[20:len(webMsg)], re.MULTILINE)
-                if(m):
-                    self.master.queue_background_task({'cmd':'carApiEmailPassword',
-                                              'email':m.group(1).decode('ascii'),
-                                              'password':m.group(2).decode('ascii')})
-            elif(webMsg[0:23] == b'setMasterHeartbeatData='):
-                m = re.search(b'([0-9a-fA-F]*)', webMsg[23:len(webMsg)], re.MULTILINE)
-                if(m):
-                    if(len(m.group(1)) > 0):
-                        overrideMasterHeartbeatData = self.trim_pad(bytearray.fromhex(m.group(1).decode('ascii')),
-                                                               9 if slaveTWCRoundRobin[0].protocolVersion == 2 else 7)
-                    else:
-                        overrideMasterHeartbeatData = b''
-            elif(webMsg == b'chargeNow'):
-                self.master.setChargeNowAmps(self.master.config['config']['wiringMaxAmpsAllTWCs'])
-                self.master.setChargeNowTimeEnd(60*60*24)
-                self.master.saveSettings()
-            elif(webMsg == b'chargeNowCancel'):
-                self.master.resetChargeNowAmps()
-            elif(webMsg == b'dumpState'):
-                # dumpState commands are used for debugging. They are called
-                # using a web page:
-                # http://(Pi address)/index.php?submit=1&dumpState=1
-                carapi = self.master.getModuleByName("TeslaAPI")
-                webResponseMsg = ('time=' + str(time.time()) + ', fakeMaster='
-                    + str(self.config['config']['fakeMaster']) + ', rs485Adapter=' + self.config['config']['rs485adapter']
-                    + ', baud=' + str(self.config['config']['baud'])
-                    + ', wiringMaxAmpsAllTWCs=' + str(self.config['config']['wiringMaxAmpsAllTWCs'])
-                    + ', wiringMaxAmpsPerTWC=' + str(self.config['config']['wiringMaxAmpsPerTWC'])
-                    + ', minAmpsPerTWC=' + str(self.config['config']['minAmpsPerTWC'])
-                    + ', greenEnergyAmpsOffset=' + str(self.config['config']['greenEnergyAmpsOffset'])
-                    + ', debugLevel=' + str(self.config['config']['debugLevel'])
-                    + '\n')
-                webResponseMsg += (
-                    'carApiLastStartOrStopChargeTime=' + str(time.strftime("%m-%d-%y %H:%M:%S", time.localtime(carapi.getLastStartOrStopChargeTime())))
-                    + '\ncarApiLastErrorTime=' + str(time.strftime("%m-%d-%y %H:%M:%S", time.localtime(carapi.getCarApiLastErrorTime())))
-                    + '\ncarApiTokenExpireTime=' + str(time.strftime("%m-%d-%y %H:%M:%S", time.localtime(carapi.getCarApiTokenExpireTime())))
-                    + '\n')
+                    self.master.debugLog(
+                        1,
+                        "WebIPCCtrl",
+                        "Unknown IPC request from web server: " + str(webMsg),
+                    )
 
-                for vehicle in carapi.getCarApiVehicles():
-                    webResponseMsg += str(vehicle.__dict__) + '\n'
+                if len(webResponseMsg) > 0:
+                    self.master.debugLog(
+                        5, "WebIPCCtrl", "Web query response: '" + webResponseMsg + "'"
+                    )
 
-                webResponseMsg += 'slaveTWCRoundRobin:\n'
-                for slaveTWC in self.master.getSlaveTWCs():
-                    webResponseMsg += str(slaveTWC.__dict__) + '\n'
+                    try:
+                        if numPackets == 0:
+                            if len(webResponseMsg) > 290:
+                                webResponseMsg = webResponseMsg[0:290]
 
-                numPackets = math.ceil(len(webResponseMsg) / 290)
-            elif(webMsg[0:14] == b'setDebugLevel='):
-                m = re.search(b'([-0-9]+)', webMsg[14:len(webMsg)], re.MULTILINE)
-                if(m):
-                    self.config['config']['debugLevel'] = int(m.group(1))
-            else:
-                self.master.debugLog(1, "WebIPCCtrl", "Unknown IPC request from web server: " + str(webMsg))
+                            self.webIPCqueue.send(
+                                struct.pack(
+                                    "=LH" + str(len(webResponseMsg)) + "s",
+                                    webMsgTime,
+                                    webMsgID,
+                                    webResponseMsg.encode("ascii"),
+                                ),
+                                block=False,
+                            )
+                        else:
+                            # In this case, block=False prevents blocking if the message
+                            # queue is too full for our message to fit. Instead, an
+                            # error is returned.
+                            msgTemp = struct.pack(
+                                "=LH1s", webMsgTime, webMsgID, bytearray([numPackets])
+                            )
+                            self.webIPCqueue.send(msgTemp, block=False)
+                            for i in range(0, numPackets):
+                                packet = webResponseMsg[i * 290 : i * 290 + 290]
+                                self.webIPCqueue.send(
+                                    struct.pack(
+                                        "=LH" + str(len(packet)) + "s",
+                                        webMsgTime,
+                                        webMsgID,
+                                        packet.encode("ascii"),
+                                    ),
+                                    block=False,
+                                )
 
-            if(len(webResponseMsg) > 0):
-                self.master.debugLog(5, "WebIPCCtrl", "Web query response: '" + webResponseMsg + "'")
+                    except sysv_ipc.BusyError:
+                        self.master.debugLog(
+                            0,
+                            "WebIPCCtrl",
+                            "Error: IPC queue full when trying to send response to web interface.",
+                        )
 
-                try:
-                    if(numPackets == 0):
-                        if(len(webResponseMsg) > 290):
-                            webResponseMsg = webResponseMsg[0:290]
-
-                        self.webIPCqueue.send(struct.pack('=LH' + str(len(webResponseMsg)) + 's', webMsgTime, webMsgID,
-                               webResponseMsg.encode('ascii')), block=False)
-                    else:
-                        # In this case, block=False prevents blocking if the message
-                        # queue is too full for our message to fit. Instead, an
-                        # error is returned.
-                        msgTemp = struct.pack('=LH1s', webMsgTime, webMsgID, bytearray([numPackets]))
-                        self.webIPCqueue.send(msgTemp, block=False)
-                        for i in range(0, numPackets):
-                            packet = webResponseMsg[i*290:i*290+290]
-                            self.webIPCqueue.send(struct.pack('=LH' + str(len(packet)) + 's', webMsgTime, webMsgID,
-                               packet.encode('ascii')), block=False)
-
-                except sysv_ipc.BusyError:
-                    self.master.debugLog(0, "WebIPCCtrl", "Error: IPC queue full when trying to send response to web interface.")
-
-    except sysv_ipc.BusyError:
-        # No web message is waiting.
-        pass
-
+        except sysv_ipc.BusyError:
+            # No web message is waiting.
+            pass

--- a/lib/TWCManager/EMS/DSMR.py
+++ b/lib/TWCManager/EMS/DSMR.py
@@ -1,28 +1,29 @@
 # Dutch SmartMeter Serial Integration (DSMR)
 
+
 class DSMR:
 
-  import time
+    import time
 
-  baudrate    = 115200
-  consumedW   = 0
-  debugLevel  = 0
-  generatedW  = 0
-  serial      = None
-  serialPort  = "/dev/ttyUSB2"
-  status      = False
-  timeout     = 0
-  voltage     = 0
+    baudrate = 115200
+    consumedW = 0
+    debugLevel = 0
+    generatedW = 0
+    serial = None
+    serialPort = "/dev/ttyUSB2"
+    status = False
+    timeout = 0
+    voltage = 0
 
-  def __init__(self, debugLevel, config):
-    self.debugLevel  = debugLevel
-    self.baudrate    = config.get('baudrate', '115200')
-    self.status      = config.get('enabled', False)
-    self.serialPort  = config.get('serialPort','80')
+    def __init__(self, debugLevel, config):
+        self.debugLevel = debugLevel
+        self.baudrate = config.get("baudrate", "115200")
+        self.status = config.get("enabled", False)
+        self.serialPort = config.get("serialPort", "80")
 
-  def main(self):
-    self.serial.port = self.serialPort
-    try:
-      self.serial.open()
-    except ValueError:
-      sys.exit("Error opening serial port (%s). exiting" % self.serial.name)
+    def main(self):
+        self.serial.port = self.serialPort
+        try:
+            self.serial.open()
+        except ValueError:
+            sys.exit("Error opening serial port (%s). exiting" % self.serial.name)

--- a/lib/TWCManager/EMS/Fronius.py
+++ b/lib/TWCManager/EMS/Fronius.py
@@ -1,136 +1,144 @@
 # Fronius Datamanager Solar.API Integration (Inverter Web Interface)
 
+
 class Fronius:
 
-  import requests
-  import time
+    import requests
+    import time
 
-  cacheTime     = 10
-  config        = None
-  configConfig  = None
-  configFronius = None
-  consumedW     = 0
-  debugLevel    = 0
-  fetchFailed   = False
-  generatedW    = 0
-  importW       = 0
-  exportW       = 0
-  lastFetch     = 0
-  serverIP      = None
-  serverPort    = 80
-  status        = False
-  timeout       = 10
-  voltage       = 0
+    cacheTime = 10
+    config = None
+    configConfig = None
+    configFronius = None
+    consumedW = 0
+    debugLevel = 0
+    fetchFailed = False
+    generatedW = 0
+    importW = 0
+    exportW = 0
+    lastFetch = 0
+    serverIP = None
+    serverPort = 80
+    status = False
+    timeout = 10
+    voltage = 0
 
-  def __init__(self, master):
-    self.config          = master.config
-    try:
-      self.configConfig  = master.config['config']
-    except KeyError:
-      self.configConfig  = {}
-    try:
-      self.configFronius = master.config['sources']['Fronius']
-    except KeyError:
-      self.configFronius = {}
-    self.debugLevel      = self.configConfig.get('debugLevel', 0)
-    self.status          = self.configFronius.get('enabled', False)
-    self.serverIP        = self.configFronius.get('serverIP', None)
-    self.serverPort      = self.configFronius.get('serverPort','80')
-
-  def debugLog(self, minlevel, message):
-    if (self.debugLevel >= minlevel):
-      print("Fronius: (" + str(minlevel) + ") " + message)
-
-  def getConsumption(self):
-
-    if (not self.status):
-      self.debugLog(10, "Fronius EMS Module Disabled. Skipping getConsumption")
-      return 0
-    
-    # Perform updates if necessary
-    self.update()
-
-    # Return consumption value. Fronius consumption is either negative
-    # (export to grid) or positive (import from grid). We add generation
-    # value to make it the delta between this and current consumption
-    if ((self.consumedW < 0) or (self.consumedW > 0)):
-      return float(self.generatedW + self.consumedW)
-    else:
-      return float(0)
-
-  def getGeneration(self):
-
-    if (not self.status):
-      self.debugLog(10, "Fronius EMS Module Disabled. Skipping getGeneration")
-      return 0
-
-    # Perform updates if necessary
-    self.update()
-
-    # Return generation value
-    return float(self.generatedW)
-    
-  def getInverterData(self):
-    url = "http://" + self.serverIP + ":" + self.serverPort
-    url = url + "/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DeviceID=1&DataCollection=CommonInverterData"
-
-    return self.getInverterValue(url)
-
-  def getInverterValue(self, url):
-    
-    # Fetch the specified URL from the Fronius Inverter and return the data
-    self.fetchFailed = False
-    
-    try:
-        r = self.requests.get(url, timeout=self.timeout)
-    except self.requests.exceptions.ConnectionError as e: 
-        self.debugLog(4, "Error connecting to Fronius Inverter to fetch sensor value")
-        self.debugLog(10, str(e))
-        self.fetchFailed = True
-        return False
-      
-    r.raise_for_status()
-    jsondata = r.json()
-    return jsondata
-
-  def getMeterData(self):
-    url = "http://" + self.serverIP + ":" + self.serverPort
-    url = url + "/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceId=0"
-
-    return self.getInverterValue(url)
-
-  def update(self):
-
-    if ((int(self.time.time()) - self.lastFetch) > self.cacheTime):
-      # Cache has expired. Fetch values from HomeAssistant sensor.
-
-      inverterData = self.getInverterData()
-      if (inverterData):
+    def __init__(self, master):
+        self.config = master.config
         try:
-          self.generatedW = inverterData['Body']['Data']['PAC']['Value']
-        except (KeyError, TypeError) as e:
-          self.debugLog(4, "Exception during parsing Inveter Data (PAC)")
-          self.debugLog(10, e)
+            self.configConfig = master.config["config"]
+        except KeyError:
+            self.configConfig = {}
+        try:
+            self.configFronius = master.config["sources"]["Fronius"]
+        except KeyError:
+            self.configFronius = {}
+        self.debugLevel = self.configConfig.get("debugLevel", 0)
+        self.status = self.configFronius.get("enabled", False)
+        self.serverIP = self.configFronius.get("serverIP", None)
+        self.serverPort = self.configFronius.get("serverPort", "80")
+
+    def debugLog(self, minlevel, message):
+        if self.debugLevel >= minlevel:
+            print("Fronius: (" + str(minlevel) + ") " + message)
+
+    def getConsumption(self):
+
+        if not self.status:
+            self.debugLog(10, "Fronius EMS Module Disabled. Skipping getConsumption")
+            return 0
+
+        # Perform updates if necessary
+        self.update()
+
+        # Return consumption value. Fronius consumption is either negative
+        # (export to grid) or positive (import from grid). We add generation
+        # value to make it the delta between this and current consumption
+        if (self.consumedW < 0) or (self.consumedW > 0):
+            return float(self.generatedW + self.consumedW)
+        else:
+            return float(0)
+
+    def getGeneration(self):
+
+        if not self.status:
+            self.debugLog(10, "Fronius EMS Module Disabled. Skipping getGeneration")
+            return 0
+
+        # Perform updates if necessary
+        self.update()
+
+        # Return generation value
+        return float(self.generatedW)
+
+    def getInverterData(self):
+        url = "http://" + self.serverIP + ":" + self.serverPort
+        url = (
+            url
+            + "/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DeviceID=1&DataCollection=CommonInverterData"
+        )
+
+        return self.getInverterValue(url)
+
+    def getInverterValue(self, url):
+
+        # Fetch the specified URL from the Fronius Inverter and return the data
+        self.fetchFailed = False
 
         try:
-          self.voltage = inverterData['Body']['Data']['UAC']['Value']
-        except (KeyError, TypeError) as e:
-          self.debugLog(4, "Exception during parsing Inveter Data (UAC)")
-          self.debugLog(10, e)
+            r = self.requests.get(url, timeout=self.timeout)
+        except self.requests.exceptions.ConnectionError as e:
+            self.debugLog(
+                4, "Error connecting to Fronius Inverter to fetch sensor value"
+            )
+            self.debugLog(10, str(e))
+            self.fetchFailed = True
+            return False
 
-      meterData = self.getMeterData()
-      if (meterData):
-        try:
-          self.consumedW = float(meterData['Body']['Data']['PowerReal_P_Sum'])
-        except (KeyError, TypeError) as e:
-          self.debugLog(4, "Exception during parsing Meter Data (Consumption)")
-          self.debugLog(10, e)
+        r.raise_for_status()
+        jsondata = r.json()
+        return jsondata
 
-      # Update last fetch time
-      if (self.fetchFailed is not True):
-        self.lastFetch = int(self.time.time())
-        
-      return True
-    else:
-      # Cache time has not elapsed since last fetch, serve from cache.
-      return False
+    def getMeterData(self):
+        url = "http://" + self.serverIP + ":" + self.serverPort
+        url = url + "/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceId=0"
+
+        return self.getInverterValue(url)
+
+    def update(self):
+
+        if (int(self.time.time()) - self.lastFetch) > self.cacheTime:
+            # Cache has expired. Fetch values from HomeAssistant sensor.
+
+            inverterData = self.getInverterData()
+            if inverterData:
+                try:
+                    self.generatedW = inverterData["Body"]["Data"]["PAC"]["Value"]
+                except (KeyError, TypeError) as e:
+                    self.debugLog(4, "Exception during parsing Inveter Data (PAC)")
+                    self.debugLog(10, e)
+
+                try:
+                    self.voltage = inverterData["Body"]["Data"]["UAC"]["Value"]
+                except (KeyError, TypeError) as e:
+                    self.debugLog(4, "Exception during parsing Inveter Data (UAC)")
+                    self.debugLog(10, e)
+
+            meterData = self.getMeterData()
+            if meterData:
+                try:
+                    self.consumedW = float(meterData["Body"]["Data"]["PowerReal_P_Sum"])
+                except (KeyError, TypeError) as e:
+                    self.debugLog(
+                        4, "Exception during parsing Meter Data (Consumption)"
+                    )
+                    self.debugLog(10, e)
+
+            # Update last fetch time
+            if self.fetchFailed is not True:
+                self.lastFetch = int(self.time.time())
+
+            return True
+        else:
+            # Cache time has not elapsed since last fetch, serve from cache.
+            return False

--- a/lib/TWCManager/EMS/HASS.py
+++ b/lib/TWCManager/EMS/HASS.py
@@ -1,143 +1,157 @@
 class HASS:
 
-  # HomeAssistant EMS Module
-  # Fetches Consumption and Generation details from HomeAssistant
+    # HomeAssistant EMS Module
+    # Fetches Consumption and Generation details from HomeAssistant
 
-  import requests
-  import time
+    import requests
+    import time
 
-  apiKey                = None
-  cacheTime             = 10
-  config                = None
-  configConfig          = None
-  configHASS            = None
-  consumedW             = 0
-  debugLevel            = 0
-  fetchFailed           = False
-  generatedW            = 0
-  hassEntityConsumption = None
-  hassEntityGeneration  = None
-  lastFetch             = 0
-  status                = False
-  serverIP              = None
-  serverPort            = 8123
-  timeout               = 2
+    apiKey = None
+    cacheTime = 10
+    config = None
+    configConfig = None
+    configHASS = None
+    consumedW = 0
+    debugLevel = 0
+    fetchFailed = False
+    generatedW = 0
+    hassEntityConsumption = None
+    hassEntityGeneration = None
+    lastFetch = 0
+    status = False
+    serverIP = None
+    serverPort = 8123
+    timeout = 2
 
-  def __init__(self, master):
-    self.config                = master.config
-    try:
-      self.configConfig        = master.config['config']
-    except KeyError:
-      self.configConfig        = {}
-    try:
-      self.configHASS          = master.config['sources']['HASS']
-    except KeyError:
-      self.configHASS          = {}
-    self.status                = self.configHASS.get('enabled', False)
-    self.serverIP              = self.configHASS.get('serverIP', None)
-    self.serverPort            = self.configHASS.get('serverPort', 8123)
-    self.apiKey                = self.configHASS.get('apiKey', None)
-    self.debugLevel            = self.configConfig.get('debugLevel', 0)
-    self.hassEntityConsumption = self.configHASS.get('hassEntityConsumption', None)
-    self.hassEntityGeneration  = self.configHASS.get('hassEntityGeneration', None)
+    def __init__(self, master):
+        self.config = master.config
+        try:
+            self.configConfig = master.config["config"]
+        except KeyError:
+            self.configConfig = {}
+        try:
+            self.configHASS = master.config["sources"]["HASS"]
+        except KeyError:
+            self.configHASS = {}
+        self.status = self.configHASS.get("enabled", False)
+        self.serverIP = self.configHASS.get("serverIP", None)
+        self.serverPort = self.configHASS.get("serverPort", 8123)
+        self.apiKey = self.configHASS.get("apiKey", None)
+        self.debugLevel = self.configConfig.get("debugLevel", 0)
+        self.hassEntityConsumption = self.configHASS.get("hassEntityConsumption", None)
+        self.hassEntityGeneration = self.configHASS.get("hassEntityGeneration", None)
 
-  def debugLog(self, minlevel, message):
-    if (self.debugLevel >= minlevel):
-      print("debugLog: (" + str(minlevel) + ") " + message)
+    def debugLog(self, minlevel, message):
+        if self.debugLevel >= minlevel:
+            print("debugLog: (" + str(minlevel) + ") " + message)
 
-  def getConsumption(self):
+    def getConsumption(self):
 
-    if (not self.status):
-      self.debugLog(10, "HASS EMS Module Disabled. Skipping getConsumption")
-      return 0
+        if not self.status:
+            self.debugLog(10, "HASS EMS Module Disabled. Skipping getConsumption")
+            return 0
 
-    # Perform updates if necessary
-    self.update()
+        # Perform updates if necessary
+        self.update()
 
-    # Return consumption value
-    return self.consumedW
+        # Return consumption value
+        return self.consumedW
 
-  def getGeneration(self):
+    def getGeneration(self):
 
-    if (not self.status):
-      self.debugLog(10, "HASS EMS Module Disabled. Skipping getGeneration")
-      return 0
+        if not self.status:
+            self.debugLog(10, "HASS EMS Module Disabled. Skipping getGeneration")
+            return 0
 
-    # Perform updates if necessary
-    self.update()
+        # Perform updates if necessary
+        self.update()
 
-    # Return generation value
-    return self.generatedW
+        # Return generation value
+        return self.generatedW
 
-  def getAPIValue(self, entity):
-    url = "http://" + self.serverIP + ":" + self.serverPort + "/api/states/" + entity
-    headers = {
-        'Authorization': 'Bearer ' + self.apiKey,
-        'content-type': 'application/json'
-    }
+    def getAPIValue(self, entity):
+        url = (
+            "http://" + self.serverIP + ":" + self.serverPort + "/api/states/" + entity
+        )
+        headers = {
+            "Authorization": "Bearer " + self.apiKey,
+            "content-type": "application/json",
+        }
 
-    # Update fetchFailed boolean to False before fetch attempt
-    # This will change to true if the fetch failed, ensuring we don't then use the value to update our cache
-    self.fetchFailed = False
+        # Update fetchFailed boolean to False before fetch attempt
+        # This will change to true if the fetch failed, ensuring we don't then use the value to update our cache
+        self.fetchFailed = False
 
-    try:
-        self.debugLog(10, "Fetching HomeAssistant EMS sensor value " + str(entity))
-        httpResponse = self.requests.get(url, headers=headers, timeout=self.timeout)
-    except self.requests.exceptions.ConnectionError as e:
-        self.debugLog(4, "Error connecting to HomeAssistant to publish sensor values")
-        self.debugLog(10, str(e))
-        self.fetchFailed = True
-        return False
-    except self.requests.exceptions.ReadTimeout as e:
-        self.debugLog(4, "Read Timeout occurred fetching HomeAssistant sensor value")
-        self.debugLog(10, str(e))
-        self.fetchFailed = True
-        return False
+        try:
+            self.debugLog(10, "Fetching HomeAssistant EMS sensor value " + str(entity))
+            httpResponse = self.requests.get(url, headers=headers, timeout=self.timeout)
+        except self.requests.exceptions.ConnectionError as e:
+            self.debugLog(
+                4, "Error connecting to HomeAssistant to publish sensor values"
+            )
+            self.debugLog(10, str(e))
+            self.fetchFailed = True
+            return False
+        except self.requests.exceptions.ReadTimeout as e:
+            self.debugLog(
+                4, "Read Timeout occurred fetching HomeAssistant sensor value"
+            )
+            self.debugLog(10, str(e))
+            self.fetchFailed = True
+            return False
 
-    jsonResponse = httpResponse.json() if httpResponse and httpResponse.status_code == 200 else None
+        jsonResponse = (
+            httpResponse.json()
+            if httpResponse and httpResponse.status_code == 200
+            else None
+        )
 
-    if jsonResponse:
-        return jsonResponse["state"]
-    else:
-        return None
+        if jsonResponse:
+            return jsonResponse["state"]
+        else:
+            return None
 
-  def setCacheTime(self, cacheTime):
-    self.cacheTime = cacheTime
+    def setCacheTime(self, cacheTime):
+        self.cacheTime = cacheTime
 
-  def setTimeout(self, timeout):
-    self.timeout = timeout
+    def setTimeout(self, timeout):
+        self.timeout = timeout
 
-  def update(self):
-    # Update function - determine if an update is required
+    def update(self):
+        # Update function - determine if an update is required
 
-    if ((int(self.time.time()) - self.lastFetch) > self.cacheTime):
-      # Cache has expired. Fetch values from HomeAssistant sensor.
+        if (int(self.time.time()) - self.lastFetch) > self.cacheTime:
+            # Cache has expired. Fetch values from HomeAssistant sensor.
 
-      if (self.hassEntityConsumption):
-          apivalue = self.getAPIValue(self.hassEntityConsumption)
-          if (self.fetchFailed is not True):
-              self.debugLog(10, "HASS getConsumption returns " + str(apivalue))
-              self.consumedW = float(apivalue)
-          else:
-              self.debugLog(10, "HASS getConsumption fetch failed, using cached values")
-      else:
-          self.debugLog(10, "HASS Consumption Entity Not Supplied. Not Querying")
+            if self.hassEntityConsumption:
+                apivalue = self.getAPIValue(self.hassEntityConsumption)
+                if self.fetchFailed is not True:
+                    self.debugLog(10, "HASS getConsumption returns " + str(apivalue))
+                    self.consumedW = float(apivalue)
+                else:
+                    self.debugLog(
+                        10, "HASS getConsumption fetch failed, using cached values"
+                    )
+            else:
+                self.debugLog(10, "HASS Consumption Entity Not Supplied. Not Querying")
 
-      if (self.hassEntityGeneration):
-          apivalue = self.getAPIValue(self.hassEntityGeneration)
-          if (self.fetchFailed is not True):
-              self.debugLog(10, "HASS getGeneration returns " + str(apivalue))
-              self.generatedW = float(apivalue)
-          else:
-              self.debugLog(10, "HASS getGeneration fetch failed, using cached values")
-      else:
-          self.debugLog(10, "HASS Generation Entity Not Supplied. Not Querying")
+            if self.hassEntityGeneration:
+                apivalue = self.getAPIValue(self.hassEntityGeneration)
+                if self.fetchFailed is not True:
+                    self.debugLog(10, "HASS getGeneration returns " + str(apivalue))
+                    self.generatedW = float(apivalue)
+                else:
+                    self.debugLog(
+                        10, "HASS getGeneration fetch failed, using cached values"
+                    )
+            else:
+                self.debugLog(10, "HASS Generation Entity Not Supplied. Not Querying")
 
-      # Update last fetch time
-      if (self.fetchFailed is not True):
-        self.lastFetch = int(self.time.time())
+            # Update last fetch time
+            if self.fetchFailed is not True:
+                self.lastFetch = int(self.time.time())
 
-      return True
-    else:
-      # Cache time has not elapsed since last fetch, serve from cache.
-      return False
+            return True
+        else:
+            # Cache time has not elapsed since last fetch, serve from cache.
+            return False

--- a/lib/TWCManager/EMS/TED.py
+++ b/lib/TWCManager/EMS/TED.py
@@ -1,115 +1,118 @@
 # The Energy Detective (TED)
 
+
 class TED:
 
     # I check solar panel generation using an API exposed by The
     # Energy Detective (TED). It's a piece of hardware available
     # at http://www.theenergydetective.com
 
-  import re
-  import requests
-  import time
+    import re
+    import requests
+    import time
 
-  cacheTime    = 10
-  config       = None
-  configConfig = None
-  configTED    = None
-  consumedW    = 0
-  debugLevel   = 0
-  fetchFailed  = False
-  generatedW   = 0
-  importW      = 0
-  exportW      = 0
-  lastFetch    = 0
-  serverIP     = None
-  serverPort   = 80
-  status       = False
-  timeout      = 10
-  voltage      = 0
+    cacheTime = 10
+    config = None
+    configConfig = None
+    configTED = None
+    consumedW = 0
+    debugLevel = 0
+    fetchFailed = False
+    generatedW = 0
+    importW = 0
+    exportW = 0
+    lastFetch = 0
+    serverIP = None
+    serverPort = 80
+    status = False
+    timeout = 10
+    voltage = 0
 
-  def __init__(self, master):
-    self.config         = master.config
-    try:
-      self.configConfig = self.config['config']
-    except KeyError:
-      self.configConfig = {}
-    try:
-      self.configTED    = self.config['sources']['TED']
-    except KeyError:
-      self.configTED    = {}
-    self.debugLevel     = self.configConfig.get('debugLevel', 0)
-    self.status         = self.configTED.get('enabled', False)
-    self.serverIP       = self.configTED.get('serverIP', None)
-    self.serverPort     = self.configTED.get('serverPort','80')
+    def __init__(self, master):
+        self.config = master.config
+        try:
+            self.configConfig = self.config["config"]
+        except KeyError:
+            self.configConfig = {}
+        try:
+            self.configTED = self.config["sources"]["TED"]
+        except KeyError:
+            self.configTED = {}
+        self.debugLevel = self.configConfig.get("debugLevel", 0)
+        self.status = self.configTED.get("enabled", False)
+        self.serverIP = self.configTED.get("serverIP", None)
+        self.serverPort = self.configTED.get("serverPort", "80")
 
-  def debugLog(self, minlevel, message):
-    if (self.debugLevel >= minlevel):
-      print("TED: (" + str(minlevel) + ") " + message)
+    def debugLog(self, minlevel, message):
+        if self.debugLevel >= minlevel:
+            print("TED: (" + str(minlevel) + ") " + message)
 
-  def getConsumption(self):
+    def getConsumption(self):
 
-    if (not self.status):
-      self.debugLog(10, "TED EMS Module Disabled. Skipping getConsumption")
-      return 0
+        if not self.status:
+            self.debugLog(10, "TED EMS Module Disabled. Skipping getConsumption")
+            return 0
 
-    # Perform updates if necessary
-    self.update()
+        # Perform updates if necessary
+        self.update()
 
-    # I don't believe this is implemented
-    return float(0)
+        # I don't believe this is implemented
+        return float(0)
 
-  def getGeneration(self):
+    def getGeneration(self):
 
-    if (not self.status):
-      self.debugLog(10, "TED EMS Module Disabled. Skipping getGeneration")
-      return 0
+        if not self.status:
+            self.debugLog(10, "TED EMS Module Disabled. Skipping getGeneration")
+            return 0
 
-    # Perform updates if necessary
-    self.update()
+        # Perform updates if necessary
+        self.update()
 
-    # Return generation value
-    return float(self.generatedW)
+        # Return generation value
+        return float(self.generatedW)
 
-  def getTEDValue(self, url):
+    def getTEDValue(self, url):
 
-    # Fetch the specified URL from TED and return the data
-    self.fetchFailed = False
+        # Fetch the specified URL from TED and return the data
+        self.fetchFailed = False
 
-    try:
-        r = self.requests.get(url, timeout=self.timeout)
-    except self.requests.exceptions.ConnectionError as e:
-        self.debugLog(4, "Error connecting to TED to fetch solar data")
-        self.debugLog(10, str(e))
-        self.fetchFailed = True
-        return False
+        try:
+            r = self.requests.get(url, timeout=self.timeout)
+        except self.requests.exceptions.ConnectionError as e:
+            self.debugLog(4, "Error connecting to TED to fetch solar data")
+            self.debugLog(10, str(e))
+            self.fetchFailed = True
+            return False
 
-    r.raise_for_status()
-    return r
+        r.raise_for_status()
+        return r
 
-  def update(self):
+    def update(self):
 
-    if ((int(self.time.time()) - self.lastFetch) > self.cacheTime):
-      # Cache has expired. Fetch values from HomeAssistant sensor.
+        if (int(self.time.time()) - self.lastFetch) > self.cacheTime:
+            # Cache has expired. Fetch values from HomeAssistant sensor.
 
-      url = "http://" + self.serverIP + ":" + self.serverPort
-      url = url + "/history/export.csv?T=1&D=0&M=1&C=1"
+            url = "http://" + self.serverIP + ":" + self.serverPort
+            url = url + "/history/export.csv?T=1&D=0&M=1&C=1"
 
-      value = self.getTEDValue(url)
-      m = None
-      if (value):
-        m = self.re.search(b'^Solar,[^,]+,-?([^, ]+),', value, self.re.MULTILINE)
-      else:
-        self.debugLog(5, "Failed to find value in response from TED")
-        self.fetchFailed = True
+            value = self.getTEDValue(url)
+            m = None
+            if value:
+                m = self.re.search(
+                    b"^Solar,[^,]+,-?([^, ]+),", value, self.re.MULTILINE
+                )
+            else:
+                self.debugLog(5, "Failed to find value in response from TED")
+                self.fetchFailed = True
 
-      if(m):
-        self.generatedW = int(float(m.group(1)) * 1000)
+            if m:
+                self.generatedW = int(float(m.group(1)) * 1000)
 
-      # Update last fetch time
-      if (self.fetchFailed is not True):
-        self.lastFetch = int(self.time.time())
+            # Update last fetch time
+            if self.fetchFailed is not True:
+                self.lastFetch = int(self.time.time())
 
-      return True
-    else:
-      # Cache time has not elapsed since last fetch, serve from cache.
-      return False
+            return True
+        else:
+            # Cache time has not elapsed since last fetch, serve from cache.
+            return False

--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -2,296 +2,324 @@
 
 from ww import f
 
+
 class TeslaPowerwall2:
 
-  import requests
-  import time
-  import urllib3
-  import json as json
+    import requests
+    import time
+    import urllib3
+    import json as json
 
-  cacheTime       = 10
-  cloudCacheTime  = 1800
-  config          = None
-  configConfig    = None
-  configPowerwall = None
-  debugLevel      = 0
-  master          = None
-  minSOE          = 90
-  lastFetch       = dict()
-  password        = None
-  serverIP        = None
-  serverPort      = 443
-  status          = False
-  timeout         = 10
-  tokenTimeout    = 0
-  httpSession     = None
-  cloudID         = None
-  suppressGeneration = False
+    cacheTime = 10
+    cloudCacheTime = 1800
+    config = None
+    configConfig = None
+    configPowerwall = None
+    debugLevel = 0
+    master = None
+    minSOE = 90
+    lastFetch = dict()
+    password = None
+    serverIP = None
+    serverPort = 443
+    status = False
+    timeout = 10
+    tokenTimeout = 0
+    httpSession = None
+    cloudID = None
+    suppressGeneration = False
 
-  def __init__(self, master):
-    self.master            = master
-    self.config            = master.config
-    try:
-      self.configConfig    = self.config['config']
-    except KeyError:
-      self.configConfig    = {}
-    try:
-      self.configPowerwall = self.config['sources']['Powerwall2']
-    except KeyError:
-      self.configPowerwall = {}
-    self.debugLevel        = self.configConfig.get('debugLevel', 0)
-    self.status            = self.configPowerwall.get('enabled', False)
-    self.serverIP          = self.configPowerwall.get('serverIP', None)
-    self.serverPort        = self.configPowerwall.get('serverPort','443')
-    self.password          = self.configPowerwall.get('password', None)
-    self.minSOE            = self.configPowerwall.get('minBatteryLevel', 90)
-    self.cloudID           = self.configPowerwall.get('cloudID', None)
-    self.cloudCacheTime    = self.configConfig.get('cloudUpdateInterval',1800)
-    self.httpSession       = self.requests.session()
-    if self.status and self.debugLevel < 11:
-      # PW uses self-signed certificates; squelch warnings
-      self.urllib3.disable_warnings(category=self.urllib3.exceptions.InsecureRequestWarning)
-
-  @property
-  def generatedW(self):
-    value = self.getPWValues()
-    return float(value['solar']['instant_power'])
-
-  @property
-  def consumedW(self):
-    value = self.getPWValues()
-    return float(value['load']['instant_power'])
-
-  @property
-  def importW(self):
-    value = self.getPWValues()
-    gridW = float(value['site']['instant_power'])
-    return gridW if gridW > 0 else 0
-
-  @property
-  def exportW(self):
-    value = self.getPWValues()
-    gridW = float(value['site']['instant_power'])
-    return abs(gridW) if gridW < 0 else 0
-
-  @property
-  def gridStatus(self):
-    value = self.getStatus()
-    # There are actually two types of disconnected, but let's simplify that away
-    return True if value['grid_status'] == "SystemGridConnected" else False
-
-  @property
-  def voltage(self):
-    value = self.getPWValues()
-    return int(value['site']['instant_average_voltage'])
-
-  @property
-  def batteryLevel(self):
-    value = self.getSOE()
-    return float(value['percentage'])
-
-  @property
-  def operatingMode(self):
-    value = self.getOperation()
-    return value['real_mode']
-
-  @property
-  def reservePercent(self):
-    value = self.getOperation()
-    return float(value['backup_reserve_percent'])
-
-  @property
-  def stormWatch(self):
-    value = self.getStormWatch()
-    return value.get('storm_mode_active', False)
-
-  def debugLog(self, minlevel, message):
-    if (self.debugLevel >= minlevel):
-      print("Powerwall2: (" + str(minlevel) + ") " + message)
-
-  def doPowerwallLogin(self):
-    # If we have password authentication configured, this function will submit
-    # the login details to the Powerwall API, and get an authentication token.
-    # If we already have an authentication token, we just use that.
-    if (self.password is not None):
-      if (self.tokenTimeout < self.time.time()):
-        self.debugLog(6, "Logging in to Powerwall API")
-        headers = {
-          "Content-Type": "application/json"
-        }
-        data = {
-          "username": "customer",
-          "password": self.password,
-          "force_sm_off": False
-        }
-        url = "https://" + self.serverIP + ":" + self.serverPort
-        url += "/api/login/Basic"
+    def __init__(self, master):
+        self.master = master
+        self.config = master.config
         try:
-          req = self.httpSession.post(url, headers=headers, json = data, timeout=self.timeout, verify=False)
-        except self.requests.exceptions.ConnectionError as e:
-          self.debugLog(4, "Error connecting to Tesla Powerwall 2 for API login")
-          self.debugLog(10, str(e))
-          return False
-
-        # Time out token after one hour
-        self.tokenTimeout = (self.time.time() + (60 * 60))
-
-        # After authentication, start Powerwall
-        # If we don't do this, the Powerwall will stop working after login
-        self.startPowerwall()
-
-      else:
-        self.debugLog(6, "Powerwall2 API token still valid for " + str(self.tokenTimeout - self.time.time()) + " seconds.")
-
-  def getConsumption(self):
-
-    if (not self.status):
-      self.debugLog(10, "Powerwall2 EMS Module Disabled. Skipping getConsumption")
-      return 0
-
-    # Return consumption value
-    return float(self.consumedW)
-
-  def getGeneration(self):
-
-    if (not self.status):
-      self.debugLog(10, "Powerwall2 EMS Module Disabled. Skipping getGeneration")
-      return 0
-
-    if self.batteryLevel > (self.minSOE * 1.05) and self.importW < 900:
-      self.suppressGeneration = False
-    if self.batteryLevel < (self.minSOE * .95):
-      self.suppressGeneration = True
-
-      # Battery is below threshold; leave all generation for PW charging
-      self.debugLog(5, "Powerwall needs to charge. Ignoring generation.")
-
-    if self.suppressGeneration:
-      return 0
-
-    # Don't take effect immediately, in case it's a temporary blip.
-    if self.importW > 1000:
-      self.suppressGeneration = True
-
-    # Return generation value
-    return float(self.generatedW)
-
-  def getPWJson(self, path):
-
-    (lastTime, lastData) = self.lastFetch[path] if path in self.lastFetch else (0, None)
-
-    if (int(self.time.time()) - lastTime) > self.cacheTime:
-
-      # Fetch the specified URL from Powerwall and return the data
-
-      # Get a login token, if password authentication is enabled
-      self.doPowerwallLogin()
-
-      url = "https://" + self.serverIP + ":" + self.serverPort + path
-      headers = {}
-
-      try:
-        r = self.httpSession.get(url, headers = headers, timeout=self.timeout, verify=False)
-        r.raise_for_status()
-      except Exception as e:
-          self.debugLog(4, "Error connecting to Tesla Powerwall 2 to fetch " + path)
-          self.debugLog(10, str(e))
-          return False
-
-      lastData = r.json()
-      self.lastFetch[path] = (self.time.time(), r.json())
-
-    return lastData
-
-  def getPWValues(self):
-    return self.getPWJson("/api/meters/aggregates")
-
-  def getSOE(self):
-    return self.getPWJson("/api/system_status/soe")
-
-  def getOperation(self):
-    return self.getPWJson("/api/operation")
-
-  def getStatus(self):
-    return self.getPWJson("/api/system_status/grid_status")
-
-  def getStormWatch(self):
-    carapi = self.master.getModuleByName("TeslaAPI")
-    token = carapi.getCarApiBearerToken()
-    expiry = carapi.getCarApiTokenExpireTime()
-    now = self.time.time()
-    key = "CLOUD/live_status"
-
-    (lastTime, lastData) = self.lastFetch[key] if key in self.lastFetch else (0, dict())
-
-    if (int(self.time.time()) - lastTime) > self.cloudCacheTime:
-
-      if token and now < expiry:
-        headers = {
-            "Authorization": "Bearer " + token,
-            "Content-Type": "application/json",
-        }
-        if not self.cloudID:
-          url = "https://owner-api.teslamotors.com/api/1/products"
-          bodyjson = None
-          products = list()
-
-          try:
-            r = self.httpSession.get(url, headers=headers)
-            r.raise_for_status()
-            bodyjson = r.json()
-            products = [
-                (i["energy_site_id"], i["site_name"])
-                for i in bodyjson["response"]
-                if "battery_type" in i and i["battery_type"] == "ac_powerwall"
-            ]
-          except:
-            pass
-
-          if len(products) == 1:
-            (site,name) = products[0]
-            self.cloudID = site
-          elif len(products) > 1:
-            self.debugLog(
-                1,
-                "Multiple Powerwall sites linked to your Tesla account.  Please specify the correct site ID in your config.json.",
+            self.configConfig = self.config["config"]
+        except KeyError:
+            self.configConfig = {}
+        try:
+            self.configPowerwall = self.config["sources"]["Powerwall2"]
+        except KeyError:
+            self.configPowerwall = {}
+        self.debugLevel = self.configConfig.get("debugLevel", 0)
+        self.status = self.configPowerwall.get("enabled", False)
+        self.serverIP = self.configPowerwall.get("serverIP", None)
+        self.serverPort = self.configPowerwall.get("serverPort", "443")
+        self.password = self.configPowerwall.get("password", None)
+        self.minSOE = self.configPowerwall.get("minBatteryLevel", 90)
+        self.cloudID = self.configPowerwall.get("cloudID", None)
+        self.cloudCacheTime = self.configConfig.get("cloudUpdateInterval", 1800)
+        self.httpSession = self.requests.session()
+        if self.status and self.debugLevel < 11:
+            # PW uses self-signed certificates; squelch warnings
+            self.urllib3.disable_warnings(
+                category=self.urllib3.exceptions.InsecureRequestWarning
             )
-            for (site,name) in products:
-                self.debugLog(1, f("   {site}: {name}"))
-          else:
-            self.debugLog(1, "Couldn't find a Powerwall on your Tesla account.")
 
-        if self.cloudID:
-          url = f("https://owner-api.teslamotors.com/api/1/energy_sites/{self.cloudID}/live_status")
-          bodyjson = None
-          result = dict()
+    @property
+    def generatedW(self):
+        value = self.getPWValues()
+        return float(value["solar"]["instant_power"])
 
-          try:
-            r = self.httpSession.get(url, headers=headers)
-            r.raise_for_status()
-            bodyjson = r.json()
-            lastData = bodyjson["response"]
-          except:
-            pass
+    @property
+    def consumedW(self):
+        value = self.getPWValues()
+        return float(value["load"]["instant_power"])
 
-      self.lastFetch[key] = (now, lastData)
-    return lastData
+    @property
+    def importW(self):
+        value = self.getPWValues()
+        gridW = float(value["site"]["instant_power"])
+        return gridW if gridW > 0 else 0
 
+    @property
+    def exportW(self):
+        value = self.getPWValues()
+        gridW = float(value["site"]["instant_power"])
+        return abs(gridW) if gridW < 0 else 0
 
-  def startPowerwall(self):
-    # This function will instruct the powerwall to run.
-    # This is needed after getting a login token for v1.15 and above
+    @property
+    def gridStatus(self):
+        value = self.getStatus()
+        # There are actually two types of disconnected, but let's simplify that away
+        return True if value["grid_status"] == "SystemGridConnected" else False
 
-    # Get a login token, if password authentication is enabled
-    self.doPowerwallLogin()
+    @property
+    def voltage(self):
+        value = self.getPWValues()
+        return int(value["site"]["instant_average_voltage"])
 
-    url = "https://" + self.serverIP + ":" + self.serverPort
-    url += "/api/sitemaster/run"
-    headers = {}
+    @property
+    def batteryLevel(self):
+        value = self.getSOE()
+        return float(value["percentage"])
 
-    try:
-        r = self.httpSession.get(url, headers = headers, timeout=self.timeout, verify=False)
-    except self.requests.exceptions.ConnectionError as e:
-        self.debugLog(4, "Error instructing Tesla Powerwall 2 to start")
-        self.debugLog(10, str(e))
-        return False
+    @property
+    def operatingMode(self):
+        value = self.getOperation()
+        return value["real_mode"]
+
+    @property
+    def reservePercent(self):
+        value = self.getOperation()
+        return float(value["backup_reserve_percent"])
+
+    @property
+    def stormWatch(self):
+        value = self.getStormWatch()
+        return value.get("storm_mode_active", False)
+
+    def debugLog(self, minlevel, message):
+        if self.debugLevel >= minlevel:
+            print("Powerwall2: (" + str(minlevel) + ") " + message)
+
+    def doPowerwallLogin(self):
+        # If we have password authentication configured, this function will submit
+        # the login details to the Powerwall API, and get an authentication token.
+        # If we already have an authentication token, we just use that.
+        if self.password is not None:
+            if self.tokenTimeout < self.time.time():
+                self.debugLog(6, "Logging in to Powerwall API")
+                headers = {"Content-Type": "application/json"}
+                data = {
+                    "username": "customer",
+                    "password": self.password,
+                    "force_sm_off": False,
+                }
+                url = "https://" + self.serverIP + ":" + self.serverPort
+                url += "/api/login/Basic"
+                try:
+                    req = self.httpSession.post(
+                        url,
+                        headers=headers,
+                        json=data,
+                        timeout=self.timeout,
+                        verify=False,
+                    )
+                except self.requests.exceptions.ConnectionError as e:
+                    self.debugLog(
+                        4, "Error connecting to Tesla Powerwall 2 for API login"
+                    )
+                    self.debugLog(10, str(e))
+                    return False
+
+                # Time out token after one hour
+                self.tokenTimeout = self.time.time() + (60 * 60)
+
+                # After authentication, start Powerwall
+                # If we don't do this, the Powerwall will stop working after login
+                self.startPowerwall()
+
+            else:
+                self.debugLog(
+                    6,
+                    "Powerwall2 API token still valid for "
+                    + str(self.tokenTimeout - self.time.time())
+                    + " seconds.",
+                )
+
+    def getConsumption(self):
+
+        if not self.status:
+            self.debugLog(10, "Powerwall2 EMS Module Disabled. Skipping getConsumption")
+            return 0
+
+        # Return consumption value
+        return float(self.consumedW)
+
+    def getGeneration(self):
+
+        if not self.status:
+            self.debugLog(10, "Powerwall2 EMS Module Disabled. Skipping getGeneration")
+            return 0
+
+        if self.batteryLevel > (self.minSOE * 1.05) and self.importW < 900:
+            self.suppressGeneration = False
+        if self.batteryLevel < (self.minSOE * 0.95):
+            self.suppressGeneration = True
+
+            # Battery is below threshold; leave all generation for PW charging
+            self.debugLog(5, "Powerwall needs to charge. Ignoring generation.")
+
+        if self.suppressGeneration:
+            return 0
+
+        # Don't take effect immediately, in case it's a temporary blip.
+        if self.importW > 1000:
+            self.suppressGeneration = True
+
+        # Return generation value
+        return float(self.generatedW)
+
+    def getPWJson(self, path):
+
+        (lastTime, lastData) = (
+            self.lastFetch[path] if path in self.lastFetch else (0, None)
+        )
+
+        if (int(self.time.time()) - lastTime) > self.cacheTime:
+
+            # Fetch the specified URL from Powerwall and return the data
+
+            # Get a login token, if password authentication is enabled
+            self.doPowerwallLogin()
+
+            url = "https://" + self.serverIP + ":" + self.serverPort + path
+            headers = {}
+
+            try:
+                r = self.httpSession.get(
+                    url, headers=headers, timeout=self.timeout, verify=False
+                )
+                r.raise_for_status()
+            except Exception as e:
+                self.debugLog(
+                    4, "Error connecting to Tesla Powerwall 2 to fetch " + path
+                )
+                self.debugLog(10, str(e))
+                return False
+
+            lastData = r.json()
+            self.lastFetch[path] = (self.time.time(), r.json())
+
+        return lastData
+
+    def getPWValues(self):
+        return self.getPWJson("/api/meters/aggregates")
+
+    def getSOE(self):
+        return self.getPWJson("/api/system_status/soe")
+
+    def getOperation(self):
+        return self.getPWJson("/api/operation")
+
+    def getStatus(self):
+        return self.getPWJson("/api/system_status/grid_status")
+
+    def getStormWatch(self):
+        carapi = self.master.getModuleByName("TeslaAPI")
+        token = carapi.getCarApiBearerToken()
+        expiry = carapi.getCarApiTokenExpireTime()
+        now = self.time.time()
+        key = "CLOUD/live_status"
+
+        (lastTime, lastData) = (
+            self.lastFetch[key] if key in self.lastFetch else (0, dict())
+        )
+
+        if (int(self.time.time()) - lastTime) > self.cloudCacheTime:
+
+            if token and now < expiry:
+                headers = {
+                    "Authorization": "Bearer " + token,
+                    "Content-Type": "application/json",
+                }
+                if not self.cloudID:
+                    url = "https://owner-api.teslamotors.com/api/1/products"
+                    bodyjson = None
+                    products = list()
+
+                    try:
+                        r = self.httpSession.get(url, headers=headers)
+                        r.raise_for_status()
+                        bodyjson = r.json()
+                        products = [
+                            (i["energy_site_id"], i["site_name"])
+                            for i in bodyjson["response"]
+                            if "battery_type" in i
+                            and i["battery_type"] == "ac_powerwall"
+                        ]
+                    except:
+                        pass
+
+                    if len(products) == 1:
+                        (site, name) = products[0]
+                        self.cloudID = site
+                    elif len(products) > 1:
+                        self.debugLog(
+                            1,
+                            "Multiple Powerwall sites linked to your Tesla account.  Please specify the correct site ID in your config.json.",
+                        )
+                        for (site, name) in products:
+                            self.debugLog(1, f("   {site}: {name}"))
+                    else:
+                        self.debugLog(
+                            1, "Couldn't find a Powerwall on your Tesla account."
+                        )
+
+                if self.cloudID:
+                    url = f(
+                        "https://owner-api.teslamotors.com/api/1/energy_sites/{self.cloudID}/live_status"
+                    )
+                    bodyjson = None
+                    result = dict()
+
+                    try:
+                        r = self.httpSession.get(url, headers=headers)
+                        r.raise_for_status()
+                        bodyjson = r.json()
+                        lastData = bodyjson["response"]
+                    except:
+                        pass
+
+            self.lastFetch[key] = (now, lastData)
+        return lastData
+
+    def startPowerwall(self):
+        # This function will instruct the powerwall to run.
+        # This is needed after getting a login token for v1.15 and above
+
+        # Get a login token, if password authentication is enabled
+        self.doPowerwallLogin()
+
+        url = "https://" + self.serverIP + ":" + self.serverPort
+        url += "/api/sitemaster/run"
+        headers = {}
+
+        try:
+            r = self.httpSession.get(
+                url, headers=headers, timeout=self.timeout, verify=False
+            )
+        except self.requests.exceptions.ConnectionError as e:
+            self.debugLog(4, "Error instructing Tesla Powerwall 2 to start")
+            self.debugLog(10, str(e))
+            return False

--- a/lib/TWCManager/Interface/Dummy.py
+++ b/lib/TWCManager/Interface/Dummy.py
@@ -1,87 +1,89 @@
 class Dummy:
 
-  import time
+    import time
 
-  debugLevel       = 0
-  enabled          = False
-  master           = None
-  msgBuffer        = None
-  twcID            = 1234
-  timeLastTx       = 0
+    debugLevel = 0
+    enabled = False
+    master = None
+    msgBuffer = None
+    twcID = 1234
+    timeLastTx = 0
 
-  def __init__(self, master):
-    self.master = master
-    try:
-        self.debugLevel = master.config['config']['debugLevel']
-    except KeyError:
-        pass
+    def __init__(self, master):
+        self.master = master
+        try:
+            self.debugLevel = master.config["config"]["debugLevel"]
+        except KeyError:
+            pass
 
-    if self.enabled:
+        if self.enabled:
 
-      # Configure the module
-      if "interface" in master.config:
-        self.twcID = master.config['interface']['Dummy'].get('twcID', 1234)
+            # Configure the module
+            if "interface" in master.config:
+                self.twcID = master.config["interface"]["Dummy"].get("twcID", 1234)
 
-  def close(self):
-    # NOOP - No need to close anything
-    return 0
+    def close(self):
+        # NOOP - No need to close anything
+        return 0
 
-  def getBufferLen(self):
-    # This function returns the size of the recieve buffer.
-    # This is used by read functions to determine if information is waiting
-    return len(self.msgBuffer)
+    def getBufferLen(self):
+        # This function returns the size of the recieve buffer.
+        # This is used by read functions to determine if information is waiting
+        return len(self.msgBuffer)
 
-  def send(self, msg):
-    # NOOP - TBD
+    def send(self, msg):
+        # NOOP - TBD
 
-    self.master.debugLog(9, "IfaceDummy", "Tx@: " + self.master.hex_str(msg))
-    self.timeLastTx = self.time.time()
-    return 0
+        self.master.debugLog(9, "IfaceDummy", "Tx@: " + self.master.hex_str(msg))
+        self.timeLastTx = self.time.time()
+        return 0
 
-  def read(self, len):
-    # Read our buffered messages. We simulate this by making a copy of the
-    # current message buffer, clearing the shared message buffer and then 
-    # returning the copied message to TWCManager. This is what it would look
-    # like if we read from a serial interface
-    localMsgBuffer = self.msgBuffer
-    self.msgBuffer = None
-    self.master.debugLog(9, "IfaceDummy", "Rx@: " + self.master.hex_str(localMsgBuffer))
-    return localMsgBuffer
+    def read(self, len):
+        # Read our buffered messages. We simulate this by making a copy of the
+        # current message buffer, clearing the shared message buffer and then
+        # returning the copied message to TWCManager. This is what it would look
+        # like if we read from a serial interface
+        localMsgBuffer = self.msgBuffer
+        self.msgBuffer = None
+        self.master.debugLog(
+            9, "IfaceDummy", "Rx@: " + self.master.hex_str(localMsgBuffer)
+        )
+        return localMsgBuffer
 
-  def sendInternal(self, msg):
-    # The sendInternal function takes a message that we would like to send
-    # from the dummy module to the TWCManager, adds the required checksum,
-    # updates the internal message buffer with the sent message and then
-    # allows this to be polled & read by TWCManager on the next loop iteration
+    def sendInternal(self, msg):
+        # The sendInternal function takes a message that we would like to send
+        # from the dummy module to the TWCManager, adds the required checksum,
+        # updates the internal message buffer with the sent message and then
+        # allows this to be polled & read by TWCManager on the next loop iteration
 
-    msg = bytearray(msg)
-    checksum = 0
-    for i in range(1, len(msg)):
-        checksum += msg[i]
+        msg = bytearray(msg)
+        checksum = 0
+        for i in range(1, len(msg)):
+            checksum += msg[i]
 
-    msg.append(checksum & 0xFF)
+        msg.append(checksum & 0xFF)
 
-    # Escaping special chars:
-    # The protocol uses C0 to mark the start and end of the message.  If a C0
-    # must appear within the message, it is 'escaped' by replacing it with
-    # DB and DC bytes.
-    # A DB byte in the message is escaped by replacing it with DB DD.
-    #
-    # User FuzzyLogic found that this method of escaping and marking the start
-    # and end of messages is based on the SLIP protocol discussed here:
-    #   https://en.wikipedia.org/wiki/Serial_Line_Internet_Protocol
+        # Escaping special chars:
+        # The protocol uses C0 to mark the start and end of the message.  If a C0
+        # must appear within the message, it is 'escaped' by replacing it with
+        # DB and DC bytes.
+        # A DB byte in the message is escaped by replacing it with DB DD.
+        #
+        # User FuzzyLogic found that this method of escaping and marking the start
+        # and end of messages is based on the SLIP protocol discussed here:
+        #   https://en.wikipedia.org/wiki/Serial_Line_Internet_Protocol
 
-    i = 0
-    while(i < len(msg)):
-        if(msg[i] == 0xc0):
-            msg[i:i+1] = b'\xdb\xdc'
+        i = 0
+        while i < len(msg):
+            if msg[i] == 0xC0:
+                msg[i : i + 1] = b"\xdb\xdc"
+                i = i + 1
+            elif msg[i] == 0xDB:
+                msg[i : i + 1] = b"\xdb\xdd"
+                i = i + 1
             i = i + 1
-        elif(msg[i] == 0xdb):
-            msg[i:i+1] = b'\xdb\xdd'
-            i = i + 1
-        i = i + 1
 
-    msg = bytearray(b'\xc0' + msg + b'\xc0')
-    self.master.debugLog(9, "IfaceDummy", "TxInt@: " + self.master.hex_str(msg))
+        msg = bytearray(b"\xc0" + msg + b"\xc0")
+        self.master.debugLog(9, "IfaceDummy", "TxInt@: " + self.master.hex_str(msg))
 
-    self.msgBuffer = msg
+        self.msgBuffer = msg

--- a/lib/TWCManager/Interface/RS485.py
+++ b/lib/TWCManager/Interface/RS485.py
@@ -1,97 +1,96 @@
 class RS485:
 
-  import serial
-  import time
+    import serial
+    import time
 
-  baud             = 9600
-  debugLevel       = 0
-  enabled          = True
-  master           = None
-  port             = None
-  ser              = None
-  timeLastTx       = 0
+    baud = 9600
+    debugLevel = 0
+    enabled = True
+    master = None
+    port = None
+    ser = None
+    timeLastTx = 0
 
-  def __init__(self, master):
-    self.master = master
-    try:
-        self.debugLevel = master.config['config']['debugLevel']
-    except KeyError:
-        pass
+    def __init__(self, master):
+        self.master = master
+        try:
+            self.debugLevel = master.config["config"]["debugLevel"]
+        except KeyError:
+            pass
 
-    # There are two places that the baud rate for the RS485 adapter may be stored.
-    # The first is the legacy configuration path, and the second is the new
-    # dedicated interface configuration. We check either/both for this value
-    bauda = master.config['config'].get('baud', 0)
-    baudb = None
-    if "interface" in master.config:
-      baudb = master.config['interface']['RS485'].get('baud', 0)
-    if baudb:
-      self.baud = baudb
-    elif bauda:
-      self.baud = bauda
+        # There are two places that the baud rate for the RS485 adapter may be stored.
+        # The first is the legacy configuration path, and the second is the new
+        # dedicated interface configuration. We check either/both for this value
+        bauda = master.config["config"].get("baud", 0)
+        baudb = None
+        if "interface" in master.config:
+            baudb = master.config["interface"]["RS485"].get("baud", 0)
+        if baudb:
+            self.baud = baudb
+        elif bauda:
+            self.baud = bauda
 
-    # Similarly, there are two places to check for a port defined.
-    porta = master.config['config'].get('rs485adapter', '')
-    portb = None
-    if "interface" in master.config:
-      portb = master.config['interface']['RS485'].get('port', '')
-    if portb:
-      self.port = portb
-    elif porta:
-      self.port = porta
+        # Similarly, there are two places to check for a port defined.
+        porta = master.config["config"].get("rs485adapter", "")
+        portb = None
+        if "interface" in master.config:
+            portb = master.config["interface"]["RS485"].get("port", "")
+        if portb:
+            self.port = portb
+        elif porta:
+            self.port = porta
 
-    # Connect to serial port
-    self.ser = self.serial.Serial(self.port, self.baud, timeout=0)
+        # Connect to serial port
+        self.ser = self.serial.Serial(self.port, self.baud, timeout=0)
 
-  def close(self):
-    # Close the serial interface
-    return self.ser.close()
+    def close(self):
+        # Close the serial interface
+        return self.ser.close()
 
-  def getBufferLen(self):
-    # This function returns the size of the recieve buffer.
-    # This is used by read functions to determine if information is waiting
-    return self.ser.inWaiting()
+    def getBufferLen(self):
+        # This function returns the size of the recieve buffer.
+        # This is used by read functions to determine if information is waiting
+        return self.ser.inWaiting()
 
-  def read(self, len):
-    # Read the specified amount of data from the serial interface
-    return self.ser.read(len)
+    def read(self, len):
+        # Read the specified amount of data from the serial interface
+        return self.ser.read(len)
 
-  def send(self, msg):
-    # Send msg on the RS485 network. We'll escape bytes with a special meaning,
-    # add a CRC byte to the message end, and add a C0 byte to the start and end
-    # to mark where it begins and ends.
+    def send(self, msg):
+        # Send msg on the RS485 network. We'll escape bytes with a special meaning,
+        # add a CRC byte to the message end, and add a C0 byte to the start and end
+        # to mark where it begins and ends.
 
-    msg = bytearray(msg)
-    checksum = 0
-    for i in range(1, len(msg)):
-        checksum += msg[i]
+        msg = bytearray(msg)
+        checksum = 0
+        for i in range(1, len(msg)):
+            checksum += msg[i]
 
-    msg.append(checksum & 0xFF)
+        msg.append(checksum & 0xFF)
 
-    # Escaping special chars:
-    # The protocol uses C0 to mark the start and end of the message.  If a C0
-    # must appear within the message, it is 'escaped' by replacing it with
-    # DB and DC bytes.
-    # A DB byte in the message is escaped by replacing it with DB DD.
-    #
-    # User FuzzyLogic found that this method of escaping and marking the start
-    # and end of messages is based on the SLIP protocol discussed here:
-    #   https://en.wikipedia.org/wiki/Serial_Line_Internet_Protocol
+        # Escaping special chars:
+        # The protocol uses C0 to mark the start and end of the message.  If a C0
+        # must appear within the message, it is 'escaped' by replacing it with
+        # DB and DC bytes.
+        # A DB byte in the message is escaped by replacing it with DB DD.
+        #
+        # User FuzzyLogic found that this method of escaping and marking the start
+        # and end of messages is based on the SLIP protocol discussed here:
+        #   https://en.wikipedia.org/wiki/Serial_Line_Internet_Protocol
 
-    i = 0
-    while(i < len(msg)):
-        if(msg[i] == 0xc0):
-            msg[i:i+1] = b'\xdb\xdc'
+        i = 0
+        while i < len(msg):
+            if msg[i] == 0xC0:
+                msg[i : i + 1] = b"\xdb\xdc"
+                i = i + 1
+            elif msg[i] == 0xDB:
+                msg[i : i + 1] = b"\xdb\xdd"
+                i = i + 1
             i = i + 1
-        elif(msg[i] == 0xdb):
-            msg[i:i+1] = b'\xdb\xdd'
-            i = i + 1
-        i = i + 1
 
-    msg = bytearray(b'\xc0' + msg + b'\xc0')
-    self.master.debugLog(9, "IfaceRS485", "Tx@: " + self.master.hex_str(msg))
+        msg = bytearray(b"\xc0" + msg + b"\xc0")
+        self.master.debugLog(9, "IfaceRS485", "Tx@: " + self.master.hex_str(msg))
 
-    self.ser.write(msg)
+        self.ser.write(msg)
 
-    self.timeLastTx = self.time.time()
-
+        self.timeLastTx = self.time.time()

--- a/lib/TWCManager/Interface/TCP.py
+++ b/lib/TWCManager/Interface/TCP.py
@@ -1,82 +1,82 @@
 import socket
 
+
 class TCP:
 
-  import time
+    import time
 
-  debugLevel       = 0
-  enabled          = False
-  master           = None
-  port             = 6000
-  server           = None
-  sock             = None
-  timeLastTx       = 0
+    debugLevel = 0
+    enabled = False
+    master = None
+    port = 6000
+    server = None
+    sock = None
+    timeLastTx = 0
 
-  def __init__(self, master):
-    self.master = master
-    try:
-        self.debugLevel = master.config['config']['debugLevel']
-    except KeyError:
-        pass
+    def __init__(self, master):
+        self.master = master
+        try:
+            self.debugLevel = master.config["config"]["debugLevel"]
+        except KeyError:
+            pass
 
-    if self.enabled:
+        if self.enabled:
 
-      # Create TCP socket
-      self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            # Create TCP socket
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-      # If we are configured to listen, open the listening socket
-      self.sock.bind(('localhost', self.port))
-      self.sock.listen(1)
+            # If we are configured to listen, open the listening socket
+            self.sock.bind(("localhost", self.port))
+            self.sock.listen(1)
 
-  def close(self):
-    # Close the TCP socket interface
-    self.sock.close()
+    def close(self):
+        # Close the TCP socket interface
+        self.sock.close()
 
-  def getBufferLen(self):
-    # This function returns the size of the recieve buffer.
-    # This is used by read functions to determine if information is waiting
-    return 0
+    def getBufferLen(self):
+        # This function returns the size of the recieve buffer.
+        # This is used by read functions to determine if information is waiting
+        return 0
 
-  def read(self, len):
-    # Read the specified amount of data from the serial interface
-    return 0
+    def read(self, len):
+        # Read the specified amount of data from the serial interface
+        return 0
 
-  def send(self, msg):
-    # Send msg on the RS485 network. We'll escape bytes with a special meaning,
-    # add a CRC byte to the message end, and add a C0 byte to the start and end
-    # to mark where it begins and ends.
+    def send(self, msg):
+        # Send msg on the RS485 network. We'll escape bytes with a special meaning,
+        # add a CRC byte to the message end, and add a C0 byte to the start and end
+        # to mark where it begins and ends.
 
-    msg = bytearray(msg)
-    checksum = 0
-    for i in range(1, len(msg)):
-        checksum += msg[i]
+        msg = bytearray(msg)
+        checksum = 0
+        for i in range(1, len(msg)):
+            checksum += msg[i]
 
-    msg.append(checksum & 0xFF)
+        msg.append(checksum & 0xFF)
 
-    # Escaping special chars:
-    # The protocol uses C0 to mark the start and end of the message.  If a C0
-    # must appear within the message, it is 'escaped' by replacing it with
-    # DB and DC bytes.
-    # A DB byte in the message is escaped by replacing it with DB DD.
-    #
-    # User FuzzyLogic found that this method of escaping and marking the start
-    # and end of messages is based on the SLIP protocol discussed here:
-    #   https://en.wikipedia.org/wiki/Serial_Line_Internet_Protocol
+        # Escaping special chars:
+        # The protocol uses C0 to mark the start and end of the message.  If a C0
+        # must appear within the message, it is 'escaped' by replacing it with
+        # DB and DC bytes.
+        # A DB byte in the message is escaped by replacing it with DB DD.
+        #
+        # User FuzzyLogic found that this method of escaping and marking the start
+        # and end of messages is based on the SLIP protocol discussed here:
+        #   https://en.wikipedia.org/wiki/Serial_Line_Internet_Protocol
 
-    i = 0
-    while(i < len(msg)):
-        if(msg[i] == 0xc0):
-            msg[i:i+1] = b'\xdb\xdc'
+        i = 0
+        while i < len(msg):
+            if msg[i] == 0xC0:
+                msg[i : i + 1] = b"\xdb\xdc"
+                i = i + 1
+            elif msg[i] == 0xDB:
+                msg[i : i + 1] = b"\xdb\xdd"
+                i = i + 1
             i = i + 1
-        elif(msg[i] == 0xdb):
-            msg[i:i+1] = b'\xdb\xdd'
-            i = i + 1
-        i = i + 1
 
-    msg = bytearray(b'\xc0' + msg + b'\xc0')
-    self.master.debugLog(9, "IfaceTCP  ", "Tx@: " + self.master.hex_str(msg))
+        msg = bytearray(b"\xc0" + msg + b"\xc0")
+        self.master.debugLog(9, "IfaceTCP  ", "Tx@: " + self.master.hex_str(msg))
 
-    #self.ser.write(msg)
+        # self.ser.write(msg)
 
-    self.timeLastTx = self.time.time()
-
+        self.timeLastTx = self.time.time()

--- a/lib/TWCManager/Status/HASSStatus.py
+++ b/lib/TWCManager/Status/HASSStatus.py
@@ -3,85 +3,106 @@
 
 from ww import f
 
+
 class HASSStatus:
 
-  import time
-  import requests
+    import time
+    import requests
 
-  apiKey           = None
-  config           = None
-  configConfig     = None
-  configHASS       = None
-  debugLevel       = 0
-  master           = None
-  msgRate          = {}
-  msgRatePerSensor = 60
-  status           = False
-  serverIP         = None
-  serverPort       = 8123
-  timeout          = 2
+    apiKey = None
+    config = None
+    configConfig = None
+    configHASS = None
+    debugLevel = 0
+    master = None
+    msgRate = {}
+    msgRatePerSensor = 60
+    status = False
+    serverIP = None
+    serverPort = 8123
+    timeout = 2
 
-  def __init__(self, master):
-    self.config         = master.config
-    self.master         = master
-    try:
-      self.configConfig = self.config['config']
-    except KeyError:
-      self.configConfig = {}
-    try:
-      self.configHASS   = self.config['status']['HASS']
-    except KeyError:
-      self.configHASS   = {}
-    self.status         = self.configHASS.get('enabled', False)
-    self.serverIP       = self.configHASS.get('serverIP', None)
-    self.serverPort     = self.configHASS.get('serverPort', 8123)
-    self.apiKey         = self.configHASS.get('apiKey', None)
-    self.debugLevel     = self.configConfig.get('debugLevel', 0)
+    def __init__(self, master):
+        self.config = master.config
+        self.master = master
+        try:
+            self.configConfig = self.config["config"]
+        except KeyError:
+            self.configConfig = {}
+        try:
+            self.configHASS = self.config["status"]["HASS"]
+        except KeyError:
+            self.configHASS = {}
+        self.status = self.configHASS.get("enabled", False)
+        self.serverIP = self.configHASS.get("serverIP", None)
+        self.serverPort = self.configHASS.get("serverPort", 8123)
+        self.apiKey = self.configHASS.get("apiKey", None)
+        self.debugLevel = self.configConfig.get("debugLevel", 0)
 
-  def setStatus(self, twcid, key_underscore, key_camelcase, value):
+    def setStatus(self, twcid, key_underscore, key_camelcase, value):
 
-    # Format TWCID nicely
-    twident = None
-    if (len(twcid) == 2):
-      twident = "%02X%02X" % (twcid[0], twcid[1])
-    else:
-      twident = str(twcid.decode("utf-8"))
-
-    sensor = "sensor.twcmanager_" + str(twident) + "_" + key_underscore
-
-    if (self.status):
-
-      # Perform rate limiting first (as there are some very chatty topics).
-      # For each message that comes through, we take the sensor name and check
-      # when we last updated it. If it was less than msgRatePerSensor
-      # seconds ago, we dampen it.
-      if (sensor in self.msgRate):
-        if ((self.time.time() - self.msgRate[sensor]) < self.msgRatePerSensor):
-          return True
+        # Format TWCID nicely
+        twident = None
+        if len(twcid) == 2:
+            twident = "%02X%02X" % (twcid[0], twcid[1])
         else:
-          self.msgRate[sensor] = self.time.time()
-      else:
-        self.msgRate[sensor] = self.time.time()
+            twident = str(twcid.decode("utf-8"))
 
-      url = "http://" + self.serverIP + ":" + self.serverPort
-      url = url + "/api/states/" + sensor
-      headers = {
-          'Authorization': 'Bearer ' + self.apiKey,
-          'content-type': 'application/json'
-      }
+        sensor = "sensor.twcmanager_" + str(twident) + "_" + key_underscore
 
-      try:
-          self.master.debugLog(8, "HASSStatus", f("Sending POST request to HomeAssistant for sensor {sensor} (value {value})."))
-          self.requests.post(url, json={"state":value}, timeout=self.timeout, headers=headers)
-      except self.requests.exceptions.ConnectionError as e:
-        self.master.debugLog(4, "HASSStatus", "Error connecting to HomeAssistant to publish sensor values")
-        self.master.debugLog(10, "HASSStatus", str(e))
-        return False
-      except self.requests.exceptions.ReadTimeout as e:
-        self.master.debugLog(4, "HASSStatus", "Error connecting to HomeAssistant to publish sensor values")
-        self.master.debugLog(10, "HASSStatus", str(e))
-        return False
-      except Exception as e:
-        self.master.debugLog(4, "HASSStatus", "Error during publishing HomeAssistant sensor values")
-        self.master.debugLog(10, "HASSStatus", str(e))
-        return False
+        if self.status:
+
+            # Perform rate limiting first (as there are some very chatty topics).
+            # For each message that comes through, we take the sensor name and check
+            # when we last updated it. If it was less than msgRatePerSensor
+            # seconds ago, we dampen it.
+            if sensor in self.msgRate:
+                if (self.time.time() - self.msgRate[sensor]) < self.msgRatePerSensor:
+                    return True
+                else:
+                    self.msgRate[sensor] = self.time.time()
+            else:
+                self.msgRate[sensor] = self.time.time()
+
+            url = "http://" + self.serverIP + ":" + self.serverPort
+            url = url + "/api/states/" + sensor
+            headers = {
+                "Authorization": "Bearer " + self.apiKey,
+                "content-type": "application/json",
+            }
+
+            try:
+                self.master.debugLog(
+                    8,
+                    "HASSStatus",
+                    f(
+                        "Sending POST request to HomeAssistant for sensor {sensor} (value {value})."
+                    ),
+                )
+                self.requests.post(
+                    url, json={"state": value}, timeout=self.timeout, headers=headers
+                )
+            except self.requests.exceptions.ConnectionError as e:
+                self.master.debugLog(
+                    4,
+                    "HASSStatus",
+                    "Error connecting to HomeAssistant to publish sensor values",
+                )
+                self.master.debugLog(10, "HASSStatus", str(e))
+                return False
+            except self.requests.exceptions.ReadTimeout as e:
+                self.master.debugLog(
+                    4,
+                    "HASSStatus",
+                    "Error connecting to HomeAssistant to publish sensor values",
+                )
+                self.master.debugLog(10, "HASSStatus", str(e))
+                return False
+            except Exception as e:
+                self.master.debugLog(
+                    4,
+                    "HASSStatus",
+                    "Error during publishing HomeAssistant sensor values",
+                )
+                self.master.debugLog(10, "HASSStatus", str(e))
+                return False

--- a/lib/TWCManager/Status/MQTTStatus.py
+++ b/lib/TWCManager/Status/MQTTStatus.py
@@ -4,130 +4,146 @@
 from termcolor import colored
 from ww import f
 
+
 class MQTTStatus:
 
-  import time
-  import paho.mqtt.client as mqtt
-  
-  brokerIP        = None
-  brokerPort      = 1883
-  config          = None
-  configConfig    = None
-  configMQTT      = {}
-  connectionState = 0
-  debugLevel      = 0
-  master          = None
-  msgQueue        = []
-  msgQueueBuffer  = []
-  msgQueueMax     = 16
-  msgRate         = {}
-  msgRatePerTopic = 60
-  password        = None
-  status          = False
-  serverTLS       = False
-  topicPrefix     = None
-  username        = None
-  
-  def __init__(self, master):
-    self.config         = master.config
-    self.master         = master
-    try:
-      self.configConfig = self.config['config']
-    except KeyError:
-      self.configConfig = {}
-    try:
-      self.configMQTT   = self.config['status']['MQTT']
-    except KeyError:
-      self.configMQTT   = {}
-    self.debugLevel     = self.configConfig.get('debugLevel', 0)
-    self.status         = self.configMQTT.get('enabled', False)
-    self.brokerIP       = self.configMQTT.get('brokerIP', None)
-    self.topicPrefix    = self.configMQTT.get('topicPrefix', None)
-    self.username       = self.configMQTT.get('username', None)
-    self.password       = self.configMQTT.get('password', None)
+    import time
+    import paho.mqtt.client as mqtt
 
-  def debugLog(self, minlevel, message):
-    if (self.debugLevel >= minlevel):
-      print(colored(self.master.time_now() + " ", 'yellow') + \
-            colored("MQTTStatus", 'green') + \
-            colored(f(" {minlevel} "), 'cyan') + \
-            f("{message}"))
+    brokerIP = None
+    brokerPort = 1883
+    config = None
+    configConfig = None
+    configMQTT = {}
+    connectionState = 0
+    debugLevel = 0
+    master = None
+    msgQueue = []
+    msgQueueBuffer = []
+    msgQueueMax = 16
+    msgRate = {}
+    msgRatePerTopic = 60
+    password = None
+    status = False
+    serverTLS = False
+    topicPrefix = None
+    username = None
 
-  def setStatus(self, twcid, key_underscore, key_camelcase, value):
-    if (self.status):
-
-      # Format TWCID nicely
-      twident = None
-      if (len(twcid) == 2):
-        twident = "%02X%02X" % (twcid[0], twcid[1])
-      else:
-        twident = str(twcid.decode("utf-8"))
-      topic = self.topicPrefix+ "/" + twident
-      topic = topic + "/" + key_camelcase
-
-      # Perform rate limiting first (as there are some very chatty topics).
-      # For each message that comes through, we take the topic name and check
-      # when we last sent a message. If it was less than msgRatePerTopic
-      # seconds ago, we dampen it.
-      if (topic in self.msgRate): 
-        if ((self.time.time() - self.msgRate[topic]) < self.msgRatePerTopic):
-          return True
-        else:
-          self.msgRate[topic] = self.time.time()
-      else:
-        self.msgRate[topic] = self.time.time()
-
-      # Now, we push the message that we'd like to send into the
-      # list of messages to be published once a connection is established
-      msg = { "topic": topic, "payload": value }
-      self.msgQueue.append(msg.copy())
-
-      # If msgQueue size exceeds msgQueueMax, trim the list size
-      # This will discard MQTT messages in environments where the MQTT
-      # broker cannot accept the rate of MQTT messages sent
-      if (len(self.msgQueue) > (self.msgQueueMax + 8)):
-        del self.msgQueue[:self.msgQueueMax]
-
-      # Now, we attempt to establish a connection to the MQTT broker
-      if (self.connectionState == 0):
-        self.debugLog(10, "MQTT Status: Attempting to Connect")
+    def __init__(self, master):
+        self.config = master.config
+        self.master = master
         try:
-          client = self.mqtt.Client()
-          if (self.username and self.password):
-            client.username_pw_set(self.username, self.password)
-          client.on_connect = self.mqttConnected
-          client.connect_async(self.brokerIP, port=self.brokerPort, keepalive=30)
-          self.connectionState = 1
-          client.loop_start()
-        except ConnectionRefusedError as e:
-          self.debugLog(4, "Error connecting to MQTT Broker to publish topic values")
-          self.debugLog(10, str(e))
-          return False
-        except OSError as e:
-          self.debugLog(4, "Error connecting to MQTT Broker to publish topic values")
-          self.debugLog(10, str(e))
-          return False
+            self.configConfig = self.config["config"]
+        except KeyError:
+            self.configConfig = {}
+        try:
+            self.configMQTT = self.config["status"]["MQTT"]
+        except KeyError:
+            self.configMQTT = {}
+        self.debugLevel = self.configConfig.get("debugLevel", 0)
+        self.status = self.configMQTT.get("enabled", False)
+        self.brokerIP = self.configMQTT.get("brokerIP", None)
+        self.topicPrefix = self.configMQTT.get("topicPrefix", None)
+        self.username = self.configMQTT.get("username", None)
+        self.password = self.configMQTT.get("password", None)
 
-  def mqttConnected(self, client, userdata, flags, rc):
-    # This callback function is called once the MQTT client successfully
-    # connects to the MQTT server. It will then publish all queued messages
-    # to the server, and then disconnect.
+    def debugLog(self, minlevel, message):
+        if self.debugLevel >= minlevel:
+            print(
+                colored(self.master.time_now() + " ", "yellow")
+                + colored("MQTTStatus", "green")
+                + colored(f(" {minlevel} "), "cyan")
+                + f("{message}")
+            )
 
-    self.debugLog(10, "Connected to MQTT Broker with RC: " + str(rc))
-    self.debugLog(11, "Copy Message Buffer")
-    self.msgQueueBuffer = self.msgQueue.copy()
-    self.debugLog(11, "Clear Message Buffer")
-    self.msgQueue.clear()
+    def setStatus(self, twcid, key_underscore, key_camelcase, value):
+        if self.status:
 
-    for msg in self.msgQueueBuffer:
-      self.debugLog(8, "Publishing MQTT Topic " + str(msg['topic']) + " (value is " + str(msg['payload']) + ")")
-      try:
-        pub = client.publish(msg['topic'], payload=msg['payload'], qos=0)
-      except e:
-        self.debugLog(4, "Error publishing MQTT Topic Status")
-        self.debugLog(10, str(e))
+            # Format TWCID nicely
+            twident = None
+            if len(twcid) == 2:
+                twident = "%02X%02X" % (twcid[0], twcid[1])
+            else:
+                twident = str(twcid.decode("utf-8"))
+            topic = self.topicPrefix + "/" + twident
+            topic = topic + "/" + key_camelcase
 
-    client.loop_stop()
-    self.msgQueueBuffer.clear()
-    self.connectionState = 0
-    client.disconnect()
+            # Perform rate limiting first (as there are some very chatty topics).
+            # For each message that comes through, we take the topic name and check
+            # when we last sent a message. If it was less than msgRatePerTopic
+            # seconds ago, we dampen it.
+            if topic in self.msgRate:
+                if (self.time.time() - self.msgRate[topic]) < self.msgRatePerTopic:
+                    return True
+                else:
+                    self.msgRate[topic] = self.time.time()
+            else:
+                self.msgRate[topic] = self.time.time()
+
+            # Now, we push the message that we'd like to send into the
+            # list of messages to be published once a connection is established
+            msg = {"topic": topic, "payload": value}
+            self.msgQueue.append(msg.copy())
+
+            # If msgQueue size exceeds msgQueueMax, trim the list size
+            # This will discard MQTT messages in environments where the MQTT
+            # broker cannot accept the rate of MQTT messages sent
+            if len(self.msgQueue) > (self.msgQueueMax + 8):
+                del self.msgQueue[: self.msgQueueMax]
+
+            # Now, we attempt to establish a connection to the MQTT broker
+            if self.connectionState == 0:
+                self.debugLog(10, "MQTT Status: Attempting to Connect")
+                try:
+                    client = self.mqtt.Client()
+                    if self.username and self.password:
+                        client.username_pw_set(self.username, self.password)
+                    client.on_connect = self.mqttConnected
+                    client.connect_async(
+                        self.brokerIP, port=self.brokerPort, keepalive=30
+                    )
+                    self.connectionState = 1
+                    client.loop_start()
+                except ConnectionRefusedError as e:
+                    self.debugLog(
+                        4, "Error connecting to MQTT Broker to publish topic values"
+                    )
+                    self.debugLog(10, str(e))
+                    return False
+                except OSError as e:
+                    self.debugLog(
+                        4, "Error connecting to MQTT Broker to publish topic values"
+                    )
+                    self.debugLog(10, str(e))
+                    return False
+
+    def mqttConnected(self, client, userdata, flags, rc):
+        # This callback function is called once the MQTT client successfully
+        # connects to the MQTT server. It will then publish all queued messages
+        # to the server, and then disconnect.
+
+        self.debugLog(10, "Connected to MQTT Broker with RC: " + str(rc))
+        self.debugLog(11, "Copy Message Buffer")
+        self.msgQueueBuffer = self.msgQueue.copy()
+        self.debugLog(11, "Clear Message Buffer")
+        self.msgQueue.clear()
+
+        for msg in self.msgQueueBuffer:
+            self.debugLog(
+                8,
+                "Publishing MQTT Topic "
+                + str(msg["topic"])
+                + " (value is "
+                + str(msg["payload"])
+                + ")",
+            )
+            try:
+                pub = client.publish(msg["topic"], payload=msg["payload"], qos=0)
+            except e:
+                self.debugLog(4, "Error publishing MQTT Topic Status")
+                self.debugLog(10, str(e))
+
+        client.loop_stop()
+        self.msgQueueBuffer.clear()
+        self.connectionState = 0
+        client.disconnect()

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -10,905 +10,1064 @@ import threading
 import time
 from ww import f
 
+
 class TWCMaster:
 
-  active_policy       = None
-  backgroundTasksQueue = queue.Queue()
-  backgroundTasksCmds = {}
-  backgroundTasksLock = threading.Lock()
-  charge_policy       = [
-    # The first policy table entry is for chargeNow. This will fire if
-    # chargeNowAmps is set to a positive integer and chargeNowTimeEnd
-    # is less than or equal to the current timestamp
-    { "name": "Charge Now",
-      "match": [ "settings.chargeNowAmps", "settings.chargeNowTimeEnd", "settings.chargeNowTimeEnd" ],
-      "condition": [ "gt", "gt", "gt" ],
-      "value": [ 0, 0, "now" ],
-      "charge_amps": "settings.chargeNowAmps",
-      "charge_limit": "config.chargeNowLimit" },
-
-    # Check if we are currently within the Scheduled Amps charging schedule.
-    # If so, charge at the specified number of amps.
-    { "name": "Scheduled Charging",
-      "match": [ "checkScheduledCharging()" ],
-      "condition": [ "eq" ],
-      "value": [ 1 ],
-      "charge_amps": "settings.scheduledAmpsMax",
-      "charge_limit": "config.scheduledLimit" },
-
-    # If we are within Track Green Energy schedule, charging will be
-    # performed based on the amount of solar energy being produced.
-    # Don't bother to check solar generation before 6am or after
-    # 8pm. Sunrise in most U.S. areas varies from a little before
-    # 6am in Jun to almost 7:30am in Nov before the clocks get set
-    # back an hour. Sunset can be ~4:30pm to just after 8pm.
-    { "name": "Track Green Energy",
-      "match": [ "tm_hour", "tm_hour", "settings.hourResumeTrackGreenEnergy" ],
-      "condition": [ "gte", "lt", "lte" ],
-      "value": [ 6, 20, "tm_hour" ],
-      "charge_amps": "getMaxAmpsToDivideGreenEnergy()",
-      "background_task": "checkGreenEnergy",
-      "charge_limit": "config.greenEnergyLimit" },
-
-      # If all else fails (ie no other policy match), we will charge at
-      # nonScheduledAmpsMax
-    { "name": "Non Scheduled Charging",
-      "match": [ "none" ],
-      "condition": [ "none" ],
-      "value": [ 0 ],
-      "charge_amps": "settings.nonScheduledAmpsMax",
-      "charge_limit": "config.nonScheduledLimit" }
-  ]
-
-  config              = None
-  consumptionValues   = {}
-  debugLevel          = 0
-  generationValues    = {}
-  lastPolicyCheck     = 0
-  lastTWCResponseMsg  = None
-  masterTWCID         = ''
-  maxAmpsToDivideAmongSlaves = 0
-  modules             = {}
-  overrideMasterHeartbeatData = b''
-  policyCheckInterval = 30
-  protocolVersion     = 2
-  settings            = {
-    'chargeNowAmps'            : 0,
-    'chargeStopMode'           : "1",
-    'chargeNowTimeEnd'         : 0,
-    'homeLat'                  : 10000,
-    'homeLon'                  : 10000,
-    'hourResumeTrackGreenEnergy' : -1,
-    'kWhDelivered'             : 119,
-    'nonScheduledAmpsMax'      : 0,
-    'respondToSlaves'          : 1,
-    'scheduledAmpsDaysBitmap'  : 0x7F,
-    'scheduledAmpsEndHour'     : -1,
-    'scheduledAmpsMax'         : 0,
-    'scheduledAmpsStartHour'   : -1
-  }
-  slaveHeartbeatData = bytearray([0x01,0x0F,0xA0,0x0F,0xA0,0x00,0x00,0x00,0x00])
-  slaveTWCs           = {}
-  slaveTWCRoundRobin  = []
-  spikeAmpsToCancel6ALimit = 16
-  subtractChargerLoad = False
-  teslaLoginAskLater  = False
-  TWCID               = None
-
-# TWCs send a seemingly-random byte after their 2-byte TWC id in a number of
-# messages. I call this byte their "Sign" for lack of a better term. The byte
-# never changes unless the TWC is reset or power cycled. We use hard-coded
-# values for now because I don't know if there are any rules to what values can
-# be chosen. I picked 77 because it's easy to recognize when looking at logs.
-# These shouldn't need to be changed.
-  masterSign = bytearray(b'\x77')
-  slaveSign = bytearray(b'\x77')
-
-  def __init__(self, TWCID, config):
-    self.config     = config
-    self.debugLevel = config['config']['debugLevel']
-    self.TWCID      = TWCID
-    self.subtractChargerLoad = config['config']['subtractChargerLoad']
-
-    # Override Charge Policy if specified
-    config_policy = config.get("policy")
-    if (config_policy):
-      if (len(config_policy.get("override", [])) > 0):
-        # Policy override specified, just override in place without processing the
-        # extensions
-        self.charge_policy = config_policy.get("override")
-      else:
-        # Insert optional policy extensions into policy list
-        # After - Inserted before Non-Scheduled Charging
-        config_extend = config_policy.get("extend", {})
-        if (len(config_extend.get("after", [])) > 0):
-          self.charge_policy[3:3] = config_extend.get("after")
-
-        # Before - Inserted after Charge Now
-        if (len(config_extend.get("before", [])) > 0):
-          self.charge_policy[1:1] = config_extend.get("before")
-
-        # Emergency - Inserted at the beginning
-        if (len(config_extend.get("emergency", [])) > 0):
-          self.charge_policy[0:0] = config_extend.get("emergency")
-
-    # Set the Policy Check Interval if specified
-    if (config_policy):
-      policy_engine = config_policy.get("engine")
-      if (policy_engine):
-        if (policy_engine.get('policyCheckInterval')):
-          self.policyCheckInterval = policy_engine.get('policyCheckInterval')
-
-    # Register ourself as a module, allows lookups via the Module architecture
-    self.registerModule({ "name": "master", "ref": self, "type": "Master" })
-
-  def addkWhDelivered(self, kWh):
-    self.settings['kWhDelivered'] = self.settings.get('kWhDelivered', 0) + kWh
-
-  def addSlaveTWC(self, slaveTWC):
-    # Adds the Slave TWC to the Round Robin list
-    return self.slaveTWCRoundRobin.append(slaveTWC)
-
-  def checkScheduledCharging(self):
-
-    # Check if we're within the hours we must use scheduledAmpsMax instead
-    # of nonScheduledAmpsMax
-    blnUseScheduledAmps = 0
-    ltNow = time.localtime()
-
-    if(self.getScheduledAmpsMax() > 0 and self.settings.get('scheduledAmpsStartHour', -1) > -1
-      and self.getScheduledAmpsEndHour() > -1 and self.getScheduledAmpsDaysBitmap() > 0):
-        if(self.settings.get('scheduledAmpsStartHour', -1) > self.getScheduledAmpsEndHour()):
-          # We have a time like 8am to 7am which we must interpret as the
-          # 23-hour period after 8am or before 7am. Since this case always
-          # crosses midnight, we only ensure that scheduledAmpsDaysBitmap
-          # is set for the day the period starts on. For example, if
-          # scheduledAmpsDaysBitmap says only schedule on Monday, 8am to
-          # 7am, we apply scheduledAmpsMax from Monday at 8am to Monday at
-          # 11:59pm, and on Tuesday at 12am to Tuesday at 6:59am.
-          hourNow = ltNow.tm_hour + (ltNow.tm_min / 60)
-          if((hourNow >= self.settings.get('scheduledAmpsStartHour', -1) and (self.getScheduledAmpsDaysBitmap() & (1 << ltNow.tm_wday)))
-               or (hourNow < self.getScheduledAmpsEndHour() and (self.getScheduledAmpsDaysBitmap() & (1 << yesterday)))):
-             blnUseScheduledAmps = 1
-        else:
-          # We have a time like 7am to 8am which we must interpret as the
-          # 1-hour period between 7am and 8am.
-          hourNow = ltNow.tm_hour + (ltNow.tm_min / 60)
-          if(hourNow >= self.settings.get('scheduledAmpsStartHour', -1) and hourNow < self.getScheduledAmpsEndHour()
-             and (self.getScheduledAmpsDaysBitmap() & (1 << ltNow.tm_wday))):
-             blnUseScheduledAmps = 1
-    return blnUseScheduledAmps
-
-  def countSlaveTWC(self):
-    return int(len(self.slaveTWCRoundRobin))
-
-  def debugLog(self, minlevel, function, message):
-    if (self.debugLevel >= minlevel):
-      print(colored(self.time_now() + " ", 'yellow') + \
-            colored(f("{function}"), 'green') + \
-            colored(f(" {minlevel} "), 'cyan') + \
-            f("{message}"))
-
-  def deleteBackgroundTask(self, task):
-    del self.backgroundTasksCmds[task['cmd']]
-
-  def doneBackgroundTask(self):
-    # task_done() must be called to let the queue know the task is finished.
-    # backgroundTasksQueue.join() can then be used to block until all tasks
-    # in the queue are done.
-    self.backgroundTasksQueue.task_done()
-
-  def getBackgroundTask(self):
-    return self.backgroundTasksQueue.get()
-
-  def getBackgroundTasksLock(self):
-    self.backgroundTasksLock.acquire()
-
-  def getChargeNowAmps(self):
-    # Returns the currently configured Charge Now Amps setting
-    chargenow = int(self.settings.get('chargeNowAmps', 0))
-    if (chargenow > 0):
-      return chargenow
-    else:
-      return 0
-
-  def getHourResumeTrackGreenEnergy(self):
-    return self.settings.get('hourResumeTrackGreenEnergy', -1)
-
-  def getMasterTWCID(self):
-    # This is called when TWCManager is in Slave mode, to track the
-    # master's TWCID
-    return self.masterTWCID
-
-  def getkWhDelivered(self):
-    return self.settings['kWhDelivered']
-
-  def getMaxAmpsToDivideAmongSlaves(self):
-    if (self.maxAmpsToDivideAmongSlaves > 0):
-      return self.maxAmpsToDivideAmongSlaves
-    else:
-      return 0
-
-  def getModuleByName(self, name):
-    module = self.modules.get(name, None)
-    if (module):
-      return module['ref']
-    else:
-      return None
-
-  def getModulesByType(self, type):
-    matched = []
-    for module in self.modules:
-      modinfo = self.modules[module]
-      if modinfo["type"] == type:
-        matched.append({ "name": module, "ref": modinfo['ref'] })
-    return matched
-
-  def getScheduledAmpsDaysBitmap(self):
-    return self.settings.get('scheduledAmpsDaysBitmap', 0x7F)
-
-  def getNonScheduledAmpsMax(self):
-    nschedamps = int(self.settings.get('nonScheduledAmpsMax', 0))
-    if (nschedamps > 0):
-      return nschedamps
-    else:
-      return 0
-
-  def getScheduledAmpsMax(self):
-    schedamps = int(self.settings.get('scheduledAmpsMax', 0))
-    if (schedamps > 0):
-      return schedamps
-    else:
-      return 0
-
-  def getScheduledAmpsStartHour(self):
-    return self.settings.get('scheduledAmpsStartHour', -1)
-
-  def getScheduledAmpsEndHour(self):
-    return self.settings.get('scheduledAmpsEndHour', -1)
-
-  def getSlaveSign(self):
-    return self.slaveSign
-
-  def getSpikeAmps(self):
-    return self.spikeAmpsToCancel6ALimit
-
-  def getTimeLastTx(self):
-    return self.getModuleByName("RS485").timeLastTx
-
-  def deleteSlaveTWC(self, deleteSlaveID):
-    for i in range(0, len(self.slaveTWCRoundRobin)):
-        if(self.slaveTWCRoundRobin[i].TWCID == deleteSlaveID):
-            del self.slaveTWCRoundRobin[i]
-            break
-    try:
-        del self.slaveTWCs[deleteSlaveID]
-    except KeyError:
-        pass
-
-  def getChargerLoad(self):
-    # Calculate in watts the load that the charger is generating so
-    # that we can exclude it from the consumption if necessary
-    return (self.getTotalAmpsInUse() * 240)
-
-  def getConsumption(self):
-    consumptionVal = 0
-
-    for key in self.consumptionValues:
-      consumptionVal += float(self.consumptionValues[key])
-
-    if (consumptionVal < 0):
-      consumptionVal = 0
-
-    return float(consumptionVal)
-
-  def getFakeTWCID(self):
-    return self.TWCID
-
-  def getGeneration(self):
-    generationVal = 0
-
-    # Currently, our only logic is to add all of the values together
-    for key in self.generationValues:
-      generationVal += float(self.generationValues[key])
-
-    if (generationVal < 0):
-      generationVal = 0
-
-    return float(generationVal)
-
-  def getGenerationOffset(self):
-    # Returns the number of watts to subtract from the solar generation stats
-    # This is consumption + charger load if subtractChargerLoad is enabled
-    # Or simply consumption if subtractChargerLoad is disabled
-    generationOffset = self.getConsumption()
-    if (self.subtractChargerLoad):
-      generationOffset -= self.getChargerLoad()
-    if (generationOffset < 0):
-      generationOffset = 0
-    return float(generationOffset)
-
-  def getHomeLatLon(self):
-    # Returns Lat/Lon coordinates to check if car location is
-    # at home
-    latlon = [10000,10000]
-    latlon[0] = self.settings.get('homeLat',10000)
-    latlon[1] = self.settings.get('homeLon',10000)
-    return latlon
-
-  def getMasterHeartbeatOverride(self):
-    return self.overrideMasterHeartbeatData
-
-  def getMaxAmpsToDivideGreenEnergy(self):
-    # Watts = Volts * Amps
-    # Car charges at 240 volts in North America so we figure
-    # out how many amps * 240 = solarW and limit the car to
-    # that many amps.
-
-    # Calculate our current generation and consumption in watts
-    solarW = float(self.getGeneration() - self.getGenerationOffset())
-
-    # Generation may be below zero if consumption is greater than generation
-    if solarW < 0:
-        solarW = 0
-
-    # Watts = Volts * Amps
-    # Car charges at 240 volts in North America so we figure
-    # out how many amps * 240 = solarW and limit the car to
-    # that many amps.
-    maxAmpsToDivide = (solarW / 240)
-
-    if (maxAmpsToDivide > 0):
-      return maxAmpsToDivide
-    else:
-      return 0
-
-  def getNormalChargeLimit(self, ID):
-    if 'chargeLimits' in self.settings and str(ID) in self.settings['chargeLimits']:
-        result = self.settings['chargeLimits'][str(ID)]
-        if type(result) is int:
-          result = (result, 0)
-        return (True, result[0], result[1])
-    return (False, None, None)
-
-  def getSlaveByID(self, twcid):
-    return self.slaveTWCs[twcid]
-
-  def getSlaveTWCID(self, twc):
-    return self.slaveTWCRoundRobin[twc].TWCID
-
-  def getSlaveTWC(self, id):
-    return self.slaveTWCRoundRobin[id]
-
-  def getSlaveTWCs(self):
-    # Returns a list of all Slave TWCs
-    return self.slaveTWCRoundRobin
-
-  def getTotalAmpsInUse(self):
-    # Returns the number of amps currently in use by all TWCs
-    totalAmps = 0
-    for slaveTWC in self.getSlaveTWCs():
-      totalAmps += slaveTWC.reportedAmpsActual
-      for module in self.getModulesByType('Status'):
-        module['ref'].setStatus(slaveTWC.TWCID, "amps_in_use", "ampsInUse", slaveTWC.reportedAmpsActual)
-
-    for module in self.getModulesByType('Status'):
-      module['ref'].setStatus(bytes("all", 'UTF-8'), "total_amps_in_use", "totalAmpsInUse", totalAmps)
-
-    self.debugLog(10, "TWCMaster ", "Total amps all slaves are using: " + str(totalAmps))
-    return totalAmps
-
-  def hex_str(self, s:str):
-    return " ".join("{:02X}".format(ord(c)) for c in s)
-
-  def hex_str(self, ba:bytearray):
-    return " ".join("{:02X}".format(c) for c in ba)
-
-  def loadSettings(self):
-    # Loads the volatile application settings (such as charger timings,
-    # API credentials, etc) from a JSON file
-
-    # Step 1 - Load settings from JSON file
-    if (not os.path.exists(self.config['config']['settingsPath'] + '/settings.json')):
-      self.settings = {}
-      return
-
-    with open(self.config['config']['settingsPath'] + '/settings.json', 'r') as inconfig:
-      try:
-        self.settings = json.load(inconfig)
-      except Exception as e:
-        self.debugLog(1, "TWCMaster ", "There was an exception whilst loading settings file " + self.config['config']['settingsPath'] + '/settings.json')
-        self.debugLog(1, "TWCMaster ", "Some data may have been loaded. This may be because the file is being created for the first time.")
-        self.debugLog(1, "TWCMaster ", "It may also be because you are upgrading from a TWCManager version prior to v1.1.4, which used the old settings file format.")
-        self.debugLog(1, "TWCMaster ", "If this is the case, you may need to locate the old config file and migrate some settings manually.")
-        self.debugLog(11, "TWCMaster ", str(e))
-
-    # Step 2 - Send settings to other modules
-    carapi = self.getModuleByName("TeslaAPI")
-    carapi.setCarApiBearerToken(self.settings.get('carApiBearerToken', ''))
-    carapi.setCarApiRefreshToken(self.settings.get('carApiRefreshToken', ''))
-    carapi.setCarApiTokenExpireTime(self.settings.get('carApiTokenExpireTime', ''))
-
-  def master_id_conflict():
-    # We're playing fake slave, and we got a message from a master with our TWCID.
-    # By convention, as a slave we must change our TWCID because a master will not.
-    self.TWCID[0] = random.randint(0, 0xFF)
-    self.TWCID[1] = random.randint(0, 0xFF)
-
-    # Real slaves change their sign during a conflict, so we do too.
-    self.slaveSign[0] = random.randint(0, 0xFF)
-
-    print(time_now() + ": Master's TWCID matches our fake slave's TWCID.  " \
-        "Picked new random TWCID %02X%02X with sign %02X" % \
-        (self.TWCID[0], self.TWCID[1], self.slaveSign[0]))
-
-
-  def newSlave(self, newSlaveID, maxAmps):
-    try:
-        slaveTWC = self.slaveTWCs[newSlaveID]
-        # We didn't get KeyError exception, so this slave is already in
-        # slaveTWCs and we can simply return it.
-        return slaveTWC
-    except KeyError:
-        pass
-
-    slaveTWC = TWCSlave(newSlaveID, maxAmps, self.config, self)
-    self.slaveTWCs[newSlaveID] = slaveTWC
-    self.addSlaveTWC(slaveTWC)
-
-    if(self.countSlaveTWC() > 3):
-        print("WARNING: More than 3 slave TWCs seen on network.  " \
-            "Dropping oldest: " + self.hex_str(self.getSlaveTWCID(0)) + ".")
-        self.deleteSlaveTWC(self.getSlaveTWCID(0))
-
-    return slaveTWC
-
-  def num_cars_charging_now(self):
-
-    carsCharging = 0
-    for slaveTWC in self.getSlaveTWCs():
-        charging = 1 if slaveTWC.reportedAmpsActual >= 1.0 else 0
-        carsCharging += charging
-        for module in self.getModulesByType('Status'):
-          module['ref'].setStatus(slaveTWC.TWCID, "cars_charging", "carsCharging", charging)
-    self.debugLog(10, "TWCMaster ", "Number of cars charging now: " + str(carsCharging))
-    return carsCharging
-
-
-    carsCharging = len([slaveTWC for slaveTWC in self.getSlaveTWCs() if slaveTWC.reportedAmpsActual >= 1.0])
-    self.debugLog(10, "TWCMaster ", "Number of cars charging now: " + str(carsCharging))
-    for module in self.getModulesByType('Status'):
-      module['ref'].setStatus(slaveTWC.TWCID, "cars_charging", "carsCharging", carsCharging)
-    return carsCharging
-
-  def policyValue(self, value):
-    # policyValue is a macro to allow charging policy to refer to things
-    # such as EMS module values or settings. This allows us to control
-    # charging via policy.
-    ltNow = time.localtime()
-
-    casefold = str(value).casefold()
-
-    # Boolean values
-    if (casefold == "true"):
-      return True
-    if (casefold == "false"):
-      return False
-
-    # If value is "now", substitute with current timestamp
-    if (casefold == "now"):
-      return time.time()
-
-    # If value is "tm_hour", substitute with current hour
-    if (casefold == "tm_hour"):
-      return ltNow.tm_hour
-
-    # The remaining checks are case-sensitive!
-    #
-    # If value refers to a function, execute the function and capture the
-    # output
-    if (str(value) == "getMaxAmpsToDivideGreenEnergy()"):
-      return self.getMaxAmpsToDivideGreenEnergy()
-    elif (str(value) == "checkScheduledCharging()"):
-      return self.checkScheduledCharging()
-
-    # If value is tiered, split it up
-    if str(value).find(".") != -1:
-      pieces = str(value).split(".")
-
-      # If value refers to a setting, return the setting
-      if pieces[0] == "settings":
-        return self.settings.get(pieces[1], 0)
-      elif pieces[0] == "config":
-        return self.config['config'].get(pieces[1], 0)
-      elif pieces[0] == "modules":
-        module = None
-        if pieces[1] in self.modules:
-          module = self.getModuleByName(pieces[1])
-          return getattr(module,pieces[2],value)
-
-    # None of the macro conditions matched, return the value as is
-    return value
-
-  def queue_background_task(self, task):
-
-    if(task['cmd'] in self.backgroundTasksCmds):
-        # Some tasks, like cmd='charge', will be called once per second until
-        # a charge starts or we determine the car is done charging.  To avoid
-        # wasting memory queing up a bunch of these tasks when we're handling
-        # a charge cmd already, don't queue two of the same task.
-        return
-
-    # Insert task['cmd'] in backgroundTasksCmds to prevent queuing another
-    # task['cmd'] till we've finished handling this one.
-    self.backgroundTasksCmds[task['cmd']] = True
-
-    # Queue the task to be handled by background_tasks_thread.
-    self.backgroundTasksQueue.put(task)
-
-  def registerModule(self, module):
-    # This function is used during module instantiation to either reference a
-    # previously loaded module, or to instantiate a module for the first time
-    if (not module['ref'] and not module['modulename']):
-      debugLog(2, f("registerModule called for module {colored(module['name'], 'red')} without an existing reference or a module to instantiate."))
-    elif (module['ref']):
-      # If the reference is passed, it means this module has already been
-      # instantiated and we should just refer to the existing instance
-
-      # Check this module has not already been instantiated
-      if (not self.modules.get(module['name'], None)):
-        self.modules[module['name']] = {
-          "ref": module['ref'],
-          "type": module['type']
-        }
-        self.debugLog(7, "TWCMaster ", f("Registered module {colored(module['name'], 'red')}"))
-      else:
-        self.debugLog(7, "TWCMaster ", f("Avoided re-registration of module {colored(module['name'], 'red')}, which has already been loaded"))
-
-  def releaseBackgroundTasksLock(self):
-    self.backgroundTasksLock.release()
-
-  def removeNormalChargeLimit(self, ID):
-    if( 'chargeLimits' in self.settings and str(ID) in self.settings['chargeLimits'] ):
-      del self.settings['chargeLimits'][str(ID)]
-      self.saveSettings()
-
-  def resetChargeNowAmps(self):
-    # Sets chargeNowAmps back to zero, so we follow the green energy
-    # tracking again
-    self.settings['chargeNowAmps'] = 0
-    self.settings['chargeNowTimeEnd'] = 0
-
-  def saveNormalChargeLimit(self, ID, outsideLimit, lastApplied):
-    if( not 'chargeLimits' in self.settings ):
-      self.settings['chargeLimits'] = dict()
-
-    self.settings['chargeLimits'][str(ID)] = (outsideLimit, lastApplied)
-    self.saveSettings()
-
-  def saveSettings(self):
-    # Saves the volatile application settings (such as charger timings,
-    # API credentials, etc) to a JSON file
-    fileName = self.config['config']['settingsPath'] + '/settings.json'
-
-    # Step 1 - Merge any config from other modules
-    carapi = self.getModuleByName("TeslaAPI")
-    self.settings['carApiBearerToken'] = carapi.getCarApiBearerToken()
-    self.settings['carApiRefreshToken'] = carapi.getCarApiRefreshToken()
-    self.settings['carApiTokenExpireTime'] = carapi.getCarApiTokenExpireTime()
-
-    # Step 2 - Write the settings dict to a JSON file
-    with open(fileName, 'w') as outconfig:
-      json.dump(self.settings, outconfig)
-
-  def send_master_linkready1(self):
-
-    self.debugLog(8, "TWCMaster ", "Send master linkready1")
-
-    # When master is powered on or reset, it sends 5 to 7 copies of this
-    # linkready1 message followed by 5 copies of linkready2 (I've never seen
-    # more or less than 5 of linkready2).
-    #
-    # This linkready1 message advertises master's TWCID to other slaves on the
-    # network.
-    # If a slave happens to have the same id as master, it will pick a new
-    # random TWCID. Other than that, slaves don't seem to respond to linkready1.
-
-    # linkready1 and linkready2 are identical except FC E1 is replaced by FB E2
-    # in bytes 2-3. Both messages will cause a slave to pick a new id if the
-    # slave's id conflicts with master.
-    # If a slave stops sending heartbeats for awhile, master may send a series
-    # of linkready1 and linkready2 messages in seemingly random order, which
-    # means they don't indicate any sort of startup state.
-
-    # linkready1 is not sent again after boot/reset unless a slave sends its
-    # linkready message.
-    # At that point, linkready1 message may start sending every 1-5 seconds, or
-    # it may not be sent at all.
-    # Behaviors I've seen:
-    #   Not sent at all as long as slave keeps responding to heartbeat messages
-    #   right from the start.
-    #   If slave stops responding, then re-appears, linkready1 gets sent
-    #   frequently.
-
-    # One other possible purpose of linkready1 and/or linkready2 is to trigger
-    # an error condition if two TWCs on the network transmit those messages.
-    # That means two TWCs have rotary switches setting them to master mode and
-    # they will both flash their red LED 4 times with top green light on if that
-    # happens.
-
-    # Also note that linkready1 starts with FC E1 which is similar to the FC D1
-    # message that masters send out every 4 hours when idle. Oddly, the FC D1
-    # message contains all zeros instead of the master's id, so it seems
-    # pointless.
-
-    # I also don't understand the purpose of having both linkready1 and
-    # linkready2 since only two or more linkready2 will provoke a response from
-    # a slave regardless of whether linkready1 was sent previously. Firmware
-    # trace shows that slaves do something somewhat complex when they receive
-    # linkready1 but I haven't been curious enough to try to understand what
-    # they're doing. Tests show neither linkready1 or 2 are necessary. Slaves
-    # send slave linkready every 10 seconds whether or not they got master
-    # linkready1/2 and if a master sees slave linkready, it will start sending
-    # the slave master heartbeat once per second and the two are then connected.
-    self.getModuleByName("RS485").send(bytearray(b'\xFC\xE1') + self.TWCID + self.masterSign + bytearray(b'\x00\x00\x00\x00\x00\x00\x00\x00'))
-
-  def send_master_linkready2(self):
-
-    self.debugLog(8, "TWCMaster ", "Send master linkready2")
-
-    # This linkready2 message is also sent 5 times when master is booted/reset
-    # and then not sent again if no other TWCs are heard from on the network.
-    # If the master has ever seen a slave on the network, linkready2 is sent at
-    # long intervals.
-    # Slaves always ignore the first linkready2, but respond to the second
-    # linkready2 around 0.2s later by sending five slave linkready messages.
-    #
-    # It may be that this linkready2 message that sends FB E2 and the master
-    # heartbeat that sends fb e0 message are really the same, (same FB byte
-    # which I think is message type) except the E0 version includes the TWC ID
-    # of the slave the message is intended for whereas the E2 version has no
-    # recipient TWC ID.
-    #
-    # Once a master starts sending heartbeat messages to a slave, it
-    # no longer sends the global linkready2 message (or if it does,
-    # they're quite rare so I haven't seen them).
-    self.getModuleByName("RS485").send(bytearray(b'\xFB\xE2') + self.TWCID + self.masterSign + bytearray(b'\x00\x00\x00\x00\x00\x00\x00\x00'))
-
-  def send_slave_linkready(self):
-    # In the message below, \x1F\x40 (hex 0x1f40 or 8000 in base 10) refers to
-    # this being a max 80.00Amp charger model.
-    # EU chargers are 32A and send 0x0c80 (3200 in base 10).
-    #
-    # I accidentally changed \x1f\x40 to \x2e\x69 at one point, which makes the
-    # master TWC immediately start blinking its red LED 6 times with top green
-    # LED on. Manual says this means "The networked Wall Connectors have
-    # different maximum current capabilities".
-    msg = bytearray(b'\xFD\xE2') + self.TWCID + self.slaveSign + bytearray(b'\x1F\x40\x00\x00\x00\x00\x00\x00')
-    if(self.protocolVersion == 2):
-        msg += bytearray(b'\x00\x00')
-
-    self.getModuleByName("RS485").send(msg)
-
-  def setChargeNowAmps(self, amps):
-    # Accepts a number of amps to define the amperage at which we
-    # should charge
-    if (amps > self.config['config']['wiringMaxAmpsAllTWCs']):
-      self.debugLog(1, "TWCMaster ", "setChargeNowAmps failed because specified amps are above wiringMaxAmpsAllTWCs")
-    elif (amps < 0):
-      self.debugLog(1, "TWCMaster ", "setChargeNowAmps failed as specified amps is less than 0")
-    else:
-      self.settings['chargeNowAmps'] = amps
-
-  def setChargeNowTimeEnd(self, timeadd):
-    self.settings['chargeNowTimeEnd'] = (time.time() + timeadd)
-
-  def setChargingPerPolicy(self):
-    # This function is called for the purpose of evaluating the charging
-    # policy and matching the first rule which matches our scenario.
-
-    # Once we have determined the maximum number of amps for all slaves to
-    # share based on the policy, we call setMaxAmpsToDivideAmongSlaves to
-    # distribute the designated power amongst slaves.
-
-    # First, determine if it has been less than 30 seconds since the last
-    # policy check. If so, skip for now
-    if ((self.lastPolicyCheck + self.policyCheckInterval) > time.time()):
-      return
-    else:
-      # Update last policy check time
-      self.lastPolicyCheck = time.time()
-
-    for policy in self.charge_policy:
-
-      # Check if the policy is within its latching period
-      latched = False
-      if '__latchTime' in policy:
-        if time.time() < policy['__latchTime']:
-          latched = True
-        else:
-          del policy['__latchTime']
-
-      # Iterate through each set of match, condition and value sets
-      iter = 0
-      for match, condition, value in zip(policy['match'], policy['condition'], policy['value']):
-
-        if not latched:
-          iter += 1
-          self.debugLog(8, "TWCMaster ", f("Evaluating Policy match ({colored(match, 'red')}), condition ({colored(condition, 'red')}), value ({colored(value, 'red')}), iteration ({colored(iter, 'red')})"))
-          # Start by not having matched the condition
-          is_matched = 0
-          match = self.policyValue(match)
-          value = self.policyValue(value)
-
-          # Perform comparison
-          if (condition == "gt"):
-            # Match must be greater than value
-            if (match > value):
-              is_matched = 1
-          elif (condition == "gte"):
-            # Match must be greater than or equal to value
-            if (match >= value):
-              is_matched = 1
-          elif (condition == "lt"):
-            # Match must be less than value
-            if (match < value):
-              is_matched = 1
-          elif (condition == "lte"):
-            # Match must be less than or equal to value
-            if (match <= value):
-              is_matched = 1
-          elif (condition == "eq"):
-            # Match must be equal to value
-            if (match == value):
-              is_matched = 1
-          elif (condition == "ne"):
-            # Match must not be equal to value
-            if (match != value):
-              is_matched = 1
-          elif (condition == "false"):
-            # Condition: false is a method to ensure a policy entry
-            # is never matched, possibly for testing purposes
-            is_matched = 0
-          elif (condition == "none"):
-            # No condition exists.
-            is_matched = 1
-
-        # Check if we have met all criteria
-        if (latched or is_matched):
-
-          # Have we checked all policy conditions yet?
-          if (latched or len(policy['match']) == iter):
-
-            # Yes, we will now enforce policy
-            self.debugLog(7, "TWCMaster ", f("All policy conditions have matched. Policy chosen is {colored(policy['name'], 'red')}"))
-            if self.active_policy != str(policy['name']):
-              self.debugLog(1, "TWCMaster ", f("New policy selected; changing to {colored(policy['name'], 'red')}"))
-              self.active_policy = str(policy['name'])
-
-            if not latched and 'latch_period' in policy:
-              policy['__latchTime'] = time.time() + policy['latch_period'] * 60
-
-            # Determine which value to set the charging to
-            if (policy['charge_amps'] == "value"):
-              self.setMaxAmpsToDivideAmongSlaves(int(policy['value']))
-              self.debugLog(10, "TWCMaster ", 'Charge at %.2f' % int(policy['value']))
+    active_policy = None
+    backgroundTasksQueue = queue.Queue()
+    backgroundTasksCmds = {}
+    backgroundTasksLock = threading.Lock()
+    charge_policy = [
+        # The first policy table entry is for chargeNow. This will fire if
+        # chargeNowAmps is set to a positive integer and chargeNowTimeEnd
+        # is less than or equal to the current timestamp
+        {
+            "name": "Charge Now",
+            "match": [
+                "settings.chargeNowAmps",
+                "settings.chargeNowTimeEnd",
+                "settings.chargeNowTimeEnd",
+            ],
+            "condition": ["gt", "gt", "gt"],
+            "value": [0, 0, "now"],
+            "charge_amps": "settings.chargeNowAmps",
+            "charge_limit": "config.chargeNowLimit",
+        },
+        # Check if we are currently within the Scheduled Amps charging schedule.
+        # If so, charge at the specified number of amps.
+        {
+            "name": "Scheduled Charging",
+            "match": ["checkScheduledCharging()"],
+            "condition": ["eq"],
+            "value": [1],
+            "charge_amps": "settings.scheduledAmpsMax",
+            "charge_limit": "config.scheduledLimit",
+        },
+        # If we are within Track Green Energy schedule, charging will be
+        # performed based on the amount of solar energy being produced.
+        # Don't bother to check solar generation before 6am or after
+        # 8pm. Sunrise in most U.S. areas varies from a little before
+        # 6am in Jun to almost 7:30am in Nov before the clocks get set
+        # back an hour. Sunset can be ~4:30pm to just after 8pm.
+        {
+            "name": "Track Green Energy",
+            "match": ["tm_hour", "tm_hour", "settings.hourResumeTrackGreenEnergy"],
+            "condition": ["gte", "lt", "lte"],
+            "value": [6, 20, "tm_hour"],
+            "charge_amps": "getMaxAmpsToDivideGreenEnergy()",
+            "background_task": "checkGreenEnergy",
+            "charge_limit": "config.greenEnergyLimit",
+        },
+        # If all else fails (ie no other policy match), we will charge at
+        # nonScheduledAmpsMax
+        {
+            "name": "Non Scheduled Charging",
+            "match": ["none"],
+            "condition": ["none"],
+            "value": [0],
+            "charge_amps": "settings.nonScheduledAmpsMax",
+            "charge_limit": "config.nonScheduledLimit",
+        },
+    ]
+
+    config = None
+    consumptionValues = {}
+    debugLevel = 0
+    generationValues = {}
+    lastPolicyCheck = 0
+    lastTWCResponseMsg = None
+    masterTWCID = ""
+    maxAmpsToDivideAmongSlaves = 0
+    modules = {}
+    overrideMasterHeartbeatData = b""
+    policyCheckInterval = 30
+    protocolVersion = 2
+    settings = {
+        "chargeNowAmps": 0,
+        "chargeStopMode": "1",
+        "chargeNowTimeEnd": 0,
+        "homeLat": 10000,
+        "homeLon": 10000,
+        "hourResumeTrackGreenEnergy": -1,
+        "kWhDelivered": 119,
+        "nonScheduledAmpsMax": 0,
+        "respondToSlaves": 1,
+        "scheduledAmpsDaysBitmap": 0x7F,
+        "scheduledAmpsEndHour": -1,
+        "scheduledAmpsMax": 0,
+        "scheduledAmpsStartHour": -1,
+    }
+    slaveHeartbeatData = bytearray(
+        [0x01, 0x0F, 0xA0, 0x0F, 0xA0, 0x00, 0x00, 0x00, 0x00]
+    )
+    slaveTWCs = {}
+    slaveTWCRoundRobin = []
+    spikeAmpsToCancel6ALimit = 16
+    subtractChargerLoad = False
+    teslaLoginAskLater = False
+    TWCID = None
+
+    # TWCs send a seemingly-random byte after their 2-byte TWC id in a number of
+    # messages. I call this byte their "Sign" for lack of a better term. The byte
+    # never changes unless the TWC is reset or power cycled. We use hard-coded
+    # values for now because I don't know if there are any rules to what values can
+    # be chosen. I picked 77 because it's easy to recognize when looking at logs.
+    # These shouldn't need to be changed.
+    masterSign = bytearray(b"\x77")
+    slaveSign = bytearray(b"\x77")
+
+    def __init__(self, TWCID, config):
+        self.config = config
+        self.debugLevel = config["config"]["debugLevel"]
+        self.TWCID = TWCID
+        self.subtractChargerLoad = config["config"]["subtractChargerLoad"]
+
+        # Override Charge Policy if specified
+        config_policy = config.get("policy")
+        if config_policy:
+            if len(config_policy.get("override", [])) > 0:
+                # Policy override specified, just override in place without processing the
+                # extensions
+                self.charge_policy = config_policy.get("override")
             else:
-              self.setMaxAmpsToDivideAmongSlaves(self.policyValue(policy['charge_amps']))
-              self.debugLog(10, "TWCMaster ", 'Charge at %.2f' % self.policyValue(policy['charge_amps']))
+                # Insert optional policy extensions into policy list
+                # After - Inserted before Non-Scheduled Charging
+                config_extend = config_policy.get("extend", {})
+                if len(config_extend.get("after", [])) > 0:
+                    self.charge_policy[3:3] = config_extend.get("after")
 
-            # If a background task is defined for this policy, queue it
-            bgt = policy.get('background_task', None)
-            if (bgt):
-              self.queue_background_task({'cmd':bgt})
+                # Before - Inserted after Charge Now
+                if len(config_extend.get("before", [])) > 0:
+                    self.charge_policy[1:1] = config_extend.get("before")
 
-            # If a charge limit is defined for this policy, apply it
-            limit = self.policyValue(policy.get('charge_limit', -1))
-            if not (limit >= 50 and limit <= 100):
-              limit = -1
-            self.queue_background_task({'cmd':'applyChargeLimit', 'limit':limit})
+                # Emergency - Inserted at the beginning
+                if len(config_extend.get("emergency", [])) > 0:
+                    self.charge_policy[0:0] = config_extend.get("emergency")
 
-            # Now, finish processing
+        # Set the Policy Check Interval if specified
+        if config_policy:
+            policy_engine = config_policy.get("engine")
+            if policy_engine:
+                if policy_engine.get("policyCheckInterval"):
+                    self.policyCheckInterval = policy_engine.get("policyCheckInterval")
+
+        # Register ourself as a module, allows lookups via the Module architecture
+        self.registerModule({"name": "master", "ref": self, "type": "Master"})
+
+    def addkWhDelivered(self, kWh):
+        self.settings["kWhDelivered"] = self.settings.get("kWhDelivered", 0) + kWh
+
+    def addSlaveTWC(self, slaveTWC):
+        # Adds the Slave TWC to the Round Robin list
+        return self.slaveTWCRoundRobin.append(slaveTWC)
+
+    def checkScheduledCharging(self):
+
+        # Check if we're within the hours we must use scheduledAmpsMax instead
+        # of nonScheduledAmpsMax
+        blnUseScheduledAmps = 0
+        ltNow = time.localtime()
+
+        if (
+            self.getScheduledAmpsMax() > 0
+            and self.settings.get("scheduledAmpsStartHour", -1) > -1
+            and self.getScheduledAmpsEndHour() > -1
+            and self.getScheduledAmpsDaysBitmap() > 0
+        ):
+            if (
+                self.settings.get("scheduledAmpsStartHour", -1)
+                > self.getScheduledAmpsEndHour()
+            ):
+                # We have a time like 8am to 7am which we must interpret as the
+                # 23-hour period after 8am or before 7am. Since this case always
+                # crosses midnight, we only ensure that scheduledAmpsDaysBitmap
+                # is set for the day the period starts on. For example, if
+                # scheduledAmpsDaysBitmap says only schedule on Monday, 8am to
+                # 7am, we apply scheduledAmpsMax from Monday at 8am to Monday at
+                # 11:59pm, and on Tuesday at 12am to Tuesday at 6:59am.
+                hourNow = ltNow.tm_hour + (ltNow.tm_min / 60)
+                if (
+                    hourNow >= self.settings.get("scheduledAmpsStartHour", -1)
+                    and (self.getScheduledAmpsDaysBitmap() & (1 << ltNow.tm_wday))
+                ) or (
+                    hourNow < self.getScheduledAmpsEndHour()
+                    and (self.getScheduledAmpsDaysBitmap() & (1 << yesterday))
+                ):
+                    blnUseScheduledAmps = 1
+            else:
+                # We have a time like 7am to 8am which we must interpret as the
+                # 1-hour period between 7am and 8am.
+                hourNow = ltNow.tm_hour + (ltNow.tm_min / 60)
+                if (
+                    hourNow >= self.settings.get("scheduledAmpsStartHour", -1)
+                    and hourNow < self.getScheduledAmpsEndHour()
+                    and (self.getScheduledAmpsDaysBitmap() & (1 << ltNow.tm_wday))
+                ):
+                    blnUseScheduledAmps = 1
+        return blnUseScheduledAmps
+
+    def countSlaveTWC(self):
+        return int(len(self.slaveTWCRoundRobin))
+
+    def debugLog(self, minlevel, function, message):
+        if self.debugLevel >= minlevel:
+            print(
+                colored(self.time_now() + " ", "yellow")
+                + colored(f("{function}"), "green")
+                + colored(f(" {minlevel} "), "cyan")
+                + f("{message}")
+            )
+
+    def deleteBackgroundTask(self, task):
+        del self.backgroundTasksCmds[task["cmd"]]
+
+    def doneBackgroundTask(self):
+        # task_done() must be called to let the queue know the task is finished.
+        # backgroundTasksQueue.join() can then be used to block until all tasks
+        # in the queue are done.
+        self.backgroundTasksQueue.task_done()
+
+    def getBackgroundTask(self):
+        return self.backgroundTasksQueue.get()
+
+    def getBackgroundTasksLock(self):
+        self.backgroundTasksLock.acquire()
+
+    def getChargeNowAmps(self):
+        # Returns the currently configured Charge Now Amps setting
+        chargenow = int(self.settings.get("chargeNowAmps", 0))
+        if chargenow > 0:
+            return chargenow
+        else:
+            return 0
+
+    def getHourResumeTrackGreenEnergy(self):
+        return self.settings.get("hourResumeTrackGreenEnergy", -1)
+
+    def getMasterTWCID(self):
+        # This is called when TWCManager is in Slave mode, to track the
+        # master's TWCID
+        return self.masterTWCID
+
+    def getkWhDelivered(self):
+        return self.settings["kWhDelivered"]
+
+    def getMaxAmpsToDivideAmongSlaves(self):
+        if self.maxAmpsToDivideAmongSlaves > 0:
+            return self.maxAmpsToDivideAmongSlaves
+        else:
+            return 0
+
+    def getModuleByName(self, name):
+        module = self.modules.get(name, None)
+        if module:
+            return module["ref"]
+        else:
+            return None
+
+    def getModulesByType(self, type):
+        matched = []
+        for module in self.modules:
+            modinfo = self.modules[module]
+            if modinfo["type"] == type:
+                matched.append({"name": module, "ref": modinfo["ref"]})
+        return matched
+
+    def getScheduledAmpsDaysBitmap(self):
+        return self.settings.get("scheduledAmpsDaysBitmap", 0x7F)
+
+    def getNonScheduledAmpsMax(self):
+        nschedamps = int(self.settings.get("nonScheduledAmpsMax", 0))
+        if nschedamps > 0:
+            return nschedamps
+        else:
+            return 0
+
+    def getScheduledAmpsMax(self):
+        schedamps = int(self.settings.get("scheduledAmpsMax", 0))
+        if schedamps > 0:
+            return schedamps
+        else:
+            return 0
+
+    def getScheduledAmpsStartHour(self):
+        return self.settings.get("scheduledAmpsStartHour", -1)
+
+    def getScheduledAmpsEndHour(self):
+        return self.settings.get("scheduledAmpsEndHour", -1)
+
+    def getSlaveSign(self):
+        return self.slaveSign
+
+    def getSpikeAmps(self):
+        return self.spikeAmpsToCancel6ALimit
+
+    def getTimeLastTx(self):
+        return self.getModuleByName("RS485").timeLastTx
+
+    def deleteSlaveTWC(self, deleteSlaveID):
+        for i in range(0, len(self.slaveTWCRoundRobin)):
+            if self.slaveTWCRoundRobin[i].TWCID == deleteSlaveID:
+                del self.slaveTWCRoundRobin[i]
+                break
+        try:
+            del self.slaveTWCs[deleteSlaveID]
+        except KeyError:
+            pass
+
+    def getChargerLoad(self):
+        # Calculate in watts the load that the charger is generating so
+        # that we can exclude it from the consumption if necessary
+        return self.getTotalAmpsInUse() * 240
+
+    def getConsumption(self):
+        consumptionVal = 0
+
+        for key in self.consumptionValues:
+            consumptionVal += float(self.consumptionValues[key])
+
+        if consumptionVal < 0:
+            consumptionVal = 0
+
+        return float(consumptionVal)
+
+    def getFakeTWCID(self):
+        return self.TWCID
+
+    def getGeneration(self):
+        generationVal = 0
+
+        # Currently, our only logic is to add all of the values together
+        for key in self.generationValues:
+            generationVal += float(self.generationValues[key])
+
+        if generationVal < 0:
+            generationVal = 0
+
+        return float(generationVal)
+
+    def getGenerationOffset(self):
+        # Returns the number of watts to subtract from the solar generation stats
+        # This is consumption + charger load if subtractChargerLoad is enabled
+        # Or simply consumption if subtractChargerLoad is disabled
+        generationOffset = self.getConsumption()
+        if self.subtractChargerLoad:
+            generationOffset -= self.getChargerLoad()
+        if generationOffset < 0:
+            generationOffset = 0
+        return float(generationOffset)
+
+    def getHomeLatLon(self):
+        # Returns Lat/Lon coordinates to check if car location is
+        # at home
+        latlon = [10000, 10000]
+        latlon[0] = self.settings.get("homeLat", 10000)
+        latlon[1] = self.settings.get("homeLon", 10000)
+        return latlon
+
+    def getMasterHeartbeatOverride(self):
+        return self.overrideMasterHeartbeatData
+
+    def getMaxAmpsToDivideGreenEnergy(self):
+        # Watts = Volts * Amps
+        # Car charges at 240 volts in North America so we figure
+        # out how many amps * 240 = solarW and limit the car to
+        # that many amps.
+
+        # Calculate our current generation and consumption in watts
+        solarW = float(self.getGeneration() - self.getGenerationOffset())
+
+        # Generation may be below zero if consumption is greater than generation
+        if solarW < 0:
+            solarW = 0
+
+        # Watts = Volts * Amps
+        # Car charges at 240 volts in North America so we figure
+        # out how many amps * 240 = solarW and limit the car to
+        # that many amps.
+        maxAmpsToDivide = solarW / 240
+
+        if maxAmpsToDivide > 0:
+            return maxAmpsToDivide
+        else:
+            return 0
+
+    def getNormalChargeLimit(self, ID):
+        if "chargeLimits" in self.settings and str(ID) in self.settings["chargeLimits"]:
+            result = self.settings["chargeLimits"][str(ID)]
+            if type(result) is int:
+                result = (result, 0)
+            return (True, result[0], result[1])
+        return (False, None, None)
+
+    def getSlaveByID(self, twcid):
+        return self.slaveTWCs[twcid]
+
+    def getSlaveTWCID(self, twc):
+        return self.slaveTWCRoundRobin[twc].TWCID
+
+    def getSlaveTWC(self, id):
+        return self.slaveTWCRoundRobin[id]
+
+    def getSlaveTWCs(self):
+        # Returns a list of all Slave TWCs
+        return self.slaveTWCRoundRobin
+
+    def getTotalAmpsInUse(self):
+        # Returns the number of amps currently in use by all TWCs
+        totalAmps = 0
+        for slaveTWC in self.getSlaveTWCs():
+            totalAmps += slaveTWC.reportedAmpsActual
+            for module in self.getModulesByType("Status"):
+                module["ref"].setStatus(
+                    slaveTWC.TWCID,
+                    "amps_in_use",
+                    "ampsInUse",
+                    slaveTWC.reportedAmpsActual,
+                )
+
+        for module in self.getModulesByType("Status"):
+            module["ref"].setStatus(
+                bytes("all", "UTF-8"), "total_amps_in_use", "totalAmpsInUse", totalAmps
+            )
+
+        self.debugLog(
+            10, "TWCMaster ", "Total amps all slaves are using: " + str(totalAmps)
+        )
+        return totalAmps
+
+    def hex_str(self, s: str):
+        return " ".join("{:02X}".format(ord(c)) for c in s)
+
+    def hex_str(self, ba: bytearray):
+        return " ".join("{:02X}".format(c) for c in ba)
+
+    def loadSettings(self):
+        # Loads the volatile application settings (such as charger timings,
+        # API credentials, etc) from a JSON file
+
+        # Step 1 - Load settings from JSON file
+        if not os.path.exists(self.config["config"]["settingsPath"] + "/settings.json"):
+            self.settings = {}
             return
 
-          else:
-            self.debugLog(8, "TWCMaster ", "This policy condition has matched, but there are more to process.")
+        with open(
+            self.config["config"]["settingsPath"] + "/settings.json", "r"
+        ) as inconfig:
+            try:
+                self.settings = json.load(inconfig)
+            except Exception as e:
+                self.debugLog(
+                    1,
+                    "TWCMaster ",
+                    "There was an exception whilst loading settings file "
+                    + self.config["config"]["settingsPath"]
+                    + "/settings.json",
+                )
+                self.debugLog(
+                    1,
+                    "TWCMaster ",
+                    "Some data may have been loaded. This may be because the file is being created for the first time.",
+                )
+                self.debugLog(
+                    1,
+                    "TWCMaster ",
+                    "It may also be because you are upgrading from a TWCManager version prior to v1.1.4, which used the old settings file format.",
+                )
+                self.debugLog(
+                    1,
+                    "TWCMaster ",
+                    "If this is the case, you may need to locate the old config file and migrate some settings manually.",
+                )
+                self.debugLog(11, "TWCMaster ", str(e))
 
+        # Step 2 - Send settings to other modules
+        carapi = self.getModuleByName("TeslaAPI")
+        carapi.setCarApiBearerToken(self.settings.get("carApiBearerToken", ""))
+        carapi.setCarApiRefreshToken(self.settings.get("carApiRefreshToken", ""))
+        carapi.setCarApiTokenExpireTime(self.settings.get("carApiTokenExpireTime", ""))
+
+    def master_id_conflict():
+        # We're playing fake slave, and we got a message from a master with our TWCID.
+        # By convention, as a slave we must change our TWCID because a master will not.
+        self.TWCID[0] = random.randint(0, 0xFF)
+        self.TWCID[1] = random.randint(0, 0xFF)
+
+        # Real slaves change their sign during a conflict, so we do too.
+        self.slaveSign[0] = random.randint(0, 0xFF)
+
+        print(
+            time_now() + ": Master's TWCID matches our fake slave's TWCID.  "
+            "Picked new random TWCID %02X%02X with sign %02X"
+            % (self.TWCID[0], self.TWCID[1], self.slaveSign[0])
+        )
+
+    def newSlave(self, newSlaveID, maxAmps):
+        try:
+            slaveTWC = self.slaveTWCs[newSlaveID]
+            # We didn't get KeyError exception, so this slave is already in
+            # slaveTWCs and we can simply return it.
+            return slaveTWC
+        except KeyError:
+            pass
+
+        slaveTWC = TWCSlave(newSlaveID, maxAmps, self.config, self)
+        self.slaveTWCs[newSlaveID] = slaveTWC
+        self.addSlaveTWC(slaveTWC)
+
+        if self.countSlaveTWC() > 3:
+            print(
+                "WARNING: More than 3 slave TWCs seen on network.  "
+                "Dropping oldest: " + self.hex_str(self.getSlaveTWCID(0)) + "."
+            )
+            self.deleteSlaveTWC(self.getSlaveTWCID(0))
+
+        return slaveTWC
+
+    def num_cars_charging_now(self):
+
+        carsCharging = 0
+        for slaveTWC in self.getSlaveTWCs():
+            charging = 1 if slaveTWC.reportedAmpsActual >= 1.0 else 0
+            carsCharging += charging
+            for module in self.getModulesByType("Status"):
+                module["ref"].setStatus(
+                    slaveTWC.TWCID, "cars_charging", "carsCharging", charging
+                )
+        self.debugLog(
+            10, "TWCMaster ", "Number of cars charging now: " + str(carsCharging)
+        )
+        return carsCharging
+
+        carsCharging = len(
+            [
+                slaveTWC
+                for slaveTWC in self.getSlaveTWCs()
+                if slaveTWC.reportedAmpsActual >= 1.0
+            ]
+        )
+        self.debugLog(
+            10, "TWCMaster ", "Number of cars charging now: " + str(carsCharging)
+        )
+        for module in self.getModulesByType("Status"):
+            module["ref"].setStatus(
+                slaveTWC.TWCID, "cars_charging", "carsCharging", carsCharging
+            )
+        return carsCharging
+
+    def policyValue(self, value):
+        # policyValue is a macro to allow charging policy to refer to things
+        # such as EMS module values or settings. This allows us to control
+        # charging via policy.
+        ltNow = time.localtime()
+
+        casefold = str(value).casefold()
+
+        # Boolean values
+        if casefold == "true":
+            return True
+        if casefold == "false":
+            return False
+
+        # If value is "now", substitute with current timestamp
+        if casefold == "now":
+            return time.time()
+
+        # If value is "tm_hour", substitute with current hour
+        if casefold == "tm_hour":
+            return ltNow.tm_hour
+
+        # The remaining checks are case-sensitive!
+        #
+        # If value refers to a function, execute the function and capture the
+        # output
+        if str(value) == "getMaxAmpsToDivideGreenEnergy()":
+            return self.getMaxAmpsToDivideGreenEnergy()
+        elif str(value) == "checkScheduledCharging()":
+            return self.checkScheduledCharging()
+
+        # If value is tiered, split it up
+        if str(value).find(".") != -1:
+            pieces = str(value).split(".")
+
+            # If value refers to a setting, return the setting
+            if pieces[0] == "settings":
+                return self.settings.get(pieces[1], 0)
+            elif pieces[0] == "config":
+                return self.config["config"].get(pieces[1], 0)
+            elif pieces[0] == "modules":
+                module = None
+                if pieces[1] in self.modules:
+                    module = self.getModuleByName(pieces[1])
+                    return getattr(module, pieces[2], value)
+
+        # None of the macro conditions matched, return the value as is
+        return value
+
+    def queue_background_task(self, task):
+
+        if task["cmd"] in self.backgroundTasksCmds:
+            # Some tasks, like cmd='charge', will be called once per second until
+            # a charge starts or we determine the car is done charging.  To avoid
+            # wasting memory queing up a bunch of these tasks when we're handling
+            # a charge cmd already, don't queue two of the same task.
+            return
+
+        # Insert task['cmd'] in backgroundTasksCmds to prevent queuing another
+        # task['cmd'] till we've finished handling this one.
+        self.backgroundTasksCmds[task["cmd"]] = True
+
+        # Queue the task to be handled by background_tasks_thread.
+        self.backgroundTasksQueue.put(task)
+
+    def registerModule(self, module):
+        # This function is used during module instantiation to either reference a
+        # previously loaded module, or to instantiate a module for the first time
+        if not module["ref"] and not module["modulename"]:
+            debugLog(
+                2,
+                f(
+                    "registerModule called for module {colored(module['name'], 'red')} without an existing reference or a module to instantiate."
+                ),
+            )
+        elif module["ref"]:
+            # If the reference is passed, it means this module has already been
+            # instantiated and we should just refer to the existing instance
+
+            # Check this module has not already been instantiated
+            if not self.modules.get(module["name"], None):
+                self.modules[module["name"]] = {
+                    "ref": module["ref"],
+                    "type": module["type"],
+                }
+                self.debugLog(
+                    7,
+                    "TWCMaster ",
+                    f("Registered module {colored(module['name'], 'red')}"),
+                )
+            else:
+                self.debugLog(
+                    7,
+                    "TWCMaster ",
+                    f(
+                        "Avoided re-registration of module {colored(module['name'], 'red')}, which has already been loaded"
+                    ),
+                )
+
+    def releaseBackgroundTasksLock(self):
+        self.backgroundTasksLock.release()
+
+    def removeNormalChargeLimit(self, ID):
+        if "chargeLimits" in self.settings and str(ID) in self.settings["chargeLimits"]:
+            del self.settings["chargeLimits"][str(ID)]
+            self.saveSettings()
+
+    def resetChargeNowAmps(self):
+        # Sets chargeNowAmps back to zero, so we follow the green energy
+        # tracking again
+        self.settings["chargeNowAmps"] = 0
+        self.settings["chargeNowTimeEnd"] = 0
+
+    def saveNormalChargeLimit(self, ID, outsideLimit, lastApplied):
+        if not "chargeLimits" in self.settings:
+            self.settings["chargeLimits"] = dict()
+
+        self.settings["chargeLimits"][str(ID)] = (outsideLimit, lastApplied)
+        self.saveSettings()
+
+    def saveSettings(self):
+        # Saves the volatile application settings (such as charger timings,
+        # API credentials, etc) to a JSON file
+        fileName = self.config["config"]["settingsPath"] + "/settings.json"
+
+        # Step 1 - Merge any config from other modules
+        carapi = self.getModuleByName("TeslaAPI")
+        self.settings["carApiBearerToken"] = carapi.getCarApiBearerToken()
+        self.settings["carApiRefreshToken"] = carapi.getCarApiRefreshToken()
+        self.settings["carApiTokenExpireTime"] = carapi.getCarApiTokenExpireTime()
+
+        # Step 2 - Write the settings dict to a JSON file
+        with open(fileName, "w") as outconfig:
+            json.dump(self.settings, outconfig)
+
+    def send_master_linkready1(self):
+
+        self.debugLog(8, "TWCMaster ", "Send master linkready1")
+
+        # When master is powered on or reset, it sends 5 to 7 copies of this
+        # linkready1 message followed by 5 copies of linkready2 (I've never seen
+        # more or less than 5 of linkready2).
+        #
+        # This linkready1 message advertises master's TWCID to other slaves on the
+        # network.
+        # If a slave happens to have the same id as master, it will pick a new
+        # random TWCID. Other than that, slaves don't seem to respond to linkready1.
+
+        # linkready1 and linkready2 are identical except FC E1 is replaced by FB E2
+        # in bytes 2-3. Both messages will cause a slave to pick a new id if the
+        # slave's id conflicts with master.
+        # If a slave stops sending heartbeats for awhile, master may send a series
+        # of linkready1 and linkready2 messages in seemingly random order, which
+        # means they don't indicate any sort of startup state.
+
+        # linkready1 is not sent again after boot/reset unless a slave sends its
+        # linkready message.
+        # At that point, linkready1 message may start sending every 1-5 seconds, or
+        # it may not be sent at all.
+        # Behaviors I've seen:
+        #   Not sent at all as long as slave keeps responding to heartbeat messages
+        #   right from the start.
+        #   If slave stops responding, then re-appears, linkready1 gets sent
+        #   frequently.
+
+        # One other possible purpose of linkready1 and/or linkready2 is to trigger
+        # an error condition if two TWCs on the network transmit those messages.
+        # That means two TWCs have rotary switches setting them to master mode and
+        # they will both flash their red LED 4 times with top green light on if that
+        # happens.
+
+        # Also note that linkready1 starts with FC E1 which is similar to the FC D1
+        # message that masters send out every 4 hours when idle. Oddly, the FC D1
+        # message contains all zeros instead of the master's id, so it seems
+        # pointless.
+
+        # I also don't understand the purpose of having both linkready1 and
+        # linkready2 since only two or more linkready2 will provoke a response from
+        # a slave regardless of whether linkready1 was sent previously. Firmware
+        # trace shows that slaves do something somewhat complex when they receive
+        # linkready1 but I haven't been curious enough to try to understand what
+        # they're doing. Tests show neither linkready1 or 2 are necessary. Slaves
+        # send slave linkready every 10 seconds whether or not they got master
+        # linkready1/2 and if a master sees slave linkready, it will start sending
+        # the slave master heartbeat once per second and the two are then connected.
+        self.getModuleByName("RS485").send(
+            bytearray(b"\xFC\xE1")
+            + self.TWCID
+            + self.masterSign
+            + bytearray(b"\x00\x00\x00\x00\x00\x00\x00\x00")
+        )
+
+    def send_master_linkready2(self):
+
+        self.debugLog(8, "TWCMaster ", "Send master linkready2")
+
+        # This linkready2 message is also sent 5 times when master is booted/reset
+        # and then not sent again if no other TWCs are heard from on the network.
+        # If the master has ever seen a slave on the network, linkready2 is sent at
+        # long intervals.
+        # Slaves always ignore the first linkready2, but respond to the second
+        # linkready2 around 0.2s later by sending five slave linkready messages.
+        #
+        # It may be that this linkready2 message that sends FB E2 and the master
+        # heartbeat that sends fb e0 message are really the same, (same FB byte
+        # which I think is message type) except the E0 version includes the TWC ID
+        # of the slave the message is intended for whereas the E2 version has no
+        # recipient TWC ID.
+        #
+        # Once a master starts sending heartbeat messages to a slave, it
+        # no longer sends the global linkready2 message (or if it does,
+        # they're quite rare so I haven't seen them).
+        self.getModuleByName("RS485").send(
+            bytearray(b"\xFB\xE2")
+            + self.TWCID
+            + self.masterSign
+            + bytearray(b"\x00\x00\x00\x00\x00\x00\x00\x00")
+        )
+
+    def send_slave_linkready(self):
+        # In the message below, \x1F\x40 (hex 0x1f40 or 8000 in base 10) refers to
+        # this being a max 80.00Amp charger model.
+        # EU chargers are 32A and send 0x0c80 (3200 in base 10).
+        #
+        # I accidentally changed \x1f\x40 to \x2e\x69 at one point, which makes the
+        # master TWC immediately start blinking its red LED 6 times with top green
+        # LED on. Manual says this means "The networked Wall Connectors have
+        # different maximum current capabilities".
+        msg = (
+            bytearray(b"\xFD\xE2")
+            + self.TWCID
+            + self.slaveSign
+            + bytearray(b"\x1F\x40\x00\x00\x00\x00\x00\x00")
+        )
+        if self.protocolVersion == 2:
+            msg += bytearray(b"\x00\x00")
+
+        self.getModuleByName("RS485").send(msg)
+
+    def setChargeNowAmps(self, amps):
+        # Accepts a number of amps to define the amperage at which we
+        # should charge
+        if amps > self.config["config"]["wiringMaxAmpsAllTWCs"]:
+            self.debugLog(
+                1,
+                "TWCMaster ",
+                "setChargeNowAmps failed because specified amps are above wiringMaxAmpsAllTWCs",
+            )
+        elif amps < 0:
+            self.debugLog(
+                1,
+                "TWCMaster ",
+                "setChargeNowAmps failed as specified amps is less than 0",
+            )
         else:
-          self.debugLog(8, "TWCMaster ", "Policy conditions were not matched.")
-          break
+            self.settings["chargeNowAmps"] = amps
 
-  def setConsumption(self, source, value):
-    # Accepts consumption values from one or more data sources
-    # For now, this gives a sum value of all, but in future we could
-    # average across sources perhaps, or do a primary/secondary priority
-    self.consumptionValues[source] = value
+    def setChargeNowTimeEnd(self, timeadd):
+        self.settings["chargeNowTimeEnd"] = time.time() + timeadd
 
-  def setGeneration(self, source, value):
-    self.generationValues[source] = value
+    def setChargingPerPolicy(self):
+        # This function is called for the purpose of evaluating the charging
+        # policy and matching the first rule which matches our scenario.
 
-  def setHomeLat(self, lat):
-    self.settings['homeLat'] = lat
+        # Once we have determined the maximum number of amps for all slaves to
+        # share based on the policy, we call setMaxAmpsToDivideAmongSlaves to
+        # distribute the designated power amongst slaves.
 
-  def setHomeLon(self, lon):
-    self.settings['homeLon'] = lon
+        # First, determine if it has been less than 30 seconds since the last
+        # policy check. If so, skip for now
+        if (self.lastPolicyCheck + self.policyCheckInterval) > time.time():
+            return
+        else:
+            # Update last policy check time
+            self.lastPolicyCheck = time.time()
 
-  def setHourResumeTrackGreenEnergy(self, hour):
-    self.settings['hourResumeTrackGreenEnergy'] = hour
+        for policy in self.charge_policy:
 
-  def setkWhDelivered(self, kWh):
-    self.settings['kWhDelivered'] = kWh
-    return True
+            # Check if the policy is within its latching period
+            latched = False
+            if "__latchTime" in policy:
+                if time.time() < policy["__latchTime"]:
+                    latched = True
+                else:
+                    del policy["__latchTime"]
 
-  def setMasterTWCID(self, twcid):
-    # This is called when TWCManager is in Slave mode, to track the
-    # master's TWCID
-    self.masterTWCID = twcid
+            # Iterate through each set of match, condition and value sets
+            iter = 0
+            for match, condition, value in zip(
+                policy["match"], policy["condition"], policy["value"]
+            ):
 
-  def setMaxAmpsToDivideAmongSlaves(self, amps):
+                if not latched:
+                    iter += 1
+                    self.debugLog(
+                        8,
+                        "TWCMaster ",
+                        f(
+                            "Evaluating Policy match ({colored(match, 'red')}), condition ({colored(condition, 'red')}), value ({colored(value, 'red')}), iteration ({colored(iter, 'red')})"
+                        ),
+                    )
+                    # Start by not having matched the condition
+                    is_matched = 0
+                    match = self.policyValue(match)
+                    value = self.policyValue(value)
 
-    # Use backgroundTasksLock to prevent changing maxAmpsToDivideAmongSlaves
-    # if the main thread is in the middle of examining and later using
-    # that value.
-    self.getBackgroundTasksLock()
+                    # Perform comparison
+                    if condition == "gt":
+                        # Match must be greater than value
+                        if match > value:
+                            is_matched = 1
+                    elif condition == "gte":
+                        # Match must be greater than or equal to value
+                        if match >= value:
+                            is_matched = 1
+                    elif condition == "lt":
+                        # Match must be less than value
+                        if match < value:
+                            is_matched = 1
+                    elif condition == "lte":
+                        # Match must be less than or equal to value
+                        if match <= value:
+                            is_matched = 1
+                    elif condition == "eq":
+                        # Match must be equal to value
+                        if match == value:
+                            is_matched = 1
+                    elif condition == "ne":
+                        # Match must not be equal to value
+                        if match != value:
+                            is_matched = 1
+                    elif condition == "false":
+                        # Condition: false is a method to ensure a policy entry
+                        # is never matched, possibly for testing purposes
+                        is_matched = 0
+                    elif condition == "none":
+                        # No condition exists.
+                        is_matched = 1
 
-    if(amps > self.config['config']['wiringMaxAmpsAllTWCs']):
-      # Never tell the slaves to draw more amps than the physical charger
-      # wiring can handle.
-      self.debugLog(1, "TWCMaster ", "ERROR: specified maxAmpsToDivideAmongSlaves " + str(amps) +
-       " > wiringMaxAmpsAllTWCs " + str(self.config['config']['wiringMaxAmpsAllTWCs']) +
-       ".\nSee notes above wiringMaxAmpsAllTWCs in the 'Configuration parameters' section.")
-      amps = self.config['config']['wiringMaxAmpsAllTWCs']
+                # Check if we have met all criteria
+                if latched or is_matched:
 
-    self.maxAmpsToDivideAmongSlaves = amps
+                    # Have we checked all policy conditions yet?
+                    if latched or len(policy["match"]) == iter:
 
-    self.releaseBackgroundTasksLock()
+                        # Yes, we will now enforce policy
+                        self.debugLog(
+                            7,
+                            "TWCMaster ",
+                            f(
+                                "All policy conditions have matched. Policy chosen is {colored(policy['name'], 'red')}"
+                            ),
+                        )
+                        if self.active_policy != str(policy["name"]):
+                            self.debugLog(
+                                1,
+                                "TWCMaster ",
+                                f(
+                                    "New policy selected; changing to {colored(policy['name'], 'red')}"
+                                ),
+                            )
+                            self.active_policy = str(policy["name"])
 
-    # Now that we have updated the maxAmpsToDivideAmongSlaves, send update
-    # to console / MQTT / etc
-    self.queue_background_task({'cmd':'updateStatus'})
+                        if not latched and "latch_period" in policy:
+                            policy["__latchTime"] = (
+                                time.time() + policy["latch_period"] * 60
+                            )
 
-  def setNonScheduledAmpsMax(self, amps):
-    self.settings['nonScheduledAmpsMax'] = amps
+                        # Determine which value to set the charging to
+                        if policy["charge_amps"] == "value":
+                            self.setMaxAmpsToDivideAmongSlaves(int(policy["value"]))
+                            self.debugLog(
+                                10,
+                                "TWCMaster ",
+                                "Charge at %.2f" % int(policy["value"]),
+                            )
+                        else:
+                            self.setMaxAmpsToDivideAmongSlaves(
+                                self.policyValue(policy["charge_amps"])
+                            )
+                            self.debugLog(
+                                10,
+                                "TWCMaster ",
+                                "Charge at %.2f"
+                                % self.policyValue(policy["charge_amps"]),
+                            )
 
-  def setScheduledAmpsDaysBitmap(self, bitmap):
-    self.settings['scheduledAmpsDaysBitmap'] = bitmap
+                        # If a background task is defined for this policy, queue it
+                        bgt = policy.get("background_task", None)
+                        if bgt:
+                            self.queue_background_task({"cmd": bgt})
 
-  def setScheduledAmpsMax(self, amps):
-    self.settings['scheduledAmpsMax'] = amps
+                        # If a charge limit is defined for this policy, apply it
+                        limit = self.policyValue(policy.get("charge_limit", -1))
+                        if not (limit >= 50 and limit <= 100):
+                            limit = -1
+                        self.queue_background_task(
+                            {"cmd": "applyChargeLimit", "limit": limit}
+                        )
 
-  def setScheduledAmpsStartHour(self, hour):
-    self.settings['scheduledAmpsStartHour'] = hour
+                        # Now, finish processing
+                        return
 
-  def setScheduledAmpsEndHour(self, hour):
-    self.settings['scheduledAmpsEndHour'] = hour
+                    else:
+                        self.debugLog(
+                            8,
+                            "TWCMaster ",
+                            "This policy condition has matched, but there are more to process.",
+                        )
 
-  def setSpikeAmps(self, amps):
-    self.spikeAmpsToCancel6ALimit = amps
+                else:
+                    self.debugLog(
+                        8, "TWCMaster ", "Policy conditions were not matched."
+                    )
+                    break
 
-  def startCarsCharging(self):
-    # This function is the opposite functionality to the stopCarsCharging function
-    # below
-    if (self.settings.get('chargeStopMode', "1") == "1"):
-      self.queue_background_task({'cmd':'charge', 'charge':True})
-    if (self.settings.get('chargeStopMode', "1") == "2"):
-      self.settings['respondToSlaves'] = 1
+    def setConsumption(self, source, value):
+        # Accepts consumption values from one or more data sources
+        # For now, this gives a sum value of all, but in future we could
+        # average across sources perhaps, or do a primary/secondary priority
+        self.consumptionValues[source] = value
 
-  def stopCarsCharging(self):
-    # This is called by components (mainly TWCSlave) who want to signal to us to
-    # call our configured routine for stopping vehicles from charging.
-    # The default setting is to use the Tesla API. Some people may not want to do
-    # this, as it only works for Tesla vehicles and requires logging in with your
-    # Tesla credentials. The alternate option is to stop responding to slaves
+    def setGeneration(self, source, value):
+        self.generationValues[source] = value
 
-    # 1 = Stop the car(s) charging via the Tesla API
-    # 2 = Stop the car(s) charging by refusing to respond to slave TWCs
-    if (self.settings.get('chargeStopMode', "1") == "1"):
-      self.queue_background_task({'cmd':'charge', 'charge':False})
-    if (self.settings.get('chargeStopMode', "1") == "2"):
-      self.settings['respondToSlaves'] = 0
+    def setHomeLat(self, lat):
+        self.settings["homeLat"] = lat
 
-  def time_now(self):
-    return(datetime.now().strftime("%H:%M:%S" + (
-        ".%f" if self.config['config']['displayMilliseconds'] else "")))
+    def setHomeLon(self, lon):
+        self.settings["homeLon"] = lon
 
+    def setHourResumeTrackGreenEnergy(self, hour):
+        self.settings["hourResumeTrackGreenEnergy"] = hour
+
+    def setkWhDelivered(self, kWh):
+        self.settings["kWhDelivered"] = kWh
+        return True
+
+    def setMasterTWCID(self, twcid):
+        # This is called when TWCManager is in Slave mode, to track the
+        # master's TWCID
+        self.masterTWCID = twcid
+
+    def setMaxAmpsToDivideAmongSlaves(self, amps):
+
+        # Use backgroundTasksLock to prevent changing maxAmpsToDivideAmongSlaves
+        # if the main thread is in the middle of examining and later using
+        # that value.
+        self.getBackgroundTasksLock()
+
+        if amps > self.config["config"]["wiringMaxAmpsAllTWCs"]:
+            # Never tell the slaves to draw more amps than the physical charger
+            # wiring can handle.
+            self.debugLog(
+                1,
+                "TWCMaster ",
+                "ERROR: specified maxAmpsToDivideAmongSlaves "
+                + str(amps)
+                + " > wiringMaxAmpsAllTWCs "
+                + str(self.config["config"]["wiringMaxAmpsAllTWCs"])
+                + ".\nSee notes above wiringMaxAmpsAllTWCs in the 'Configuration parameters' section.",
+            )
+            amps = self.config["config"]["wiringMaxAmpsAllTWCs"]
+
+        self.maxAmpsToDivideAmongSlaves = amps
+
+        self.releaseBackgroundTasksLock()
+
+        # Now that we have updated the maxAmpsToDivideAmongSlaves, send update
+        # to console / MQTT / etc
+        self.queue_background_task({"cmd": "updateStatus"})
+
+    def setNonScheduledAmpsMax(self, amps):
+        self.settings["nonScheduledAmpsMax"] = amps
+
+    def setScheduledAmpsDaysBitmap(self, bitmap):
+        self.settings["scheduledAmpsDaysBitmap"] = bitmap
+
+    def setScheduledAmpsMax(self, amps):
+        self.settings["scheduledAmpsMax"] = amps
+
+    def setScheduledAmpsStartHour(self, hour):
+        self.settings["scheduledAmpsStartHour"] = hour
+
+    def setScheduledAmpsEndHour(self, hour):
+        self.settings["scheduledAmpsEndHour"] = hour
+
+    def setSpikeAmps(self, amps):
+        self.spikeAmpsToCancel6ALimit = amps
+
+    def startCarsCharging(self):
+        # This function is the opposite functionality to the stopCarsCharging function
+        # below
+        if self.settings.get("chargeStopMode", "1") == "1":
+            self.queue_background_task({"cmd": "charge", "charge": True})
+        if self.settings.get("chargeStopMode", "1") == "2":
+            self.settings["respondToSlaves"] = 1
+
+    def stopCarsCharging(self):
+        # This is called by components (mainly TWCSlave) who want to signal to us to
+        # call our configured routine for stopping vehicles from charging.
+        # The default setting is to use the Tesla API. Some people may not want to do
+        # this, as it only works for Tesla vehicles and requires logging in with your
+        # Tesla credentials. The alternate option is to stop responding to slaves
+
+        # 1 = Stop the car(s) charging via the Tesla API
+        # 2 = Stop the car(s) charging by refusing to respond to slave TWCs
+        if self.settings.get("chargeStopMode", "1") == "1":
+            self.queue_background_task({"cmd": "charge", "charge": False})
+        if self.settings.get("chargeStopMode", "1") == "2":
+            self.settings["respondToSlaves"] = 0
+
+    def time_now(self):
+        return datetime.now().strftime(
+            "%H:%M:%S" + (".%f" if self.config["config"]["displayMilliseconds"] else "")
+        )

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -545,6 +545,14 @@ class TWCSlave:
         if self.minAmpsTWCSupports > minAmpsToOffer:
             minAmpsToOffer = self.minAmpsTWCSupports
 
+        flex = self.master.getAllowedFlex()
+        if (
+            desiredAmpsOffered < minAmpsToOffer
+            and desiredAmpsOffered + flex >= minAmpsToOffer
+            and self.reportedAmpsActual >= 1.0
+        ):
+            desiredAmpsOffered = minAmpsToOffer
+
         if desiredAmpsOffered < minAmpsToOffer:
             self.master.debugLog(
                 10,

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -511,6 +511,7 @@ class TWCSlave:
         # Determine how many cars are charging and how many amps they're using
         numCarsCharging = self.master.num_cars_charging_now()
         desiredAmpsOffered = self.master.getMaxAmpsToDivideAmongSlaves()
+        flex = 0
 
         if numCarsCharging > 0:
             desiredAmpsOffered -= sum(
@@ -518,6 +519,7 @@ class TWCSlave:
                 for slaveTWC in self.master.getSlaveTWCs()
                 if slaveTWC.TWCID != self.TWCID
             )
+            flex = self.master.getAllowedFlex() / numCarsCharging
 
             # Allocate this slave a fraction of maxAmpsToDivideAmongSlaves divided
             # by the number of cars actually charging.
@@ -545,7 +547,6 @@ class TWCSlave:
         if self.minAmpsTWCSupports > minAmpsToOffer:
             minAmpsToOffer = self.minAmpsTWCSupports
 
-        flex = self.master.getAllowedFlex()
         if (
             desiredAmpsOffered < minAmpsToOffer
             and desiredAmpsOffered + flex >= minAmpsToOffer

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1,806 +1,1036 @@
 class TeslaAPI:
 
-  import json
-  import re
-  import requests
-  import time
+    import json
+    import re
+    import requests
+    import time
 
-  carApiLastErrorTime = 0
-  carApiBearerToken   = ''
-  carApiRefreshToken  = ''
-  carApiTokenExpireTime = time.time()
-  carApiLastStartOrStopChargeTime = 0
-  carApiLastChargeLimitApplyTime = 0
-  lastChargeLimitApplied = 0
-  lastChargeCheck     = 0
-  chargeUpdateInterval = 1800
-  carApiVehicles      = []
-  config              = None
-  debugLevel          = 0
-  master              = None
-  minChargeLevel      = -1
+    carApiLastErrorTime = 0
+    carApiBearerToken = ""
+    carApiRefreshToken = ""
+    carApiTokenExpireTime = time.time()
+    carApiLastStartOrStopChargeTime = 0
+    carApiLastChargeLimitApplyTime = 0
+    lastChargeLimitApplied = 0
+    lastChargeCheck = 0
+    chargeUpdateInterval = 1800
+    carApiVehicles = []
+    config = None
+    debugLevel = 0
+    master = None
+    minChargeLevel = -1
 
-  # Transient errors are ones that usually disappear if we retry the car API
-  # command a minute or less later.
-  # 'vehicle unavailable:' sounds like it implies the car is out of connection
-  # range, but I once saw it returned by drive_state after wake_up returned
-  # 'online'. In that case, the car is reachable, but drive_state failed for some
-  # reason. Thus we consider it a transient error.
-  # Error strings below need only match the start of an error response such as:
-  # {'response': None, 'error_description': '',
-  # 'error': 'operation_timedout for txid `4853e3ad74de12733f8cc957c9f60040`}'}
-  carApiTransientErrors = ['upstream internal error',
-                           'operation_timedout',
-                           'vehicle unavailable']
+    # Transient errors are ones that usually disappear if we retry the car API
+    # command a minute or less later.
+    # 'vehicle unavailable:' sounds like it implies the car is out of connection
+    # range, but I once saw it returned by drive_state after wake_up returned
+    # 'online'. In that case, the car is reachable, but drive_state failed for some
+    # reason. Thus we consider it a transient error.
+    # Error strings below need only match the start of an error response such as:
+    # {'response': None, 'error_description': '',
+    # 'error': 'operation_timedout for txid `4853e3ad74de12733f8cc957c9f60040`}'}
+    carApiTransientErrors = [
+        "upstream internal error",
+        "operation_timedout",
+        "vehicle unavailable",
+    ]
 
-  # Define minutes between retrying non-transient errors.
-  carApiErrorRetryMins = 10
+    # Define minutes between retrying non-transient errors.
+    carApiErrorRetryMins = 10
 
-  def __init__(self, master):
-    self.master = master
-    try:
-        self.config = master.config
-        self.debugLevel = self.config['config']['debugLevel']
-        self.minChargeLevel = self.config['config']['minChargeLevel']
-        self.chargeUpdateInterval = self.config['config'].get('cloudUpdateInterval', 1800)
-    except KeyError:
-        pass
-
-  def addVehicle(self, json):
-    self.carApiVehicles.append(CarApiVehicle(json, self, self.config))
-    return True
-
-  def car_api_available(self, email = None, password = None, charge = None, applyLimit = None):
-    now = self.time.time()
-    apiResponseDict = {}
-
-    if(self.getCarApiRetryRemaining()):
-        # It's been under carApiErrorRetryMins minutes since the car API
-        # generated an error. To keep strain off Tesla's API servers, wait
-        # carApiErrorRetryMins mins till we try again. This delay could be
-        # reduced if you feel the need. It's mostly here to deal with unexpected
-        # errors that are hopefully transient.
-        # https://teslamotorsclub.com/tmc/threads/model-s-rest-api.13410/page-114#post-2732052
-        # says he tested hammering the servers with requests as fast as possible
-        # and was automatically blacklisted after 2 minutes. Waiting 30 mins was
-        # enough to clear the blacklist. So at this point it seems Tesla has
-        # accepted that third party apps use the API and deals with bad behavior
-        # automatically.
-        self.master.debugLog(6, "TeslaAPI  ", 'Car API disabled for ' + str(self.getCarApiRetryRemaining()) + ' more seconds due to recent error.')
-        return False
-    else:
-        self.master.debugLog(8, "TeslaAPI  ", "Entering car_api_available - next step is to query Tesla API")
-
-    # Tesla car API info comes from https://timdorr.docs.apiary.io/
-    if(self.getCarApiBearerToken() == '' or self.getCarApiTokenExpireTime() - now < 30*24*60*60):
-        req = None
-        apiResponse = b''
-        client_id = '81527cff06843c8634fdc09e8ac0abefb46ac849f38fe1e431c2ef2106796384'
-        client_secret = 'c7257eb71a564034f9419ee651c7d0e5f7aa6bfbd18bafb5c5c033b093bb2fa3'
-        url = 'https://owner-api.teslamotors.com/oauth/token'
-        headers = None
-        data = None
-
-        # If we don't have a bearer token or our refresh token will expire in
-        # under 30 days, get a new bearer token.  Refresh tokens expire in 45
-        # days when first issued, so we'll get a new token every 15 days.
-        if(self.getCarApiRefreshToken() != ''):
-            headers = {
-              'accept': 'application/json',
-              'Content-Type': 'application/json'
-            }
-            data = {
-              'client_id': client_id,
-              'client_secret': client_secret,
-              'grant_type': 'refresh_token',
-              'refresh_token': self.getCarApiRefreshToken()
-            }
-            self.master.debugLog(8, "TeslaAPI  ", "Attempting token refresh")
-
-        elif(email != None and password != None):
-            headers = {
-              'accept': 'application/json',
-              'Content-Type': 'application/json'
-            }
-            data = {
-              'client_id': client_id,
-              'client_secret': client_secret,
-              'grant_type': 'password',
-              'email': email,
-              'password': password
-            }
-            self.master.debugLog(8, "TeslaAPI  ", "Attempting password auth")
-
-        if(headers and data):
-            try:
-                req = self.requests.post(url, headers = headers, json = data)
-                self.master.debugLog(2, "TeslaAPI  ", 'Car API request' + str(req))
-                # Example response:
-                # b'{"access_token":"4720d5f980c9969b0ca77ab39399b9103adb63ee832014fe299684201929380","token_type":"bearer","expires_in":3888000,"refresh_token":"110dd4455437ed351649391a3425b411755a213aa815171a2c6bfea8cc1253ae","created_at":1525232970}'
-
-                apiResponseDict = self.json.loads(req.text)
-            except:
-                pass
-        else:
-            self.master.debugLog(2, "TeslaAPI  ", 'Car API request is empty')
-
-
+    def __init__(self, master):
+        self.master = master
         try:
-            self.master.debugLog(4, "TeslaAPI  ", 'Car API auth response' + str(apiResponseDict))
-            self.setCarApiBearerToken(apiResponseDict['access_token'])
-            self.setCarApiRefreshToken(apiResponseDict['refresh_token'])
-            self.setCarApiTokenExpireTime(now + apiResponseDict['expires_in'])
+            self.config = master.config
+            self.debugLevel = self.config["config"]["debugLevel"]
+            self.minChargeLevel = self.config["config"]["minChargeLevel"]
+            self.chargeUpdateInterval = self.config["config"].get(
+                "cloudUpdateInterval", 1800
+            )
         except KeyError:
-            self.master.debugLog(2, "TeslaAPI  ", "ERROR: Can't access Tesla car via API.  Please log in again via web interface.")
-            self.updateCarApiLastErrorTime()
-            # Instead of just setting carApiLastErrorTime, erase tokens to
-            # prevent further authorization attempts until user enters password
-            # on web interface. I feel this is safer than trying to log in every
-            # ten minutes with a bad token because Tesla might decide to block
-            # remote access to your car after too many authorization errors.
-            self.setCarApiBearerToken("")
-            self.setCarApiRefreshToken("")
+            pass
 
-        self.master.saveSettings()
+    def addVehicle(self, json):
+        self.carApiVehicles.append(CarApiVehicle(json, self, self.config))
+        return True
 
-    if(self.getCarApiBearerToken() != ''):
-        if(self.getVehicleCount() < 1):
-            url = "https://owner-api.teslamotors.com/api/1/vehicles"
-            headers = {
-              'accept': 'application/json',
-              'Authorization': 'Bearer ' + self.getCarApiBearerToken()
-            }
-            try:
-                req = self.requests.get(url, headers = headers)
-                self.master.debugLog(8, "TeslaAPI  ", 'Car API cmd ' + str(req))
-                apiResponseDict = self.json.loads(req.text)
-            except:
-                self.master.debugLog(1, "TeslaAPI  ", "Failed to make API call " + url)
-                self.master.debugLog(6, "TeslaAPI  ", "Response: " + req.text)
-                pass
+    def car_api_available(
+        self, email=None, password=None, charge=None, applyLimit=None
+    ):
+        now = self.time.time()
+        apiResponseDict = {}
 
-            try:
-                self.master.debugLog(10, "TeslaAPI  ", 'Car API vehicle list' + str(apiResponseDict) + '\n')
+        if self.getCarApiRetryRemaining():
+            # It's been under carApiErrorRetryMins minutes since the car API
+            # generated an error. To keep strain off Tesla's API servers, wait
+            # carApiErrorRetryMins mins till we try again. This delay could be
+            # reduced if you feel the need. It's mostly here to deal with unexpected
+            # errors that are hopefully transient.
+            # https://teslamotorsclub.com/tmc/threads/model-s-rest-api.13410/page-114#post-2732052
+            # says he tested hammering the servers with requests as fast as possible
+            # and was automatically blacklisted after 2 minutes. Waiting 30 mins was
+            # enough to clear the blacklist. So at this point it seems Tesla has
+            # accepted that third party apps use the API and deals with bad behavior
+            # automatically.
+            self.master.debugLog(
+                6,
+                "TeslaAPI  ",
+                "Car API disabled for "
+                + str(self.getCarApiRetryRemaining())
+                + " more seconds due to recent error.",
+            )
+            return False
+        else:
+            self.master.debugLog(
+                8,
+                "TeslaAPI  ",
+                "Entering car_api_available - next step is to query Tesla API",
+            )
 
-                for i in range(0, apiResponseDict['count']):
-                    self.addVehicle(apiResponseDict['response'][i])
-            except (KeyError, TypeError):
-                # This catches cases like trying to access
-                # apiResponseDict['response'] when 'response' doesn't exist in
-                # apiResponseDict.
-                self.master.debugLog(2, "TeslaAPI  ", "ERROR: Can't get list of vehicles via Tesla car API.  Will try again in " + str(self.getCarApiErrorRetryMins()) + " minutes.")
-                self.updateCarApiLastErrorTime()
-                return False
+        # Tesla car API info comes from https://timdorr.docs.apiary.io/
+        if (
+            self.getCarApiBearerToken() == ""
+            or self.getCarApiTokenExpireTime() - now < 30 * 24 * 60 * 60
+        ):
+            req = None
+            apiResponse = b""
+            client_id = (
+                "81527cff06843c8634fdc09e8ac0abefb46ac849f38fe1e431c2ef2106796384"
+            )
+            client_secret = (
+                "c7257eb71a564034f9419ee651c7d0e5f7aa6bfbd18bafb5c5c033b093bb2fa3"
+            )
+            url = "https://owner-api.teslamotors.com/oauth/token"
+            headers = None
+            data = None
 
-        needSleep = False
-        if(self.getVehicleCount() > 0 and (charge or applyLimit)):
-            # Wake cars if needed
-            for vehicle in self.getCarApiVehicles():
-                if(charge == True and vehicle.stopAskingToStartCharging):
-                    # Vehicle is in a state (complete or charging) already
-                    # which doesn't make sense for us to keep requesting it
-                    # to start charging, so we will stop.
-                    self.master.debugLog(11, "TeslaAPI  ", "Don't repeatedly request API to charge "
-                        + vehicle.name + ", because vehicle.stopAskingToStartCharging "
-                        + " == True - it has already been requested.")
-                    continue
-
-                if(applyLimit == True and vehicle.stopTryingToApplyLimit):
-                    self.master.debugLog(11, "TeslaAPI  ", "Don't wake " + vehicle.name
-                              + " to set the charge limit - it has already been set")
-                    continue
-
-                if(self.getCarApiRetryRemaining()):
-                    # It's been under carApiErrorRetryMins minutes since the car
-                    # API generated an error on this vehicle. Don't send it more
-                    # commands yet.
-                    self.master.debugLog(11, "TeslaAPI  ", "Don't send commands to " + vehicle.name
-                              + " because it returned an error in the last "
-                              + str(self.getCarApiErrorRetryMins()) + " minutes.")
-                    continue
-
-                if(vehicle.ready()):
-                    continue
-
-                if(now - vehicle.lastWakeAttemptTime <= vehicle.delayNextWakeAttempt):
-                    self.master.debugLog(10, "TeslaAPI  ", "car_api_available returning False because we are still delaying "
-                              + str(vehicle.delayNextWakeAttempt) + " seconds after the last failed wake attempt.")
-                    return False
-
-                # It's been delayNextWakeAttempt seconds since we last failed to
-                # wake the car, or it's never been woken. Wake it.
-                vehicle.lastWakeAttemptTime = now
-                url = "https://owner-api.teslamotors.com/api/1/vehicles/"
-                url = url + str(vehicle.ID) + "/wake_up"
-
+            # If we don't have a bearer token or our refresh token will expire in
+            # under 30 days, get a new bearer token.  Refresh tokens expire in 45
+            # days when first issued, so we'll get a new token every 15 days.
+            if self.getCarApiRefreshToken() != "":
                 headers = {
-                  'accept': 'application/json',
-                  'Authorization': 'Bearer ' + self.getCarApiBearerToken()
+                    "accept": "application/json",
+                    "Content-Type": "application/json",
+                }
+                data = {
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "grant_type": "refresh_token",
+                    "refresh_token": self.getCarApiRefreshToken(),
+                }
+                self.master.debugLog(8, "TeslaAPI  ", "Attempting token refresh")
+
+            elif email != None and password != None:
+                headers = {
+                    "accept": "application/json",
+                    "Content-Type": "application/json",
+                }
+                data = {
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "grant_type": "password",
+                    "email": email,
+                    "password": password,
+                }
+                self.master.debugLog(8, "TeslaAPI  ", "Attempting password auth")
+
+            if headers and data:
+                try:
+                    req = self.requests.post(url, headers=headers, json=data)
+                    self.master.debugLog(2, "TeslaAPI  ", "Car API request" + str(req))
+                    # Example response:
+                    # b'{"access_token":"4720d5f980c9969b0ca77ab39399b9103adb63ee832014fe299684201929380","token_type":"bearer","expires_in":3888000,"refresh_token":"110dd4455437ed351649391a3425b411755a213aa815171a2c6bfea8cc1253ae","created_at":1525232970}'
+
+                    apiResponseDict = self.json.loads(req.text)
+                except:
+                    pass
+            else:
+                self.master.debugLog(2, "TeslaAPI  ", "Car API request is empty")
+
+            try:
+                self.master.debugLog(
+                    4, "TeslaAPI  ", "Car API auth response" + str(apiResponseDict)
+                )
+                self.setCarApiBearerToken(apiResponseDict["access_token"])
+                self.setCarApiRefreshToken(apiResponseDict["refresh_token"])
+                self.setCarApiTokenExpireTime(now + apiResponseDict["expires_in"])
+            except KeyError:
+                self.master.debugLog(
+                    2,
+                    "TeslaAPI  ",
+                    "ERROR: Can't access Tesla car via API.  Please log in again via web interface.",
+                )
+                self.updateCarApiLastErrorTime()
+                # Instead of just setting carApiLastErrorTime, erase tokens to
+                # prevent further authorization attempts until user enters password
+                # on web interface. I feel this is safer than trying to log in every
+                # ten minutes with a bad token because Tesla might decide to block
+                # remote access to your car after too many authorization errors.
+                self.setCarApiBearerToken("")
+                self.setCarApiRefreshToken("")
+
+            self.master.saveSettings()
+
+        if self.getCarApiBearerToken() != "":
+            if self.getVehicleCount() < 1:
+                url = "https://owner-api.teslamotors.com/api/1/vehicles"
+                headers = {
+                    "accept": "application/json",
+                    "Authorization": "Bearer " + self.getCarApiBearerToken(),
                 }
                 try:
-                    req = self.requests.post(url, headers = headers)
-                    self.master.debugLog(8, "TeslaAPI  ", 'Car API cmd' + str(req))
+                    req = self.requests.get(url, headers=headers)
+                    self.master.debugLog(8, "TeslaAPI  ", "Car API cmd " + str(req))
+                    apiResponseDict = self.json.loads(req.text)
+                except:
+                    self.master.debugLog(
+                        1, "TeslaAPI  ", "Failed to make API call " + url
+                    )
+                    self.master.debugLog(6, "TeslaAPI  ", "Response: " + req.text)
+                    pass
+
+                try:
+                    self.master.debugLog(
+                        10,
+                        "TeslaAPI  ",
+                        "Car API vehicle list" + str(apiResponseDict) + "\n",
+                    )
+
+                    for i in range(0, apiResponseDict["count"]):
+                        self.addVehicle(apiResponseDict["response"][i])
+                except (KeyError, TypeError):
+                    # This catches cases like trying to access
+                    # apiResponseDict['response'] when 'response' doesn't exist in
+                    # apiResponseDict.
+                    self.master.debugLog(
+                        2,
+                        "TeslaAPI  ",
+                        "ERROR: Can't get list of vehicles via Tesla car API.  Will try again in "
+                        + str(self.getCarApiErrorRetryMins())
+                        + " minutes.",
+                    )
+                    self.updateCarApiLastErrorTime()
+                    return False
+
+            needSleep = False
+            if self.getVehicleCount() > 0 and (charge or applyLimit):
+                # Wake cars if needed
+                for vehicle in self.getCarApiVehicles():
+                    if charge == True and vehicle.stopAskingToStartCharging:
+                        # Vehicle is in a state (complete or charging) already
+                        # which doesn't make sense for us to keep requesting it
+                        # to start charging, so we will stop.
+                        self.master.debugLog(
+                            11,
+                            "TeslaAPI  ",
+                            "Don't repeatedly request API to charge "
+                            + vehicle.name
+                            + ", because vehicle.stopAskingToStartCharging "
+                            + " == True - it has already been requested.",
+                        )
+                        continue
+
+                    if applyLimit == True and vehicle.stopTryingToApplyLimit:
+                        self.master.debugLog(
+                            11,
+                            "TeslaAPI  ",
+                            "Don't wake "
+                            + vehicle.name
+                            + " to set the charge limit - it has already been set",
+                        )
+                        continue
+
+                    if self.getCarApiRetryRemaining():
+                        # It's been under carApiErrorRetryMins minutes since the car
+                        # API generated an error on this vehicle. Don't send it more
+                        # commands yet.
+                        self.master.debugLog(
+                            11,
+                            "TeslaAPI  ",
+                            "Don't send commands to "
+                            + vehicle.name
+                            + " because it returned an error in the last "
+                            + str(self.getCarApiErrorRetryMins())
+                            + " minutes.",
+                        )
+                        continue
+
+                    if vehicle.ready():
+                        continue
+
+                    if (
+                        now - vehicle.lastWakeAttemptTime
+                        <= vehicle.delayNextWakeAttempt
+                    ):
+                        self.master.debugLog(
+                            10,
+                            "TeslaAPI  ",
+                            "car_api_available returning False because we are still delaying "
+                            + str(vehicle.delayNextWakeAttempt)
+                            + " seconds after the last failed wake attempt.",
+                        )
+                        return False
+
+                    # It's been delayNextWakeAttempt seconds since we last failed to
+                    # wake the car, or it's never been woken. Wake it.
+                    vehicle.lastWakeAttemptTime = now
+                    url = "https://owner-api.teslamotors.com/api/1/vehicles/"
+                    url = url + str(vehicle.ID) + "/wake_up"
+
+                    headers = {
+                        "accept": "application/json",
+                        "Authorization": "Bearer " + self.getCarApiBearerToken(),
+                    }
+                    try:
+                        req = self.requests.post(url, headers=headers)
+                        self.master.debugLog(8, "TeslaAPI  ", "Car API cmd" + str(req))
+                        apiResponseDict = self.json.loads(req.text)
+                    except:
+                        pass
+
+                    state = "error"
+                    self.master.debugLog(
+                        10,
+                        "TeslaAPI  ",
+                        "Car API wake car response" + str(apiResponseDict),
+                    )
+                    try:
+                        state = apiResponseDict["response"]["state"]
+
+                    except (KeyError, TypeError):
+                        # This catches unexpected cases like trying to access
+                        # apiResponseDict['response'] when 'response' doesn't exist
+                        # in apiResponseDict.
+                        state = "error"
+
+                    if state == "online":
+                        # With max power saving settings, car will almost always
+                        # report 'asleep' or 'offline' the first time it's sent
+                        # wake_up.  Rarely, it returns 'online' on the first wake_up
+                        # even when the car has not been contacted in a long while.
+                        # I suspect that happens when we happen to query the car
+                        # when it periodically awakens for some reason.
+                        vehicle.firstWakeAttemptTime = 0
+                        vehicle.delayNextWakeAttempt = 0
+                        # Don't alter vehicle.lastWakeAttemptTime because
+                        # vehicle.ready() uses it to return True if the last wake
+                        # was under 2 mins ago.
+                        needSleep = True
+                    else:
+                        if vehicle.firstWakeAttemptTime == 0:
+                            vehicle.firstWakeAttemptTime = now
+
+                        if state == "asleep" or state == "waking":
+                            if now - vehicle.firstWakeAttemptTime <= 10 * 60:
+                                # http://visibletesla.com has a 'force wakeup' mode
+                                # that sends wake_up messages once every 5 seconds
+                                # 15 times. This generally manages to wake my car if
+                                # it's returning 'asleep' state, but I don't think
+                                # there is any reason for 5 seconds and 15 attempts.
+                                # The car did wake in two tests with that timing,
+                                # but on the third test, it had not entered online
+                                # mode by the 15th wake_up and took another 10+
+                                # seconds to come online. In general, I hear relays
+                                # in the car clicking a few seconds after the first
+                                # wake_up but the car does not enter 'waking' or
+                                # 'online' state for a random period of time. I've
+                                # seen it take over one minute, 20 sec.
+                                #
+                                # I interpret this to mean a car in 'asleep' mode is
+                                # still receiving car API messages and will start
+                                # to wake after the first wake_up, but it may take
+                                # awhile to finish waking up. Therefore, we try
+                                # waking every 30 seconds for the first 10 mins.
+                                vehicle.delayNextWakeAttempt = 30
+                            elif now - vehicle.firstWakeAttemptTime <= 70 * 60:
+                                # Cars in 'asleep' state should wake within a
+                                # couple minutes in my experience, so we should
+                                # never reach this point. If we do, try every 5
+                                # minutes for the next hour.
+                                vehicle.delayNextWakeAttempt = 5 * 60
+                            else:
+                                # Car hasn't woken for an hour and 10 mins. Try
+                                # again in 15 minutes. We'll show an error about
+                                # reaching this point later.
+                                vehicle.delayNextWakeAttempt = 15 * 60
+                        elif state == "offline":
+                            if now - vehicle.firstWakeAttemptTime <= 31 * 60:
+                                # A car in offline state is presumably not connected
+                                # wirelessly so our wake_up command will not reach
+                                # it. Instead, the car wakes itself every 20-30
+                                # minutes and waits some period of time for a
+                                # message, then goes back to sleep. I'm not sure
+                                # what the period of time is, so I tried sending
+                                # wake_up every 55 seconds for 16 minutes but the
+                                # car failed to wake.
+                                # Next I tried once every 25 seconds for 31 mins.
+                                # This worked after 19.5 and 19.75 minutes in 2
+                                # tests but I can't be sure the car stays awake for
+                                # 30secs or if I just happened to send a command
+                                # during a shorter period of wakefulness.
+                                vehicle.delayNextWakeAttempt = 25
+
+                                # I've run tests sending wake_up every 10-30 mins to
+                                # a car in offline state and it will go hours
+                                # without waking unless you're lucky enough to hit
+                                # it in the brief time it's waiting for wireless
+                                # commands. I assume cars only enter offline state
+                                # when set to max power saving mode, and even then,
+                                # they don't always enter the state even after 8
+                                # hours of no API contact or other interaction. I've
+                                # seen it remain in 'asleep' state when contacted
+                                # after 16.5 hours, but I also think I've seen it in
+                                # offline state after less than 16 hours, so I'm not
+                                # sure what the rules are or if maybe Tesla contacts
+                                # the car periodically which resets the offline
+                                # countdown.
+                                #
+                                # I've also seen it enter 'offline' state a few
+                                # minutes after finishing charging, then go 'online'
+                                # on the third retry every 55 seconds.  I suspect
+                                # that might be a case of the car briefly losing
+                                # wireless connection rather than actually going
+                                # into a deep sleep.
+                                # 'offline' may happen almost immediately if you
+                                # don't have the charger plugged in.
+                        else:
+                            # Handle 'error' state.
+                            if now - vehicle.firstWakeAttemptTime <= 60 * 60:
+                                # We've tried to wake the car for less than an
+                                # hour.
+                                foundKnownError = False
+                                if "error" in apiResponseDict:
+                                    error = apiResponseDict["error"]
+                                    for knownError in self.getCarApiTransientErrors():
+                                        if knownError == error[0 : len(knownError)]:
+                                            foundKnownError = True
+                                            break
+
+                                if foundKnownError:
+                                    # I see these errors often enough that I think
+                                    # it's worth re-trying in 1 minute rather than
+                                    # waiting 5 minutes for retry in the standard
+                                    # error handler.
+                                    vehicle.delayNextWakeAttempt = 60
+                                else:
+                                    # by the API servers being down, car being out of
+                                    # range, or by something I can't anticipate. Try
+                                    # waking the car every 5 mins.
+                                    vehicle.delayNextWakeAttempt = 5 * 60
+                            else:
+                                # Car hasn't woken for over an hour. Try again
+                                # in 15 minutes. We'll show an error about this
+                                # later.
+                                vehicle.delayNextWakeAttempt = 15 * 60
+
+                        if state == "error":
+                            self.master.debugLog(
+                                1,
+                                "TeslaAPI  ",
+                                "Car API wake car failed with unknown response.  "
+                                + "Will try again in "
+                                + str(vehicle.delayNextWakeAttempt)
+                                + " seconds.",
+                            )
+                        else:
+                            self.master.debugLog(
+                                1,
+                                "TeslaAPI  ",
+                                "Car API wake car failed.  State remains: '"
+                                + state
+                                + "'.  Will try again in "
+                                + str(vehicle.delayNextWakeAttempt)
+                                + " seconds.",
+                            )
+
+                    if (
+                        vehicle.firstWakeAttemptTime > 0
+                        and now - vehicle.firstWakeAttemptTime > 60 * 60
+                    ):
+                        # It should never take over an hour to wake a car.  If it
+                        # does, ask user to report an error.
+                        self.master.debugLog(
+                            1,
+                            "TeslaAPI  ",
+                            "ERROR: We have failed to wake a car from '"
+                            + state
+                            + "' state for %.1f hours.\n"
+                            "Please private message user CDragon at "
+                            "http://teslamotorsclub.com with a copy of this error. "
+                            "Also include this: %s"
+                            % (
+                                ((now - vehicle.firstWakeAttemptTime) / 60 / 60),
+                                str(apiResponseDict),
+                            ),
+                        )
+
+        if (
+            now - self.getCarApiLastErrorTime() < (self.getCarApiErrorRetryMins() * 60)
+            or self.getCarApiBearerToken() == ""
+        ):
+            self.master.debugLog(
+                8,
+                "TeslaAPI  ",
+                "car_api_available returning False because of recent carApiLasterrorTime "
+                + str(now - self.getCarApiLastErrorTime())
+                + " or empty carApiBearerToken '"
+                + self.getCarApiBearerToken()
+                + "'",
+            )
+            return False
+
+        # We return True to indicate there was no error that prevents running
+        # car API commands and that we successfully got a list of vehicles.
+        # True does not indicate that any vehicle is actually awake and ready
+        # for commands.
+        self.master.debugLog(8, "TeslaAPI  ", "car_api_available returning True")
+
+        if needSleep:
+            # If you send charge_start/stop less than 1 second after calling
+            # update_location(), the charge command usually returns:
+            #   {'response': {'result': False, 'reason': 'could_not_wake_buses'}}
+            # I'm not sure if the same problem exists when sending commands too
+            # quickly after we send wake_up.  I haven't seen a problem sending a
+            # command immediately, but it seems safest to sleep 5 seconds after
+            # waking before sending a command.
+            self.time.sleep(5)
+
+        return True
+
+    def is_location_home(self, lat, lon):
+
+        if self.master.getHomeLatLon()[0] == 10000:
+            self.master.debugLog(
+                1,
+                "TeslaAPI  ",
+                "Home location for vehicles has never been set.  "
+                + "We'll assume home is where we found the first vehicle currently parked.  "
+                + "Home set to lat="
+                + str(lat)
+                + ", lon="
+                + str(lon),
+            )
+            self.master.setHomeLat(lat)
+            self.master.setHomeLon(lon)
+            self.master.saveSettings()
+            return True
+
+        # 1 lat or lon = ~364488.888 feet. The exact feet is different depending
+        # on the value of latitude, but this value should be close enough for
+        # our rough needs.
+        # 1/364488.888 * 10560 = 0.0289.
+        # So if vehicle is within 0289 lat and lon of homeLat/Lon,
+        # it's within ~10560 feet (2 miles) of home and we'll consider it to be
+        # at home.
+        # I originally tried using 0.00548 (~2000 feet) but one night the car
+        # consistently reported being 2839 feet away from home despite being
+        # parked in the exact spot I always park it.  This is very odd because
+        # GPS is supposed to be accurate to within 12 feet.  Tesla phone app
+        # also reports the car is not at its usual address.  I suspect this
+        # is another case of a bug that's been causing car GPS to freeze  the
+        # last couple months.
+        if (
+            abs(self.master.getHomeLatLon()[0] - lat) > 0.0289
+            or abs(self.master.getHomeLatLon()[1] - lon) > 0.0289
+        ):
+            return False
+
+        return True
+
+    def car_api_charge(self, charge):
+        # Do not call this function directly.  Call by using background thread:
+        # queue_background_task({'cmd':'charge', 'charge':<True/False>})
+
+        now = self.time.time()
+        apiResponseDict = {}
+        if not charge:
+            # Whenever we are going to tell vehicles to stop charging, set
+            # vehicle.stopAskingToStartCharging = False on all vehicles.
+            for vehicle in self.getCarApiVehicles():
+                vehicle.stopAskingToStartCharging = False
+
+        if now - self.getLastStartOrStopChargeTime() < 60:
+            # Don't start or stop more often than once a minute
+            self.master.debugLog(
+                11,
+                "TeslaAPI  ",
+                "car_api_charge return because under 60 sec since last carApiLastStartOrStopChargeTime",
+            )
+            return "error"
+
+        if self.car_api_available(charge=charge) == False:
+            self.master.debugLog(
+                8,
+                "TeslaAPI  ",
+                "car_api_charge return because car_api_available() == False",
+            )
+            return "error"
+
+        startOrStop = "start" if charge else "stop"
+        result = "success"
+        self.master.debugLog(
+            8, "TeslaAPI  ", "startOrStop is set to " + str(startOrStop)
+        )
+
+        for vehicle in self.getCarApiVehicles():
+            if charge and vehicle.stopAskingToStartCharging:
+                self.master.debugLog(
+                    8,
+                    "TeslaAPI  ",
+                    "Don't charge "
+                    + vehicle.name
+                    + " because vehicle.stopAskingToStartCharging == True",
+                )
+                continue
+
+            if vehicle.ready(wake=charge) == False:
+                continue
+
+            if (
+                vehicle.update_charge(wake=False)
+                and vehicle.batteryLevel < self.minChargeLevel
+            ):
+                # If the vehicle's charge state is lower than the configured minimum,
+                #   don't stop it from charging, even if we'd otherwise not charge.
+                continue
+
+            # Only update carApiLastStartOrStopChargeTime if car_api_available() managed
+            # to wake cars.  Setting this prevents any command below from being sent
+            # more than once per minute.
+            self.updateLastStartOrStopChargeTime()
+
+            if (
+                self.config["config"]["onlyChargeMultiCarsAtHome"]
+                and self.getVehicleCount() > 1
+            ):
+                # When multiple cars are enrolled in the car API, only start/stop
+                # charging cars parked at home.
+
+                if vehicle.update_location() == False:
+                    result = "error"
+                    continue
+
+                if not vehicle.atHome:
+                    # Vehicle is not at home, so don't change its charge state.
+                    self.master.debugLog(
+                        1,
+                        "TeslaAPI  ",
+                        vehicle.name
+                        + " is not at home.  Do not "
+                        + startOrStop
+                        + " charge.",
+                    )
+                    continue
+
+                # If you send charge_start/stop less than 1 second after calling
+                # update_location(), the charge command usually returns:
+                #   {'response': {'result': False, 'reason': 'could_not_wake_buses'}}
+                # Waiting 2 seconds seems to consistently avoid the error, but let's
+                # wait 5 seconds in case of hardware differences between cars.
+                time.sleep(5)
+
+            url = "https://owner-api.teslamotors.com/api/1/vehicles/"
+            url = url + str(vehicle.ID) + "/command/charge_" + startOrStop
+            headers = {
+                "accept": "application/json",
+                "Authorization": "Bearer " + self.getCarApiBearerToken(),
+            }
+
+            # Retry up to 3 times on certain errors.
+            for retryCount in range(0, 3):
+                try:
+                    req = self.requests.post(url, headers=headers)
+                    self.master.debugLog(8, "TeslaAPI  ", "Car API cmd" + str(req))
                     apiResponseDict = self.json.loads(req.text)
                 except:
                     pass
 
-                state = 'error'
-                self.master.debugLog(10, "TeslaAPI  ", 'Car API wake car response' + str(apiResponseDict))
                 try:
-                    state = apiResponseDict['response']['state']
+                    self.master.debugLog(
+                        4,
+                        "TeslaAPI  ",
+                        vehicle.name
+                        + ": "
+                        + startOrStop
+                        + " charge response"
+                        + str(apiResponseDict),
+                    )
+                    # Responses I've seen in apiResponseDict:
+                    # Car is done charging:
+                    #   {'response': {'result': False, 'reason': 'complete'}}
+                    # Car wants to charge but may not actually be charging. Oddly, this
+                    # is the state reported when car is not plugged in to a charger!
+                    # It's also reported when plugged in but charger is not offering
+                    # power or even when the car is in an error state and refuses to
+                    # charge.
+                    #   {'response': {'result': False, 'reason': 'charging'}}
+                    # Car not reachable:
+                    #   {'response': None, 'error_description': '', 'error': 'vehicle unavailable: {:error=>"vehicle unavailable:"}'}
+                    # This weird error seems to happen randomly and re-trying a few
+                    # seconds later often succeeds:
+                    #   {'response': {'result': False, 'reason': 'could_not_wake_buses'}}
+                    # I've seen this a few times on wake_up, charge_start, and drive_state:
+                    #   {'error': 'upstream internal error', 'response': None, 'error_description': ''}
+                    # I've seen this once on wake_up:
+                    #   {'error': 'operation_timedout for txid `4853e3ad74de12733f8cc957c9f60040`}', 'response': None, 'error_description': ''}
+                    # Start or stop charging success:
+                    #   {'response': {'result': True, 'reason': ''}}
+                    if apiResponseDict["response"] == None:
+                        if "error" in apiResponseDict:
+                            foundKnownError = False
+                            error = apiResponseDict["error"]
+                            for knownError in self.getCarApiTransientErrors():
+                                if knownError == error[0 : len(knownError)]:
+                                    # I see these errors often enough that I think
+                                    # it's worth re-trying in 1 minute rather than
+                                    # waiting carApiErrorRetryMins minutes for retry
+                                    # in the standard error handler.
+                                    self.master.debugLog(
+                                        1,
+                                        "TeslaAPI  ",
+                                        "Car API returned '"
+                                        + error
+                                        + "' when trying to start charging.  Try again in 1 minute.",
+                                    )
+                                    time.sleep(60)
+                                    foundKnownError = True
+                                    break
+                            if foundKnownError:
+                                continue
+
+                        # This generally indicates a significant error like 'vehicle
+                        # unavailable', but it's not something I think the caller can do
+                        # anything about, so return generic 'error'.
+                        result = "error"
+                        # Don't send another command to this vehicle for
+                        # carApiErrorRetryMins mins.
+                        vehicle.lastErrorTime = now
+                    elif apiResponseDict["response"]["result"] == False:
+                        if charge:
+                            reason = apiResponseDict["response"]["reason"]
+                            if reason == "complete" or reason == "charging":
+                                # We asked the car to charge, but it responded that
+                                # it can't, either because it's reached target
+                                # charge state (reason == 'complete'), or it's
+                                # already trying to charge (reason == 'charging').
+                                # In these cases, it won't help to keep asking it to
+                                # charge, so set vehicle.stopAskingToStartCharging =
+                                # True.
+                                #
+                                # Remember, this only means at least one car in the
+                                # list wants us to stop asking and we don't know
+                                # which car in the list is connected to our TWC.
+                                self.master.debugLog(
+                                    1,
+                                    "TeslaAPI  ",
+                                    vehicle.name
+                                    + " is done charging or already trying to charge.  Stop asking to start charging.",
+                                )
+                                vehicle.stopAskingToStartCharging = True
+                            else:
+                                # Car was unable to charge for some other reason, such
+                                # as 'could_not_wake_buses'.
+                                if reason == "could_not_wake_buses":
+                                    # This error often happens if you call
+                                    # charge_start too quickly after another command
+                                    # like drive_state. Even if you delay 5 seconds
+                                    # between the commands, this error still comes
+                                    # up occasionally. Retrying often succeeds, so
+                                    # wait 5 secs and retry.
+                                    # If all retries fail, we'll try again in a
+                                    # minute because we set
+                                    # carApiLastStartOrStopChargeTime = now earlier.
+                                    time.sleep(5)
+                                    continue
+                                else:
+                                    # Start or stop charge failed with an error I
+                                    # haven't seen before, so wait
+                                    # carApiErrorRetryMins mins before trying again.
+                                    self.master.debugLog(
+                                        1,
+                                        "TeslaAPI  ",
+                                        'ERROR "'
+                                        + reason
+                                        + '" when trying to '
+                                        + startOrStop
+                                        + " car charging via Tesla car API.  Will try again later."
+                                        + "\nIf this error persists, please private message user CDragon at http://teslamotorsclub.com with a copy of this error.",
+                                    )
+                                    result = "error"
+                                    vehicle.lastErrorTime = now
 
                 except (KeyError, TypeError):
-                    # This catches unexpected cases like trying to access
-                    # apiResponseDict['response'] when 'response' doesn't exist
-                    # in apiResponseDict.
-                    state = 'error'
-
-                if(state == 'online'):
-                    # With max power saving settings, car will almost always
-                    # report 'asleep' or 'offline' the first time it's sent
-                    # wake_up.  Rarely, it returns 'online' on the first wake_up
-                    # even when the car has not been contacted in a long while.
-                    # I suspect that happens when we happen to query the car
-                    # when it periodically awakens for some reason.
-                    vehicle.firstWakeAttemptTime = 0
-                    vehicle.delayNextWakeAttempt = 0
-                    # Don't alter vehicle.lastWakeAttemptTime because
-                    # vehicle.ready() uses it to return True if the last wake
-                    # was under 2 mins ago.
-                    needSleep = True
-                else:
-                    if(vehicle.firstWakeAttemptTime == 0):
-                        vehicle.firstWakeAttemptTime = now
-
-                    if(state == 'asleep' or state == 'waking'):
-                        if(now - vehicle.firstWakeAttemptTime <= 10*60):
-                            # http://visibletesla.com has a 'force wakeup' mode
-                            # that sends wake_up messages once every 5 seconds
-                            # 15 times. This generally manages to wake my car if
-                            # it's returning 'asleep' state, but I don't think
-                            # there is any reason for 5 seconds and 15 attempts.
-                            # The car did wake in two tests with that timing,
-                            # but on the third test, it had not entered online
-                            # mode by the 15th wake_up and took another 10+
-                            # seconds to come online. In general, I hear relays
-                            # in the car clicking a few seconds after the first
-                            # wake_up but the car does not enter 'waking' or
-                            # 'online' state for a random period of time. I've
-                            # seen it take over one minute, 20 sec.
-                            #
-                            # I interpret this to mean a car in 'asleep' mode is
-                            # still receiving car API messages and will start
-                            # to wake after the first wake_up, but it may take
-                            # awhile to finish waking up. Therefore, we try
-                            # waking every 30 seconds for the first 10 mins.
-                            vehicle.delayNextWakeAttempt = 30;
-                        elif(now - vehicle.firstWakeAttemptTime <= 70*60):
-                            # Cars in 'asleep' state should wake within a
-                            # couple minutes in my experience, so we should
-                            # never reach this point. If we do, try every 5
-                            # minutes for the next hour.
-                            vehicle.delayNextWakeAttempt = 5*60;
-                        else:
-                            # Car hasn't woken for an hour and 10 mins. Try
-                            # again in 15 minutes. We'll show an error about
-                            # reaching this point later.
-                            vehicle.delayNextWakeAttempt = 15*60;
-                    elif(state == 'offline'):
-                        if(now - vehicle.firstWakeAttemptTime <= 31*60):
-                            # A car in offline state is presumably not connected
-                            # wirelessly so our wake_up command will not reach
-                            # it. Instead, the car wakes itself every 20-30
-                            # minutes and waits some period of time for a
-                            # message, then goes back to sleep. I'm not sure
-                            # what the period of time is, so I tried sending
-                            # wake_up every 55 seconds for 16 minutes but the
-                            # car failed to wake.
-                            # Next I tried once every 25 seconds for 31 mins.
-                            # This worked after 19.5 and 19.75 minutes in 2
-                            # tests but I can't be sure the car stays awake for
-                            # 30secs or if I just happened to send a command
-                            # during a shorter period of wakefulness.
-                            vehicle.delayNextWakeAttempt = 25;
-
-                            # I've run tests sending wake_up every 10-30 mins to
-                            # a car in offline state and it will go hours
-                            # without waking unless you're lucky enough to hit
-                            # it in the brief time it's waiting for wireless
-                            # commands. I assume cars only enter offline state
-                            # when set to max power saving mode, and even then,
-                            # they don't always enter the state even after 8
-                            # hours of no API contact or other interaction. I've
-                            # seen it remain in 'asleep' state when contacted
-                            # after 16.5 hours, but I also think I've seen it in
-                            # offline state after less than 16 hours, so I'm not
-                            # sure what the rules are or if maybe Tesla contacts
-                            # the car periodically which resets the offline
-                            # countdown.
-                            #
-                            # I've also seen it enter 'offline' state a few
-                            # minutes after finishing charging, then go 'online'
-                            # on the third retry every 55 seconds.  I suspect
-                            # that might be a case of the car briefly losing
-                            # wireless connection rather than actually going
-                            # into a deep sleep.
-                            # 'offline' may happen almost immediately if you
-                            # don't have the charger plugged in.
-                    else:
-                        # Handle 'error' state.
-                        if(now - vehicle.firstWakeAttemptTime <= 60*60):
-                            # We've tried to wake the car for less than an
-                            # hour.
-                            foundKnownError = False
-                            if('error' in apiResponseDict):
-                                error = apiResponseDict['error']
-                                for knownError in self.getCarApiTransientErrors():
-                                    if(knownError == error[0:len(knownError)]):
-                                        foundKnownError = True
-                                        break
-
-                            if(foundKnownError):
-                                # I see these errors often enough that I think
-                                # it's worth re-trying in 1 minute rather than
-                                # waiting 5 minutes for retry in the standard
-                                # error handler.
-                                vehicle.delayNextWakeAttempt = 60;
-                            else:
-                                # by the API servers being down, car being out of
-                                # range, or by something I can't anticipate. Try
-                                # waking the car every 5 mins.
-                                vehicle.delayNextWakeAttempt = 5*60;
-                        else:
-                            # Car hasn't woken for over an hour. Try again
-                            # in 15 minutes. We'll show an error about this
-                            # later.
-                            vehicle.delayNextWakeAttempt = 15*60;
-
-                    if(state == 'error'):
-                        self.master.debugLog(1, "TeslaAPI  ", "Car API wake car failed with unknown response.  " + "Will try again in " + str(vehicle.delayNextWakeAttempt) + " seconds.")
-                    else:
-                        self.master.debugLog(1, "TeslaAPI  ", "Car API wake car failed.  State remains: '"
-                                + state + "'.  Will try again in "
-                                + str(vehicle.delayNextWakeAttempt) + " seconds.")
-
-                if(vehicle.firstWakeAttemptTime > 0
-                   and now - vehicle.firstWakeAttemptTime > 60*60):
-                    # It should never take over an hour to wake a car.  If it
-                    # does, ask user to report an error.
-                    self.master.debugLog(1, "TeslaAPI  ", "ERROR: We have failed to wake a car from '"
-                        + state + "' state for %.1f hours.\n" \
-                          "Please private message user CDragon at " \
-                          "http://teslamotorsclub.com with a copy of this error. " \
-                          "Also include this: %s" % (
-                          ((now - vehicle.firstWakeAttemptTime) / 60 / 60),
-                          str(apiResponseDict)))
-
-    if(now - self.getCarApiLastErrorTime() < (self.getCarApiErrorRetryMins()*60) or self.getCarApiBearerToken() == ''):
-        self.master.debugLog(8, "TeslaAPI  ", "car_api_available returning False because of recent carApiLasterrorTime "
-                + str(now - self.getCarApiLastErrorTime()) + " or empty carApiBearerToken '"
-                + self.getCarApiBearerToken() + "'")
-        return False
-
-    # We return True to indicate there was no error that prevents running
-    # car API commands and that we successfully got a list of vehicles.
-    # True does not indicate that any vehicle is actually awake and ready
-    # for commands.
-    self.master.debugLog(8, "TeslaAPI  ", "car_api_available returning True")
-
-    if(needSleep):
-        # If you send charge_start/stop less than 1 second after calling
-        # update_location(), the charge command usually returns:
-        #   {'response': {'result': False, 'reason': 'could_not_wake_buses'}}
-        # I'm not sure if the same problem exists when sending commands too
-        # quickly after we send wake_up.  I haven't seen a problem sending a
-        # command immediately, but it seems safest to sleep 5 seconds after
-        # waking before sending a command.
-        self.time.sleep(5);
-
-    return True
-
-  def is_location_home(self, lat, lon):
-
-    if(self.master.getHomeLatLon()[0] == 10000):
-        self.master.debugLog(1, "TeslaAPI  ", "Home location for vehicles has never been set.  " +
-                "We'll assume home is where we found the first vehicle currently parked.  " +
-                "Home set to lat=" + str(lat) + ", lon=" +
-                str(lon))
-        self.master.setHomeLat(lat)
-        self.master.setHomeLon(lon)
-        self.master.saveSettings()
-        return True
-
-    # 1 lat or lon = ~364488.888 feet. The exact feet is different depending
-    # on the value of latitude, but this value should be close enough for
-    # our rough needs.
-    # 1/364488.888 * 10560 = 0.0289.
-    # So if vehicle is within 0289 lat and lon of homeLat/Lon,
-    # it's within ~10560 feet (2 miles) of home and we'll consider it to be
-    # at home.
-    # I originally tried using 0.00548 (~2000 feet) but one night the car
-    # consistently reported being 2839 feet away from home despite being
-    # parked in the exact spot I always park it.  This is very odd because
-    # GPS is supposed to be accurate to within 12 feet.  Tesla phone app
-    # also reports the car is not at its usual address.  I suspect this
-    # is another case of a bug that's been causing car GPS to freeze  the
-    # last couple months.
-    if(abs(self.master.getHomeLatLon()[0] - lat) > 0.0289
-       or abs(self.master.getHomeLatLon()[1] - lon) > 0.0289):
-        return False
-
-    return True
-
-  def car_api_charge(self, charge):
-    # Do not call this function directly.  Call by using background thread:
-    # queue_background_task({'cmd':'charge', 'charge':<True/False>})
-
-    now = self.time.time()
-    apiResponseDict = {}
-    if(not charge):
-        # Whenever we are going to tell vehicles to stop charging, set
-        # vehicle.stopAskingToStartCharging = False on all vehicles.
-        for vehicle in self.getCarApiVehicles():
-            vehicle.stopAskingToStartCharging = False
-
-    if(now - self.getLastStartOrStopChargeTime() < 60):
-        # Don't start or stop more often than once a minute
-        self.master.debugLog(11, "TeslaAPI  ", 'car_api_charge return because under 60 sec since last carApiLastStartOrStopChargeTime')
-        return 'error'
-
-    if(self.car_api_available(charge = charge) == False):
-        self.master.debugLog(8, "TeslaAPI  ", 'car_api_charge return because car_api_available() == False')
-        return 'error'
-
-    startOrStop = 'start' if charge else 'stop'
-    result = 'success'
-    self.master.debugLog(8, "TeslaAPI  ", "startOrStop is set to " + str(startOrStop))
-
-    for vehicle in self.getCarApiVehicles():
-        if(charge and vehicle.stopAskingToStartCharging):
-            self.master.debugLog(8, "TeslaAPI  ", "Don't charge " + vehicle.name
-                      + " because vehicle.stopAskingToStartCharging == True")
-            continue
-
-        if(vehicle.ready(wake = charge) == False):
-            continue
-
-        if(vehicle.update_charge(wake = False) and vehicle.batteryLevel < self.minChargeLevel ):
-            # If the vehicle's charge state is lower than the configured minimum,
-            #   don't stop it from charging, even if we'd otherwise not charge.
-            continue
-
-        # Only update carApiLastStartOrStopChargeTime if car_api_available() managed
-        # to wake cars.  Setting this prevents any command below from being sent
-        # more than once per minute.
-        self.updateLastStartOrStopChargeTime()
-
-        if(self.config['config']['onlyChargeMultiCarsAtHome'] and self.getVehicleCount() > 1):
-            # When multiple cars are enrolled in the car API, only start/stop
-            # charging cars parked at home.
-
-            if(vehicle.update_location() == False):
-                result = 'error'
-                continue
-
-            if(not vehicle.atHome):
-                # Vehicle is not at home, so don't change its charge state.
-                self.master.debugLog(1, "TeslaAPI  ", vehicle.name +
-                          ' is not at home.  Do not ' + startOrStop + ' charge.')
-                continue
-
-            # If you send charge_start/stop less than 1 second after calling
-            # update_location(), the charge command usually returns:
-            #   {'response': {'result': False, 'reason': 'could_not_wake_buses'}}
-            # Waiting 2 seconds seems to consistently avoid the error, but let's
-            # wait 5 seconds in case of hardware differences between cars.
-            time.sleep(5)
-
-        url = "https://owner-api.teslamotors.com/api/1/vehicles/"
-        url = url + str(vehicle.ID) + "/command/charge_" + startOrStop
-        headers = {
-          'accept': 'application/json',
-          'Authorization': 'Bearer ' + self.getCarApiBearerToken()
-        }
-
-        # Retry up to 3 times on certain errors.
-        for retryCount in range(0, 3):
-            try:
-                req = self.requests.post(url, headers = headers)
-                self.master.debugLog(8, "TeslaAPI  ", 'Car API cmd' + str(req))
-                apiResponseDict = self.json.loads(req.text)
-            except:
-                pass
-
-            try:
-                self.master.debugLog(4, "TeslaAPI  ", vehicle.name + ": " + startOrStop + ' charge response' + str(apiResponseDict))
-                # Responses I've seen in apiResponseDict:
-                # Car is done charging:
-                #   {'response': {'result': False, 'reason': 'complete'}}
-                # Car wants to charge but may not actually be charging. Oddly, this
-                # is the state reported when car is not plugged in to a charger!
-                # It's also reported when plugged in but charger is not offering
-                # power or even when the car is in an error state and refuses to
-                # charge.
-                #   {'response': {'result': False, 'reason': 'charging'}}
-                # Car not reachable:
-                #   {'response': None, 'error_description': '', 'error': 'vehicle unavailable: {:error=>"vehicle unavailable:"}'}
-                # This weird error seems to happen randomly and re-trying a few
-                # seconds later often succeeds:
-                #   {'response': {'result': False, 'reason': 'could_not_wake_buses'}}
-                # I've seen this a few times on wake_up, charge_start, and drive_state:
-                #   {'error': 'upstream internal error', 'response': None, 'error_description': ''}
-                # I've seen this once on wake_up:
-                #   {'error': 'operation_timedout for txid `4853e3ad74de12733f8cc957c9f60040`}', 'response': None, 'error_description': ''}
-                # Start or stop charging success:
-                #   {'response': {'result': True, 'reason': ''}}
-                if(apiResponseDict['response'] == None):
-                    if('error' in apiResponseDict):
-                        foundKnownError = False
-                        error = apiResponseDict['error']
-                        for knownError in self.getCarApiTransientErrors():
-                            if(knownError == error[0:len(knownError)]):
-                                # I see these errors often enough that I think
-                                # it's worth re-trying in 1 minute rather than
-                                # waiting carApiErrorRetryMins minutes for retry
-                                # in the standard error handler.
-                                self.master.debugLog(1, "TeslaAPI  ", "Car API returned '"
-                                          + error
-                                          + "' when trying to start charging.  Try again in 1 minute.")
-                                time.sleep(60)
-                                foundKnownError = True
-                                break
-                        if(foundKnownError):
-                            continue
-
-                    # This generally indicates a significant error like 'vehicle
-                    # unavailable', but it's not something I think the caller can do
-                    # anything about, so return generic 'error'.
-                    result = 'error'
-                    # Don't send another command to this vehicle for
-                    # carApiErrorRetryMins mins.
+                    # This catches cases like trying to access
+                    # apiResponseDict['response'] when 'response' doesn't exist in
+                    # apiResponseDict.
+                    self.master.debugLog(
+                        1,
+                        "TeslaAPI  ",
+                        "ERROR: Failed to "
+                        + startOrStop
+                        + " car charging via Tesla car API.  Will try again later.",
+                    )
                     vehicle.lastErrorTime = now
-                elif(apiResponseDict['response']['result'] == False):
-                    if(charge):
-                        reason = apiResponseDict['response']['reason']
-                        if(reason == 'complete' or reason == 'charging'):
-                            # We asked the car to charge, but it responded that
-                            # it can't, either because it's reached target
-                            # charge state (reason == 'complete'), or it's
-                            # already trying to charge (reason == 'charging').
-                            # In these cases, it won't help to keep asking it to
-                            # charge, so set vehicle.stopAskingToStartCharging =
-                            # True.
-                            #
-                            # Remember, this only means at least one car in the
-                            # list wants us to stop asking and we don't know
-                            # which car in the list is connected to our TWC.
-                            self.master.debugLog(1, "TeslaAPI  ", vehicle.name
-                                      + ' is done charging or already trying to charge.  Stop asking to start charging.')
-                            vehicle.stopAskingToStartCharging = True
-                        else:
-                            # Car was unable to charge for some other reason, such
-                            # as 'could_not_wake_buses'.
-                            if(reason == 'could_not_wake_buses'):
-                                # This error often happens if you call
-                                # charge_start too quickly after another command
-                                # like drive_state. Even if you delay 5 seconds
-                                # between the commands, this error still comes
-                                # up occasionally. Retrying often succeeds, so
-                                # wait 5 secs and retry.
-                                # If all retries fail, we'll try again in a
-                                # minute because we set
-                                # carApiLastStartOrStopChargeTime = now earlier.
-                                time.sleep(5)
-                                continue
-                            else:
-                                # Start or stop charge failed with an error I
-                                # haven't seen before, so wait
-                                # carApiErrorRetryMins mins before trying again.
-                                self.master.debugLog(1, "TeslaAPI  ", 'ERROR "' + reason + '" when trying to ' +
-                                      startOrStop + ' car charging via Tesla car API.  Will try again later.' +
-                                      "\nIf this error persists, please private message user CDragon at http://teslamotorsclub.com with a copy of this error.")
-                                result = 'error'
-                                vehicle.lastErrorTime = now
+                break
 
-            except (KeyError, TypeError):
-                # This catches cases like trying to access
-                # apiResponseDict['response'] when 'response' doesn't exist in
-                # apiResponseDict.
-                self.master.debugLog(1, "TeslaAPI  ", 'ERROR: Failed to ' + startOrStop
-                      + ' car charging via Tesla car API.  Will try again later.')
-                vehicle.lastErrorTime = now
-            break
+        if (
+            self.config["config"]["debugLevel"] >= 1
+            and self.getLastStartOrStopChargeTime() == now
+        ):
+            print(time_now() + ": Car API " + startOrStop + " charge result: " + result)
 
-    if(self.config['config']['debugLevel'] >= 1 and self.getLastStartOrStopChargeTime() == now):
-        print(time_now() + ': Car API ' + startOrStop + ' charge result: ' + result)
+        return result
 
-    return result
+    def applyChargeLimit(self, limit, checkArrival=False, checkDeparture=False):
 
-  def applyChargeLimit(self, limit, checkArrival=False, checkDeparture=False):
+        if self.car_api_available() == False:
+            self.master.debugLog(
+                8,
+                "TeslaAPI  ",
+                "applyChargeLimit return because car_api_available() == False",
+            )
+            return "error"
 
-    if(self.car_api_available() == False):
-        self.master.debugLog(8, "TeslaAPI  ", 'applyChargeLimit return because car_api_available() == False')
-        return 'error'
+        now = self.time.time()
+        if (
+            not checkArrival
+            and not checkDeparture
+            and now - self.carApiLastChargeLimitApplyTime < 60
+        ):
+            # Don't change limits more often than once a minute
+            self.master.debugLog(
+                11,
+                "TeslaAPI  ",
+                "applyChargeLimit return because under 60 sec since last carApiLastChargeLimitApplyTime",
+            )
+            return "error"
 
-    now = self.time.time()
-    if( not checkArrival and not checkDeparture and
-        now - self.carApiLastChargeLimitApplyTime < 60):
-        # Don't change limits more often than once a minute
-        self.master.debugLog(11, "TeslaAPI  ", 'applyChargeLimit return because under 60 sec since last carApiLastChargeLimitApplyTime')
-        return 'error'
+        # We need to try to apply limits if:
+        #   - We think the car is at home and the limit has changed
+        #   - We think the car is at home and we've been asked to check for departures
+        #   - We think the car is at home and we notice it gone
+        #   - We think the car is away from home and we've been asked to check for arrivals
+        #
+        # We do NOT opportunistically check for arrivals, because that would be a
+        # continuous API poll.
+        for vehicle in self.carApiVehicles:
+            (wasAtHome, outside, lastApplied) = self.master.getNormalChargeLimit(
+                vehicle.ID
+            )
+            if (
+                wasAtHome
+                and (
+                    limit != lastApplied
+                    or checkDeparture
+                    or (vehicle.update_location(wake=False) and not vehicle.atHome)
+                )
+            ) or (not wasAtHome and checkArrival):
+                vehicle.stopTryingToApplyLimit = False
 
-    # We need to try to apply limits if:
-    #   - We think the car is at home and the limit has changed
-    #   - We think the car is at home and we've been asked to check for departures
-    #   - We think the car is at home and we notice it gone
-    #   - We think the car is away from home and we've been asked to check for arrivals
-    #
-    # We do NOT opportunistically check for arrivals, because that would be a
-    # continuous API poll.
-    for vehicle in self.carApiVehicles:
-        (wasAtHome, outside, lastApplied) = self.master.getNormalChargeLimit(vehicle.ID)
-        if((wasAtHome and (
-                limit != lastApplied or
-                checkDeparture or
-                (vehicle.update_location(wake=False) and not vehicle.atHome))) or
-            (not wasAtHome and checkArrival)):
-            vehicle.stopTryingToApplyLimit = False
+        if self.car_api_available(applyLimit=True) == False:
+            self.master.debugLog(
+                8,
+                "TeslaAPI  ",
+                "applyChargeLimit return because car_api_available() == False",
+            )
+            return "error"
 
-    if(self.car_api_available(applyLimit = True) == False):
-        self.master.debugLog(8, "TeslaAPI  ", 'applyChargeLimit return because car_api_available() == False')
-        return 'error'
-
-    if self.lastChargeLimitApplied != limit:
-        if limit != -1:
-            self.master.debugLog(2, "TeslaAPI  ", 'Attempting to apply limit of ' + str(limit) + '% to all vehicles at home')
-        else:
-            self.master.debugLog(2, "TeslaAPI  ", 'Attempting to restore charge limits for all vehicles at home')
-        self.lastChargeLimitApplied = limit
-
-    self.carApiLastChargeLimitApplyTime = now
-
-    for vehicle in self.carApiVehicles:
-        if( vehicle.stopTryingToApplyLimit or not vehicle.ready() ):
-            continue
-
-        located = vehicle.update_location()
-        (wasAtHome, outside, lastApplied) = self.master.getNormalChargeLimit(vehicle.ID)
-        forgetVehicle = False
-        if( not vehicle.update_charge() ):
-            # We failed to read the "normal" limit; don't risk changing it.
-            continue
-
-        if( not wasAtHome and located and vehicle.atHome ):
-            self.master.debugLog(2, "TeslaAPI  ", vehicle.name + ' has arrived')
-            outside = vehicle.chargeLimit
-        elif( wasAtHome and located and not vehicle.atHome ):
-            self.master.debugLog(2, "TeslaAPI  ", vehicle.name + ' has departed')
-            forgetVehicle = True
-
-        if( limit == -1 or (located and not vehicle.atHome) ):
-            # We're removing any applied limit, provided it hasn't been manually changed
-            if(wasAtHome and vehicle.chargeLimit == lastApplied):
-                if( vehicle.apply_charge_limit(outside) ):
-                    self.master.debugLog(2, "TeslaAPI  ", 'Restoring ' + vehicle.name + ' to charge limit ' + str(outside) + '%')
-                    vehicle.stopTryingToApplyLimit = True
-                    if( forgetVehicle ):
-                        self.master.removeNormalChargeLimit(vehicle.ID)
+        if self.lastChargeLimitApplied != limit:
+            if limit != -1:
+                self.master.debugLog(
+                    2,
+                    "TeslaAPI  ",
+                    "Attempting to apply limit of "
+                    + str(limit)
+                    + "% to all vehicles at home",
+                )
             else:
-                vehicle.stopTryingToApplyLimit = True
-        else:
-            if vehicle.chargeLimit != limit:
-                if( vehicle.apply_charge_limit(limit) ):
-                    self.master.debugLog(2, "TeslaAPI  ", 'Set ' + vehicle.name + ' to charge limit of ' + str(limit) + '%')
+                self.master.debugLog(
+                    2,
+                    "TeslaAPI  ",
+                    "Attempting to restore charge limits for all vehicles at home",
+                )
+            self.lastChargeLimitApplied = limit
+
+        self.carApiLastChargeLimitApplyTime = now
+
+        for vehicle in self.carApiVehicles:
+            if vehicle.stopTryingToApplyLimit or not vehicle.ready():
+                continue
+
+            located = vehicle.update_location()
+            (wasAtHome, outside, lastApplied) = self.master.getNormalChargeLimit(
+                vehicle.ID
+            )
+            forgetVehicle = False
+            if not vehicle.update_charge():
+                # We failed to read the "normal" limit; don't risk changing it.
+                continue
+
+            if not wasAtHome and located and vehicle.atHome:
+                self.master.debugLog(2, "TeslaAPI  ", vehicle.name + " has arrived")
+                outside = vehicle.chargeLimit
+            elif wasAtHome and located and not vehicle.atHome:
+                self.master.debugLog(2, "TeslaAPI  ", vehicle.name + " has departed")
+                forgetVehicle = True
+
+            if limit == -1 or (located and not vehicle.atHome):
+                # We're removing any applied limit, provided it hasn't been manually changed
+                if wasAtHome and vehicle.chargeLimit == lastApplied:
+                    if vehicle.apply_charge_limit(outside):
+                        self.master.debugLog(
+                            2,
+                            "TeslaAPI  ",
+                            "Restoring "
+                            + vehicle.name
+                            + " to charge limit "
+                            + str(outside)
+                            + "%",
+                        )
+                        vehicle.stopTryingToApplyLimit = True
+                        if forgetVehicle:
+                            self.master.removeNormalChargeLimit(vehicle.ID)
+                else:
+                    vehicle.stopTryingToApplyLimit = True
+            else:
+                if vehicle.chargeLimit != limit:
+                    if vehicle.apply_charge_limit(limit):
+                        self.master.debugLog(
+                            2,
+                            "TeslaAPI  ",
+                            "Set "
+                            + vehicle.name
+                            + " to charge limit of "
+                            + str(limit)
+                            + "%",
+                        )
+                        vehicle.stopTryingToApplyLimit = True
+                        self.master.saveNormalChargeLimit(vehicle.ID, outside, limit)
+                else:
                     vehicle.stopTryingToApplyLimit = True
                     self.master.saveNormalChargeLimit(vehicle.ID, outside, limit)
+
+        if checkArrival:
+            self.updateChargeAtHome()
+
+    def getCarApiBearerToken(self):
+        return self.carApiBearerToken
+
+    def getCarApiErrorRetryMins(self):
+        return self.carApiErrorRetryMins
+
+    def getCarApiLastErrorTime(self):
+        return self.carApiLastErrorTime
+
+    def getCarApiRefreshToken(self):
+        return self.carApiRefreshToken
+
+    def getCarApiRetryRemaining(self, vehicleLast=0):
+        # Calculate the amount of time remaining until the API can be queried
+        # again. This is the api backoff time minus the difference between now
+        # and the last error time
+
+        # The optional vehicleLast parameter allows passing the last error time
+        # for an individual vehicle, rather than the entire API.
+        lastError = self.getCarApiLastErrorTime()
+        if vehicleLast > 0:
+            lastError = vehicleLast
+
+        if lastError == 0:
+            return 0
+        else:
+            backoff = self.getCarApiErrorRetryMins() * 60
+            lasterrortime = self.time.time() - lastError
+            if lasterrortime >= backoff:
+                return 0
             else:
-                vehicle.stopTryingToApplyLimit = True
-                self.master.saveNormalChargeLimit(vehicle.ID, outside, limit)
+                self.master.debugLog(
+                    11,
+                    "TeslaAPI  ",
+                    "Backoff is "
+                    + str(backoff)
+                    + ", lasterror delta is "
+                    + str(lasterrortime)
+                    + ", last error was "
+                    + str(lastError),
+                )
+                return int(backoff - lasterrortime)
 
-    if checkArrival:
-        self.updateChargeAtHome()
+    def getCarApiTransientErrors(self):
+        return self.carApiTransientErrors
 
-  def getCarApiBearerToken(self):
-    return self.carApiBearerToken
+    def getCarApiTokenExpireTime(self):
+        return self.carApiTokenExpireTime
 
-  def getCarApiErrorRetryMins(self):
-    return self.carApiErrorRetryMins
+    def getLastStartOrStopChargeTime(self):
+        return int(self.carApiLastStartOrStopChargeTime)
 
-  def getCarApiLastErrorTime(self):
-    return self.carApiLastErrorTime
+    def getVehicleCount(self):
+        # Returns the number of currently tracked vehicles
+        return int(len(self.carApiVehicles))
 
-  def getCarApiRefreshToken(self):
-    return self.carApiRefreshToken
+    def getCarApiVehicles(self):
+        return self.carApiVehicles
 
-  def getCarApiRetryRemaining(self, vehicleLast = 0):
-    # Calculate the amount of time remaining until the API can be queried
-    # again. This is the api backoff time minus the difference between now
-    # and the last error time
+    def setCarApiBearerToken(self, token=None):
+        if token:
+            self.carApiBearerToken = token
+            return True
+        else:
+            return False
 
-    # The optional vehicleLast parameter allows passing the last error time
-    # for an individual vehicle, rather than the entire API.
-    lastError = self.getCarApiLastErrorTime()
-    if (vehicleLast > 0):
-      lastError = vehicleLast
+    def setCarApiErrorRetryMins(self, mins):
+        self.carApiErrorRetryMins = mins
+        return True
 
-    if (lastError == 0):
-      return 0
-    else:
-      backoff = (self.getCarApiErrorRetryMins()*60)
-      lasterrortime = (self.time.time() - lastError)
-      if (lasterrortime >= backoff):
-        return 0
-      else:
-        self.master.debugLog(11, "TeslaAPI  ", "Backoff is " + str(backoff) + ", lasterror delta is " + str(lasterrortime) + ", last error was " + str(lastError))
-        return int(backoff - lasterrortime)
+    def setCarApiLastErrorTime(self, tstamp):
+        self.carApiLastErrorTime = tstamp
+        return True
 
-  def getCarApiTransientErrors(self):
-    return self.carApiTransientErrors
+    def setCarApiRefreshToken(self, token):
+        self.carApiRefreshToken = token
+        return True
 
-  def getCarApiTokenExpireTime(self):
-    return self.carApiTokenExpireTime
+    def setCarApiTokenExpireTime(self, value):
+        self.carApiTokenExpireTime = value
+        return True
 
-  def getLastStartOrStopChargeTime(self):
-    return int(self.carApiLastStartOrStopChargeTime)
+    def updateCarApiLastErrorTime(self):
+        timestamp = self.time.time()
+        self.master.debugLog(
+            8,
+            "TeslaAPI  ",
+            "updateCarApiLastErrorTime() called due to Tesla API Error. Updating timestamp from "
+            + str(self.carApiLastErrorTime)
+            + " to "
+            + str(timestamp),
+        )
+        self.carApiLastErrorTime = timestamp
+        return True
 
-  def getVehicleCount(self):
-    # Returns the number of currently tracked vehicles
-    return int(len(self.carApiVehicles))
+    def updateLastStartOrStopChargeTime(self):
+        self.carApiLastStartOrStopChargeTime = self.time.time()
+        return True
 
-  def getCarApiVehicles(self):
-    return self.carApiVehicles
+    def updateChargeAtHome(self):
+        for car in self.carApiVehicles:
+            if car.atHome:
+                car.update_charge(wake=False)
+        self.lastChargeCheck = self.time.time()
 
-  def setCarApiBearerToken(self, token=None):
-    if token:
-      self.carApiBearerToken = token
-      return True
-    else:
-      return False
+    @property
+    def numCarsAtHome(self):
+        return len([car for car in self.carApiVehicles if car.atHome])
 
-  def setCarApiErrorRetryMins(self, mins):
-    self.carApiErrorRetryMins = mins
-    return True
+    @property
+    def minBatteryLevelAtHome(self):
+        if self.time.time() - self.lastChargeCheck > self.chargeUpdateInterval:
+            self.updateChargeAtHome()
+        return min(
+            [car.batteryLevel for car in self.carApiVehicles if car.atHome],
+            default=10000,
+        )
 
-  def setCarApiLastErrorTime(self, tstamp):
-    self.carApiLastErrorTime = tstamp
-    return True
-
-  def setCarApiRefreshToken(self, token):
-    self.carApiRefreshToken = token
-    return True
-
-  def setCarApiTokenExpireTime(self, value):
-    self.carApiTokenExpireTime = value
-    return True
-
-  def updateCarApiLastErrorTime(self):
-    timestamp = self.time.time()
-    self.master.debugLog(8, "TeslaAPI  ", "updateCarApiLastErrorTime() called due to Tesla API Error. Updating timestamp from " + str(self.carApiLastErrorTime) + " to " + str(timestamp))
-    self.carApiLastErrorTime = timestamp
-    return True
-
-  def updateLastStartOrStopChargeTime(self):
-    self.carApiLastStartOrStopChargeTime = self.time.time()
-    return True
-
-  def updateChargeAtHome(self):
-    for car in self.carApiVehicles:
-        if car.atHome:
-            car.update_charge(wake=False)
-    self.lastChargeCheck = self.time.time()
-
-  @property
-  def numCarsAtHome(self):
-      return len([car for car in self.carApiVehicles if car.atHome])
-
-  @property
-  def minBatteryLevelAtHome(self):
-      if self.time.time() - self.lastChargeCheck > self.chargeUpdateInterval:
-          self.updateChargeAtHome()
-      return min(
-          [car.batteryLevel for car in self.carApiVehicles if car.atHome],
-          default=10000
-      )
 
 class CarApiVehicle:
 
@@ -808,11 +1038,11 @@ class CarApiVehicle:
     import requests
     import json
 
-    carapi     = None
-    config     = None
+    carapi = None
+    config = None
     debuglevel = 0
-    ID         = None
-    name       = ''
+    ID = None
+    name = ""
 
     firstWakeAttemptTime = 0
     lastWakeAttemptTime = 0
@@ -826,30 +1056,35 @@ class CarApiVehicle:
     stopTryingToApplyLimit = False
 
     batteryLevel = 10000
-    chargeLimit  = -1
+    chargeLimit = -1
     lat = 10000
     lon = 10000
     atHome = False
 
     def __init__(self, json, carapi, config):
-        self.carapi     = carapi
-        self.config     = config
-        self.debugLevel = config['config']['debugLevel']
-        self.ID         = json['id']
-        self.name       = json['display_name']
+        self.carapi = carapi
+        self.config = config
+        self.debugLevel = config["config"]["debugLevel"]
+        self.ID = json["id"]
+        self.name = json["display_name"]
 
     def ready(self, wake=True):
-        if(self.carapi.getCarApiRetryRemaining(self.lastErrorTime)):
+        if self.carapi.getCarApiRetryRemaining(self.lastErrorTime):
             # It's been under carApiErrorRetryMins minutes since the car API
             # generated an error on this vehicle. Return that car is not ready.
-            self.master.debugLog(8, "TeslaAPI  ", self.name
-                    + ' not ready because of recent lastErrorTime '
-                    + str(self.lastErrorTime))
+            self.master.debugLog(
+                8,
+                "TeslaAPI  ",
+                self.name
+                + " not ready because of recent lastErrorTime "
+                + str(self.lastErrorTime),
+            )
             return False
 
-        if(wake == False or
-           (self.firstWakeAttemptTime == 0 and
-            self.time.time() - self.lastWakeAttemptTime < 2*60)):
+        if wake == False or (
+            self.firstWakeAttemptTime == 0
+            and self.time.time() - self.lastWakeAttemptTime < 2 * 60
+        ):
             # If we need to wake the car, it's been
             # less than 2 minutes since we successfully woke this car, so it
             # should still be awake.  Tests on my car in energy saver mode show
@@ -857,25 +1092,29 @@ class CarApiVehicle:
             # was issued.  Times I've tested: 1:35, 1:57, 2:30
             return True
 
-        self.carapi.master.debugLog(8, "TeslaVehic", self.name + " not ready because it wasn't woken in the last 2 minutes.")
+        self.carapi.master.debugLog(
+            8,
+            "TeslaVehic",
+            self.name + " not ready because it wasn't woken in the last 2 minutes.",
+        )
         return False
 
     def get_car_api(self, url, wake=True):
-        if(self.ready(wake) == False):
+        if self.ready(wake) == False:
             return (False, None)
 
         apiResponseDict = {}
 
         headers = {
-          'accept': 'application/json',
-          'Authorization': 'Bearer ' + self.carapi.getCarApiBearerToken()
+            "accept": "application/json",
+            "Authorization": "Bearer " + self.carapi.getCarApiBearerToken(),
         }
 
         # Retry up to 3 times on certain errors.
         for retryCount in range(0, 3):
             try:
-                req = self.requests.get(url, headers = headers)
-                self.carapi.master.debugLog(8, "TeslaVehic", 'Car API cmd' + str(req))
+                req = self.requests.get(url, headers=headers)
+                self.carapi.master.debugLog(8, "TeslaVehic", "Car API cmd" + str(req))
                 apiResponseDict = self.json.loads(req.text)
                 # This error can happen here as well:
                 #   {'response': {'reason': 'could_not_wake_buses', 'result': False}}
@@ -885,36 +1124,46 @@ class CarApiVehicle:
                 pass
 
             try:
-                self.carapi.master.debugLog(10, "TeslaVehic", 'Car API vehicle status' + str(apiResponseDict))
+                self.carapi.master.debugLog(
+                    10, "TeslaVehic", "Car API vehicle status" + str(apiResponseDict)
+                )
 
-                if('error' in apiResponseDict):
+                if "error" in apiResponseDict:
                     foundKnownError = False
-                    error = apiResponseDict['error']
+                    error = apiResponseDict["error"]
 
                     # If we opted not to wake the vehicle, unavailable is expected.
                     # Don't keep trying if that happens.
-                    unavailable = 'vehicle unavailable'
-                    if(wake == False and unavailable == error[0:len(unavailable)]):
+                    unavailable = "vehicle unavailable"
+                    if wake == False and unavailable == error[0 : len(unavailable)]:
                         return (False, None)
                     for knownError in self.carapi.getCarApiTransientErrors():
-                        if(knownError == error[0:len(knownError)]):
+                        if knownError == error[0 : len(knownError)]:
                             # I see these errors often enough that I think
                             # it's worth re-trying in 1 minute rather than
                             # waiting carApiErrorRetryMins minutes for retry
                             # in the standard error handler.
-                            self.carapi.master.debugLog(1, "TeslaVehic", "Car API returned '" + error
-                                      + "' when trying to get status.  Try again in 1 minute.")
+                            self.carapi.master.debugLog(
+                                1,
+                                "TeslaVehic",
+                                "Car API returned '"
+                                + error
+                                + "' when trying to get status.  Try again in 1 minute.",
+                            )
                             self.time.sleep(60)
                             foundKnownError = True
                             break
-                    if(foundKnownError):
+                    if foundKnownError:
                         continue
 
-                response = apiResponseDict['response']
+                response = apiResponseDict["response"]
 
                 # A successful call to drive_state will not contain a
                 # response['reason'], so we check if the 'reason' key exists.
-                if('reason' in response and response['reason'] == 'could_not_wake_buses'):
+                if (
+                    "reason" in response
+                    and response["reason"] == "could_not_wake_buses"
+                ):
                     # Retry after 5 seconds.  See notes in car_api_charge where
                     # 'could_not_wake_buses' is handled.
                     self.time.sleep(5)
@@ -923,8 +1172,13 @@ class CarApiVehicle:
                 # This catches cases like trying to access
                 # apiResponseDict['response'] when 'response' doesn't exist in
                 # apiResponseDict.
-                self.carapi.master.debugLog(1, "TeslaVehic", "ERROR: Can't access vehicle status for " + self.name + \
-                          ".  Will try again later.")
+                self.carapi.master.debugLog(
+                    1,
+                    "TeslaVehic",
+                    "ERROR: Can't access vehicle status for "
+                    + self.name
+                    + ".  Will try again later.",
+                )
                 self.lastErrorTime = self.time.time()
                 return (False, None)
 
@@ -937,48 +1191,50 @@ class CarApiVehicle:
 
         now = self.time.time()
 
-        if (now - self.lastDriveStatusTime < (60 if wake else 3600)):
+        if now - self.lastDriveStatusTime < (60 if wake else 3600):
             return True
 
         (result, response) = self.get_car_api(url, wake)
 
         if result:
             self.lastDriveStatusTime = self.time.time()
-            self.lat = response['latitude']
-            self.lon = response['longitude']
+            self.lat = response["latitude"]
+            self.lon = response["longitude"]
             self.atHome = self.carapi.is_location_home(self.lat, self.lon)
 
         return result
 
-    def update_charge(self, wake = True):
+    def update_charge(self, wake=True):
         url = "https://owner-api.teslamotors.com/api/1/vehicles/"
         url = url + str(self.ID) + "/data_request/charge_state"
 
         now = self.time.time()
 
-        if (now - self.lastChargeStatusTime < 60):
+        if now - self.lastChargeStatusTime < 60:
             return True
 
         (result, response) = self.get_car_api(url, wake=wake)
 
         if result:
             self.lastChargeStatusTime = self.time.time()
-            self.chargeLimit = response['charge_limit_soc']
-            self.batteryLevel = response['battery_level']
+            self.chargeLimit = response["charge_limit_soc"]
+            self.batteryLevel = response["battery_level"]
 
         return result
 
     def apply_charge_limit(self, limit):
-        if(self.stopTryingToApplyLimit):
+        if self.stopTryingToApplyLimit:
             return True
 
         now = self.time.time()
 
-        if( now - self.lastLimitAttemptTime <= 300
-            or self.carapi.getCarApiRetryRemaining(self.lastErrorTime)):
+        if (
+            now - self.lastLimitAttemptTime <= 300
+            or self.carapi.getCarApiRetryRemaining(self.lastErrorTime)
+        ):
             return False
 
-        if( self.ready() == False):
+        if self.ready() == False:
             return False
 
         self.lastLimitAttemptTime = now
@@ -987,59 +1243,60 @@ class CarApiVehicle:
         url = url + str(self.ID) + "/command/set_charge_limit"
 
         headers = {
-            'accept': 'application/json',
-            'Authorization': 'Bearer ' + self.carapi.getCarApiBearerToken()
+            "accept": "application/json",
+            "Authorization": "Bearer " + self.carapi.getCarApiBearerToken(),
         }
-        body = {
-            'percent': limit
-        }
+        body = {"percent": limit}
 
         for retryCount in range(0, 3):
             try:
-                req = self.requests.post(url, headers = headers, json = body)
-                self.carapi.master.debugLog(8, "TeslaVehic", 'Car API cmd' + str(req))
+                req = self.requests.post(url, headers=headers, json=body)
+                self.carapi.master.debugLog(8, "TeslaVehic", "Car API cmd" + str(req))
 
                 apiResponseDict = self.json.loads(req.text)
             except:
                 pass
 
             result = False
-            reason = ''
+            reason = ""
             try:
-                result = apiResponseDict['response']['result']
-                reason = apiResponseDict['response']['reason']
+                result = apiResponseDict["response"]["result"]
+                reason = apiResponseDict["response"]["reason"]
             except (KeyError, TypeError):
                 # This catches unexpected cases like trying to access
                 # apiResponseDict['response'] when 'response' doesn't exist
                 # in apiResponseDict.
                 result = False
 
-            if(result == True or reason == 'already_set'):
+            if result == True or reason == "already_set":
                 self.stopTryingToApplyLimit = True
                 return True
-            elif(reason == 'could_not_wake_buses'):
+            elif reason == "could_not_wake_buses":
                 time.sleep(5)
                 continue
-            elif(apiResponseDict['response'] == None):
-                if('error' in apiResponseDict):
+            elif apiResponseDict["response"] == None:
+                if "error" in apiResponseDict:
                     foundKnownError = False
-                    error = apiResponseDict['error']
+                    error = apiResponseDict["error"]
                     for knownError in self.carapi.getCarApiTransientErrors():
-                        if(knownError == error[0:len(knownError)]):
+                        if knownError == error[0 : len(knownError)]:
                             # I see these errors often enough that I think
                             # it's worth re-trying in 1 minute rather than
                             # waiting carApiErrorRetryMins minutes for retry
                             # in the standard error handler.
-                            self.carapi.master.debugLog(1, "TeslaVehic", "Car API returned '"
-                                        + error
-                                        + "' when trying to set charge limit.  Try again in 1 minute.")
+                            self.carapi.master.debugLog(
+                                1,
+                                "TeslaVehic",
+                                "Car API returned '"
+                                + error
+                                + "' when trying to set charge limit.  Try again in 1 minute.",
+                            )
                             time.sleep(60)
                             foundKnownError = True
                             break
-                    if(foundKnownError):
+                    if foundKnownError:
                         continue
             else:
                 self.lastErrorTime = now
-
 
         return False

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,26 @@
 #!/usr/bin/python3
 
 from setuptools import setup, find_namespace_packages
+
 setup(
     name="TWCManager",
     version="1.1.8",
     package_dir={"": "lib"},
     packages=find_namespace_packages(where="lib"),
-
     # Dependencies
-    install_requires = [
-      "commentjson>=0.8.3",
-      "paho_mqtt>=1.5.0",
-      "pyserial>=3.4",
-      "requests>=2.23.0",
-      "sysv_ipc>=1.0.1",
-      "termcolor>=1.1.0",
-      "ww>=0.2.1"
+    install_requires=[
+        "commentjson>=0.8.3",
+        "paho_mqtt>=1.5.0",
+        "pyserial>=3.4",
+        "requests>=2.23.0",
+        "sysv_ipc>=1.0.1",
+        "termcolor>=1.1.0",
+        "ww>=0.2.1",
     ],
-
     # Package Metadata
     author="Nathan Gardiner",
     author_email="ngardiner@gmail.com",
     description="Package to manage Tesla Wall Connector installations",
     keywords="tesla wall connector charger",
-    url="https://github.com/ngardiner/twcmanager"
+    url="https://github.com/ngardiner/twcmanager",
 )


### PR DESCRIPTION
(Already rebased on #68, so this PR doesn't read well until that is merged.)

I've noticed that on a partly cloudy day, the charging stops and starts a lot as clouds briefly drop the solar output, then it comes back when they pass.  This allows a policy to define an amount of "flex" -- a little extra current the system is allowed to draw in order to avoid stopping.  So the intended behavior is that if green energy is insufficient to charge the car, it won't wake the car to start charging, but if the car is already charging, but then solar dips, it won't stop the charge if it's only slightly below the threshold.  (If solar drops so far that the flex isn't sufficient, then it stops.)