### PR TITLE
Min to start

### DIFF
--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -403,11 +403,6 @@ class TWCSlave:
                 # more than once per minute. Once the car gets the message to
                 # stop, reportedAmpsActualSignificantChangeMonitor should drop
                 # to near zero within a few seconds.
-                # WARNING: If you own two vehicles and one is charging at home but
-                # the other is charging away from home, this command will stop
-                # them both from charging.  If the away vehicle is not currently
-                # charging, I'm not sure if this would prevent it from charging
-                # when next plugged in.
                 self.master.stopCarsCharging()
             elif (
                 self.lastAmpsOffered >= self.config["config"]["minAmpsPerTWC"]

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -410,7 +410,7 @@ class TWCSlave:
                 # when next plugged in.
                 self.master.stopCarsCharging()
             elif (
-                self.lastAmpsOffered >= 5.0
+                self.lastAmpsOffered >= self.config["config"]["minAmpsPerTWC"]
                 and self.reportedAmpsActual < 2.0
                 and self.reportedState != 0x02
             ):


### PR DESCRIPTION
I'm still trying to figure out why I keep starting and stopping so often, and I think this might be the culprit.  Because I have `minAmpsToOffer` set to 12, it looks like this like will tell the car to start charging at anything over 5A, then a minute later tell it to stop.  I think this will reduce the spurious starts, but at the very least, shouldn't hurt anything.