### PR TITLE
Policy module

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -233,7 +233,7 @@ def update_statuses():
     # Print a status update if we are on track green energy showing the
     # generation and consumption figures
     maxamps = f("{master.getMaxAmpsToDivideAmongSlaves():.2f}A")
-    if master.getModuleByName("Policy").active_policy == "Track Green Energy":
+    if master.getModuleByName("Policy").policyIsGreen():
         genwatts = f("{master.getGeneration():.0f}W")
         conwatts = f("{master.getConsumption():.0f}W")
         chgwatts = f("{master.getChargerLoad():.0f}W")

--- a/TWCManager.py
+++ b/TWCManager.py
@@ -50,6 +50,7 @@ modules_available = [
     "Interface.Dummy",
     "Interface.RS485",
     "Interface.TCP",
+    "Policy.Policy",
     "Vehicle.TeslaAPI",
     "Control.HTTPControl",
     "Control.MQTTControl",
@@ -232,7 +233,7 @@ def update_statuses():
     # Print a status update if we are on track green energy showing the
     # generation and consumption figures
     maxamps = f("{master.getMaxAmpsToDivideAmongSlaves():.2f}A")
-    if master.active_policy == "Track Green Energy":
+    if master.getModuleByName("Policy").active_policy == "Track Green Energy":
         genwatts = f("{master.getGeneration():.0f}W")
         conwatts = f("{master.getConsumption():.0f}W")
         chgwatts = f("{master.getChargerLoad():.0f}W")

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -234,10 +234,25 @@
         # Rules in the before section here are evaluated after the Charge Now rule
         "before":[
         ],
-        # Rules in the after section here are evaluted before the Unscheduled Charging
+        # Rules in the after section here are evaluated before the Unscheduled Charging
         # rule at the end of the policy.
         "after":[
-        ]
+        ],
+
+        # Rather than defining additional policies, these values place additional constraints
+        # on the built-in policies.
+        "restrictions":{
+          #"Track Green Energy":{
+          #  "match":[],
+          #  "condition":[],
+          #  "value":[]
+          #},
+          #"Charge Now":{
+            #  "match":[],
+            #  "condition":[],
+            #  "value":[]
+            #},
+        }
       },
       # NOTE: Override and Extend are mutually exclusive options. Once you override, you
       # can no longer extend the inbuilt policy.

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -2,6 +2,7 @@ import time
 from ww import f
 from termcolor import colored
 
+
 class Policy:
 
     active_policy = None
@@ -303,3 +304,18 @@ class Policy:
 
         # None of the macro conditions matched, return the value as is
         return value
+
+    def policyIsGreen(self):
+        current_policy = next(
+            policy
+            for policy in self.charge_policy
+            if policy["name"] == self.active_policy
+        )
+
+        return (
+            True
+            if current_policy.get("background_task", "") == "checkGreenEnergy"
+            and current_policy.get("charge_amps", "")
+            == "getMaxAmpsToDivideGreenEnergy()"
+            else False
+        )

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -139,42 +139,7 @@ class Policy:
                         ),
                     )
                     # Start by not having matched the condition
-                    is_matched = 0
-                    match = self.policyValue(match)
-                    value = self.policyValue(value)
-
-                    # Perform comparison
-                    if condition == "gt":
-                        # Match must be greater than value
-                        if match > value:
-                            is_matched = 1
-                    elif condition == "gte":
-                        # Match must be greater than or equal to value
-                        if match >= value:
-                            is_matched = 1
-                    elif condition == "lt":
-                        # Match must be less than value
-                        if match < value:
-                            is_matched = 1
-                    elif condition == "lte":
-                        # Match must be less than or equal to value
-                        if match <= value:
-                            is_matched = 1
-                    elif condition == "eq":
-                        # Match must be equal to value
-                        if match == value:
-                            is_matched = 1
-                    elif condition == "ne":
-                        # Match must not be equal to value
-                        if match != value:
-                            is_matched = 1
-                    elif condition == "false":
-                        # Condition: false is a method to ensure a policy entry
-                        # is never matched, possibly for testing purposes
-                        is_matched = 0
-                    elif condition == "none":
-                        # No condition exists.
-                        is_matched = 1
+                    is_matched = self.doesConditionMatch(match, condition, value)
 
                 # Check if we have met all criteria
                 if latched or is_matched:
@@ -319,3 +284,36 @@ class Policy:
             == "getMaxAmpsToDivideGreenEnergy()"
             else False
         )
+
+    def doesConditionMatch(self, match, condition, value):
+        match = self.policyValue(match)
+        value = self.policyValue(value)
+
+        # Perform comparison
+        if condition == "gt":
+            # Match must be greater than value
+            return True if match > value else False
+        elif condition == "gte":
+            # Match must be greater than or equal to value
+            return True if match >= value else False
+        elif condition == "lt":
+            # Match must be less than value
+            return True if match < value else False
+        elif condition == "lte":
+            # Match must be less than or equal to value
+            return True if match <= value else False
+        elif condition == "eq":
+            # Match must be equal to value
+            return True if match == value else False
+        elif condition == "ne":
+            # Match must not be equal to value
+            return True if match != value else False
+        elif condition == "false":
+            # Condition: false is a method to ensure a policy entry
+            # is never matched, possibly for testing purposes
+            return False
+        elif condition == "none":
+            # No condition exists.
+            return True
+        else:
+            raise ValueError("Unknown condition " + condition)

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -254,7 +254,7 @@ class Policy:
             else False
         )
 
-    def doesConditionMatch(self, match, condition, value):
+    def doesConditionMatch(self, match, condition, value, exitOn):
         self.master.debugLog(
             8,
             "Policy    ",
@@ -265,6 +265,9 @@ class Policy:
 
         match = self.policyValue(match)
         value = self.policyValue(value)
+
+        if all([isinstance(a, list) for a in (match, condition, value)]):
+            return self.checkConditions(match, condition, value, not exitOn)
 
         # Perform comparison
         if condition == "gt":
@@ -295,10 +298,10 @@ class Policy:
         else:
             raise ValueError("Unknown condition " + condition)
 
-    # exitOn = False returns True if all conditions are True, else False
-    # exitOn = True returns True if any condition is True, else False
+    # exitOn = False returns True if all conditions are True, else False ==> AND
+    # exitOn = True returns True if any condition is True, else False ==> OR
     def checkConditions(self, matches, conditions, values, exitOn = False):
         for match, condition, value in zip(matches, conditions, values):
-            if self.doesConditionMatch(match, condition, value) == exitOn:
+            if self.doesConditionMatch(match, condition, value, exitOn) == exitOn:
                 return exitOn
         return not exitOn

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -1,0 +1,305 @@
+import time
+from ww import f
+from termcolor import colored
+
+class Policy:
+
+    active_policy = None
+
+    # This is the default charge policy.  It can be overridden or extended.
+    charge_policy = [
+        # The first policy table entry is for chargeNow. This will fire if
+        # chargeNowAmps is set to a positive integer and chargeNowTimeEnd
+        # is less than or equal to the current timestamp
+        {
+            "name": "Charge Now",
+            "match": [
+                "settings.chargeNowAmps",
+                "settings.chargeNowTimeEnd",
+                "settings.chargeNowTimeEnd",
+            ],
+            "condition": ["gt", "gt", "gt"],
+            "value": [0, 0, "now"],
+            "charge_amps": "settings.chargeNowAmps",
+            "charge_limit": "config.chargeNowLimit",
+        },
+        # Check if we are currently within the Scheduled Amps charging schedule.
+        # If so, charge at the specified number of amps.
+        {
+            "name": "Scheduled Charging",
+            "match": ["checkScheduledCharging()"],
+            "condition": ["eq"],
+            "value": [1],
+            "charge_amps": "settings.scheduledAmpsMax",
+            "charge_limit": "config.scheduledLimit",
+        },
+        # If we are within Track Green Energy schedule, charging will be
+        # performed based on the amount of solar energy being produced.
+        # Don't bother to check solar generation before 6am or after
+        # 8pm. Sunrise in most U.S. areas varies from a little before
+        # 6am in Jun to almost 7:30am in Nov before the clocks get set
+        # back an hour. Sunset can be ~4:30pm to just after 8pm.
+        {
+            "name": "Track Green Energy",
+            "match": ["tm_hour", "tm_hour", "settings.hourResumeTrackGreenEnergy"],
+            "condition": ["gte", "lt", "lte"],
+            "value": [6, 20, "tm_hour"],
+            "charge_amps": "getMaxAmpsToDivideGreenEnergy()",
+            "background_task": "checkGreenEnergy",
+            "allowed_flex": "config.greenEnergyFlexAmps",
+            "charge_limit": "config.greenEnergyLimit",
+        },
+        # If all else fails (ie no other policy match), we will charge at
+        # nonScheduledAmpsMax
+        {
+            "name": "Non Scheduled Charging",
+            "match": ["none"],
+            "condition": ["none"],
+            "value": [0],
+            "charge_amps": "settings.nonScheduledAmpsMax",
+            "charge_limit": "config.nonScheduledLimit",
+        },
+    ]
+    lastPolicyCheck = 0
+    master = None
+    policyCheckInterval = 30
+
+    def __init__(self, master):
+        self.master = master
+        self.config = self.master.config
+
+        # Override Charge Policy if specified
+        config_policy = self.config.get("policy")
+        if config_policy:
+            if len(config_policy.get("override", [])) > 0:
+                # Policy override specified, just override in place without processing the
+                # extensions
+                self.charge_policy = config_policy.get("override")
+            else:
+                # Insert optional policy extensions into policy list
+                # After - Inserted before Non-Scheduled Charging
+                config_extend = config_policy.get("extend", {})
+                if len(config_extend.get("after", [])) > 0:
+                    self.charge_policy[3:3] = config_extend.get("after")
+
+                # Before - Inserted after Charge Now
+                if len(config_extend.get("before", [])) > 0:
+                    self.charge_policy[1:1] = config_extend.get("before")
+
+                # Emergency - Inserted at the beginning
+                if len(config_extend.get("emergency", [])) > 0:
+                    self.charge_policy[0:0] = config_extend.get("emergency")
+
+            # Set the Policy Check Interval if specified
+            policy_engine = config_policy.get("engine")
+            if policy_engine:
+                if policy_engine.get("policyCheckInterval"):
+                    self.policyCheckInterval = policy_engine.get("policyCheckInterval")
+
+    def setChargingPerPolicy(self):
+        # This function is called for the purpose of evaluating the charging
+        # policy and matching the first rule which matches our scenario.
+
+        # Once we have determined the maximum number of amps for all slaves to
+        # share based on the policy, we call setMaxAmpsToDivideAmongSlaves to
+        # distribute the designated power amongst slaves.
+
+        # First, determine if it has been less than 30 seconds since the last
+        # policy check. If so, skip for now
+        if (self.lastPolicyCheck + self.policyCheckInterval) > time.time():
+            return
+        else:
+            # Update last policy check time
+            self.lastPolicyCheck = time.time()
+
+        for policy in self.charge_policy:
+
+            # Check if the policy is within its latching period
+            latched = False
+            if "__latchTime" in policy:
+                if time.time() < policy["__latchTime"]:
+                    latched = True
+                else:
+                    del policy["__latchTime"]
+
+            # Iterate through each set of match, condition and value sets
+            iter = 0
+            for match, condition, value in zip(
+                policy["match"], policy["condition"], policy["value"]
+            ):
+
+                if not latched:
+                    iter += 1
+                    self.master.debugLog(
+                        8,
+                        "Policy    ",
+                        f(
+                            "Evaluating Policy match ({colored(match, 'red')}), condition ({colored(condition, 'red')}), value ({colored(value, 'red')}), iteration ({colored(iter, 'red')})"
+                        ),
+                    )
+                    # Start by not having matched the condition
+                    is_matched = 0
+                    match = self.policyValue(match)
+                    value = self.policyValue(value)
+
+                    # Perform comparison
+                    if condition == "gt":
+                        # Match must be greater than value
+                        if match > value:
+                            is_matched = 1
+                    elif condition == "gte":
+                        # Match must be greater than or equal to value
+                        if match >= value:
+                            is_matched = 1
+                    elif condition == "lt":
+                        # Match must be less than value
+                        if match < value:
+                            is_matched = 1
+                    elif condition == "lte":
+                        # Match must be less than or equal to value
+                        if match <= value:
+                            is_matched = 1
+                    elif condition == "eq":
+                        # Match must be equal to value
+                        if match == value:
+                            is_matched = 1
+                    elif condition == "ne":
+                        # Match must not be equal to value
+                        if match != value:
+                            is_matched = 1
+                    elif condition == "false":
+                        # Condition: false is a method to ensure a policy entry
+                        # is never matched, possibly for testing purposes
+                        is_matched = 0
+                    elif condition == "none":
+                        # No condition exists.
+                        is_matched = 1
+
+                # Check if we have met all criteria
+                if latched or is_matched:
+
+                    # Have we checked all policy conditions yet?
+                    if latched or len(policy["match"]) == iter:
+
+                        # Yes, we will now enforce policy
+                        self.master.debugLog(
+                            7,
+                            "Policy    ",
+                            f(
+                                "All policy conditions have matched. Policy chosen is {colored(policy['name'], 'red')}"
+                            ),
+                        )
+                        if self.active_policy != str(policy["name"]):
+                            self.master.debugLog(
+                                1,
+                                "Policy    ",
+                                f(
+                                    "New policy selected; changing to {colored(policy['name'], 'red')}"
+                                ),
+                            )
+                            self.active_policy = str(policy["name"])
+
+                        if not latched and "latch_period" in policy:
+                            policy["__latchTime"] = (
+                                time.time() + policy["latch_period"] * 60
+                            )
+
+                        # Determine which value to set the charging to
+                        if policy["charge_amps"] == "value":
+                            self.master.setMaxAmpsToDivideAmongSlaves(
+                                int(policy["value"])
+                            )
+                            self.master.debugLog(
+                                10,
+                                "Policy    ",
+                                "Charge at %.2f" % int(policy["value"]),
+                            )
+                        else:
+                            self.master.setMaxAmpsToDivideAmongSlaves(
+                                self.policyValue(policy["charge_amps"])
+                            )
+                            self.master.debugLog(
+                                10,
+                                "Policy    ",
+                                "Charge at %.2f"
+                                % self.policyValue(policy["charge_amps"]),
+                            )
+
+                        # Set flex, if any
+                        self.master.setAllowedFlex(
+                            self.policyValue(policy.get("allowed_flex", 0))
+                        )
+
+                        # If a background task is defined for this policy, queue it
+                        bgt = policy.get("background_task", None)
+                        if bgt:
+                            self.master.queue_background_task({"cmd": bgt})
+
+                        # If a charge limit is defined for this policy, apply it
+                        limit = self.policyValue(policy.get("charge_limit", -1))
+                        if not (limit >= 50 and limit <= 100):
+                            limit = -1
+                        self.master.queue_background_task(
+                            {"cmd": "applyChargeLimit", "limit": limit}
+                        )
+
+                        # Now, finish processing
+                        return
+
+                    else:
+                        self.master.debugLog(
+                            8,
+                            "Policy    ",
+                            "This policy condition has matched, but there are more to process.",
+                        )
+
+                else:
+                    self.master.debugLog(
+                        8, "Policy    ", "Policy conditions were not matched."
+                    )
+                    break
+
+    def policyValue(self, value):
+        # policyValue is a macro to allow charging policy to refer to things
+        # such as EMS module values or settings. This allows us to control
+        # charging via policy.
+        ltNow = time.localtime()
+
+        # Anything other than a string can only be a literal value
+        if not isinstance(value, str):
+            return value
+
+        # If value is "now", substitute with current timestamp
+        if value == "now":
+            return time.time()
+
+        # If value is "tm_hour", substitute with current hour
+        if value == "tm_hour":
+            return ltNow.tm_hour
+
+        # The remaining checks are case-sensitive!
+        #
+        # If value refers to a function, execute the function and capture the
+        # output
+        if value == "getMaxAmpsToDivideGreenEnergy()":
+            return self.master.getMaxAmpsToDivideGreenEnergy()
+        elif value == "checkScheduledCharging()":
+            return self.master.checkScheduledCharging()
+
+        # If value is tiered, split it up
+        if value.find(".") != -1:
+            pieces = value.split(".")
+
+            # If value refers to a setting, return the setting
+            if pieces[0] == "settings":
+                return self.master.settings.get(pieces[1], 0)
+            elif pieces[0] == "config":
+                return self.config["config"].get(pieces[1], 0)
+            elif pieces[0] == "modules":
+                module = None
+                if pieces[1] in self.master.modules:
+                    module = self.master.getModuleByName(pieces[1])
+                    return getattr(module, pieces[2], value)
+
+        # None of the macro conditions matched, return the value as is
+        return value

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -506,7 +506,7 @@ class TWCSlave:
         # Determine our charging policy. This is the policy engine of the
         # TWCManager application. Using defined rules, we can determine how
         # we charge.
-        self.master.setChargingPerPolicy()
+        self.master.getModuleByName("Policy").setChargingPerPolicy()
 
         # Determine how many cars are charging and how many amps they're using
         numCarsCharging = self.master.num_cars_charging_now()

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -42,8 +42,8 @@ class TeslaAPI:
         self.master = master
         try:
             self.config = master.config
-            self.debugLevel = self.config["config"]["debugLevel"]
-            self.minChargeLevel = self.config["config"]["minChargeLevel"]
+            self.debugLevel = self.config["config"].get("debugLevel", 1)
+            self.minChargeLevel = self.config["config"].get("minChargeLevel", -1)
             self.chargeUpdateInterval = self.config["config"].get(
                 "cloudUpdateInterval", 1800
             )


### PR DESCRIPTION
This is another big one.  You can look at the individual commits for a better view, but the short version is:

- The policy engine is moved to its own module, more for code management than because I expect we'd want to swap out the engine.
- Decision of whether a policy needs the Green logging is encapsulated in that module
- It's possible to add additional constraints to the built-in policies
- It's possible to OR conditions in the policies by using sub-lists -- the top list ANDs, sub-lists OR, sub-sub-lists AND again, etc.