### PR TITLE
Keep reportedAmpsHistory, use for charger load

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -267,7 +267,7 @@ class TWCMaster:
 
     def getGenerationOffset(self):
         # Returns the number of watts to subtract from the solar generation stats
-        # This is consumption + charger load if subtractChargerLoad is enabled
+        # This is consumption minus charger load if subtractChargerLoad is enabled
         # Or simply consumption if subtractChargerLoad is disabled
         generationOffset = self.getConsumption()
         if self.subtractChargerLoad:
@@ -336,7 +336,9 @@ class TWCMaster:
         # Returns the number of amps currently in use by all TWCs
         totalAmps = 0
         for slaveTWC in self.getSlaveTWCs():
-            totalAmps += slaveTWC.reportedAmpsActual
+            totalAmps += sum(slaveTWC.reportedAmpsHistory) / len(
+                slaveTWC.reportedAmpsHistory
+            )
             for module in self.getModulesByType("Status"):
                 module["ref"].setStatus(
                     slaveTWC.TWCID,

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -336,8 +336,8 @@ class TWCMaster:
         # Returns the number of amps currently in use by all TWCs
         totalAmps = 0
         for slaveTWC in self.getSlaveTWCs():
-            totalAmps += sum(slaveTWC.reportedAmpsHistory) / len(
-                slaveTWC.reportedAmpsHistory
+            totalAmps += sum(slaveTWC.reportedAmpsHistory) / max(
+                len(slaveTWC.reportedAmpsHistory), 1
             )
             for module in self.getModulesByType("Status"):
                 module["ref"].setStatus(

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -26,7 +26,7 @@ class TWCSlave:
     reportedAmpsMax = 0
     reportedAmpsActual = 0
     reportedState = 0
-    reportedAmpsHistory = deque(maxlen=30)
+    reportedAmpsHistory = deque(maxlen=20)
 
     # reportedAmpsActual frequently changes by small amounts, like 5.14A may
     # frequently change to 5.23A and back.

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -1,5 +1,6 @@
 from termcolor import colored
 from ww import f
+from collections import deque
 
 
 class TWCSlave:
@@ -25,6 +26,7 @@ class TWCSlave:
     reportedAmpsMax = 0
     reportedAmpsActual = 0
     reportedState = 0
+    reportedAmpsHistory = deque(maxlen=30)
 
     # reportedAmpsActual frequently changes by small amounts, like 5.14A may
     # frequently change to 5.23A and back.
@@ -443,6 +445,8 @@ class TWCSlave:
         self.reportedAmpsMax = ((heartbeatData[1] << 8) + heartbeatData[2]) / 100
         self.reportedAmpsActual = ((heartbeatData[3] << 8) + heartbeatData[4]) / 100
         self.reportedState = heartbeatData[0]
+
+        self.reportedAmpsHistory.append(self.reportedAmpsActual)
 
         for module in self.master.getModulesByType("Status"):
             module["ref"].setStatus(


### PR DESCRIPTION
Another cause of bouncing charge rates that I've seen is that the Powerwall reports over some recent interval (I'm not totally sure what that is), while TWCManager uses the instantaneous charger current to offset the charger load.  This leads to errors in two directions:

- When charging has just started, charger load will report a higher value than the Powerwall's consumption number.  TWCManager offers the entire solar output to the car, ignoring any real consumption, and discovers its error on the next cycle.
- When charging current has just been reduced (e.g. because of the spike to 21A for five seconds), consumption is artificially inflated, causing TWCManager to reduce current or stop charging unnecessarily.

I suspect this is exacerbated by a shorter policy interval, since changes from the previous one don't get as long to settle into a steady-state / get included in the current data.

This change uses the average of the last 30 slave heartbeats instead of the most recent one.  I'm hopeful that will make the charger offset more accurate in both directions.