### PR TITLE
Sleep longer

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -821,7 +821,7 @@ class TeslaAPI:
                 and (
                     limit != lastApplied
                     or checkDeparture
-                    or (vehicle.update_location() and not vehicle.atHome)
+                    or (vehicle.update_location(cacheTime=3600) and not vehicle.atHome)
                 )
             ) or (not wasAtHome and checkArrival):
                 vehicle.stopTryingToApplyLimit = False
@@ -1195,14 +1195,14 @@ class CarApiVehicle:
 
             return (True, response)
 
-    def update_location(self):
+    def update_location(self, cacheTime=60):
 
         url = "https://owner-api.teslamotors.com/api/1/vehicles/"
         url = url + str(self.ID) + "/data_request/drive_state"
 
         now = self.time.time()
 
-        if now - self.lastDriveStatusTime < (60 if wake else 3600):
+        if now - self.lastDriveStatusTime < cacheTime:
             return True
 
         (result, response) = self.get_car_api(url)

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -875,6 +875,8 @@ class TeslaAPI:
 
             if limit == -1 or (located and not vehicle.atHome):
                 # We're removing any applied limit, provided it hasn't been manually changed
+                #
+                # If lastApplied == -1, the manual-change path is always selected.
                 if wasAtHome and vehicle.chargeLimit == lastApplied:
                     if vehicle.apply_charge_limit(outside):
                         self.master.debugLog(
@@ -887,10 +889,17 @@ class TeslaAPI:
                             + "%",
                         )
                         vehicle.stopTryingToApplyLimit = True
-                        if forgetVehicle:
-                            self.master.removeNormalChargeLimit(vehicle.ID)
                 else:
+                    # If the charge limit has been manually changed, user action overrides the
+                    # saved charge limit.  Leave it alone.
                     vehicle.stopTryingToApplyLimit = True
+                    outside = vehicle.chargeLimit
+
+                if vehicle.stopTryingToApplyLimit:
+                    if forgetVehicle:
+                        self.master.removeNormalChargeLimit(vehicle.ID)
+                    else:
+                        self.master.saveNormalChargeLimit(vehicle.ID, outside, -1)
             else:
                 if vehicle.chargeLimit != limit:
                     if vehicle.apply_charge_limit(limit):

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1102,6 +1102,7 @@ class CarApiVehicle:
         # This can check whether the car is online; if so, it will likely stay online for
         # two minutes.
         if self.is_awake():
+            self.firstWakeAttemptTime = 0
             return True
 
         self.carapi.master.debugLog(

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1077,7 +1077,7 @@ class CarApiVehicle:
         self.ID = json["id"]
         self.name = json["display_name"]
 
-    def inError(self):
+    def ready(self):
         if self.carapi.getCarApiRetryRemaining(self.lastErrorTime):
             # It's been under carApiErrorRetryMins minutes since the car API
             # generated an error on this vehicle. Return that car is not ready.
@@ -1088,11 +1088,6 @@ class CarApiVehicle:
                 + " not ready because of recent lastErrorTime "
                 + str(self.lastErrorTime),
             )
-            return True
-        return False
-
-    def ready(self):
-        if self.inError():
             return False
 
         if (
@@ -1218,7 +1213,7 @@ class CarApiVehicle:
         (result, response) = self.get_car_api(url)
 
         if result:
-            self.lastDriveStatusTime = self.time.time()
+            self.lastDriveStatusTime = now
             self.lat = response["latitude"]
             self.lon = response["longitude"]
             self.atHome = self.carapi.is_location_home(self.lat, self.lon)
@@ -1259,7 +1254,6 @@ class CarApiVehicle:
             return False
 
         self.lastLimitAttemptTime = now
-        self.lastAPIAccessTime = now
 
         url = "https://owner-api.teslamotors.com/api/1/vehicles/"
         url = url + str(self.ID) + "/command/set_charge_limit"
@@ -1292,6 +1286,7 @@ class CarApiVehicle:
 
             if result == True or reason == "already_set":
                 self.stopTryingToApplyLimit = True
+                self.lastAPIAccessTime = now
                 return True
             elif reason == "could_not_wake_buses":
                 time.sleep(5)

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -913,9 +913,10 @@ class TeslaAPI:
                             + "%",
                         )
                         vehicle.stopTryingToApplyLimit = True
-                        self.master.saveNormalChargeLimit(vehicle.ID, outside, limit)
                 else:
                     vehicle.stopTryingToApplyLimit = True
+
+                if vehicle.stopTryingToApplyLimit:
                     self.master.saveNormalChargeLimit(vehicle.ID, outside, limit)
 
         if checkArrival:

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -814,7 +814,7 @@ class TeslaAPI:
             )
             # Don't wake cars to tell them about reduced limits;
             # only wake if they might be able to charge further now
-            if wasAtHome and limit > lastApplied:
+            if wasAtHome and limit > (lastApplied if lastApplied != -1 else outside):
                 needToWake = True
             if (
                 wasAtHome


### PR DESCRIPTION
This makes a couple changes to avoid the charge limit code waking the car for every policy transition:

- If the limit has decreased from the last time the car saw it, the car isn't woken up
- Better opportunistic interactions with the car -- check whether the car is awake instead of relying on last wake time.
- If the car wakes up for some other reason, it will get the new limit then.