### PR TITLE
Extend latch

### DIFF
--- a/docs/PolicyCustomization.md
+++ b/docs/PolicyCustomization.md
@@ -68,12 +68,31 @@ level, a passing cloud might cause you to exit and later re-enter the policy.
 
 To handle these cases, policies support latching.  When a policy is defined to
 latch, the conditions are treated as continuing to be true for a specified
-number of minutes after they last evaluated true.  (Note:  This does not prevent
-a policy change if an earlier policy's conditions become true.)
+number of minutes after they last evaluated true.
+
+Note:
+: This does not prevent a policy change if an earlier policy's conditions become
+  true.  It also does not prevent the Track Green Energy policy from deciding
+  there is insufficient power to charge, but see Flex below.
 
 The Track Green Energy policy can be latched using the `greenEnergyLatch` value.
 Custom policies can be latched using the `latch_period` attribute.
 
+## Flexibility
+
+The Track Green Energy policy attempts to send only excess power to the car.
+However, on cloudy days, this power might be inconsistent.  Setting an amount of
+Flex current permits the policy to continue charging at the minimum rate,
+drawing up to the specified amount from the grid, even if Green Energy becomes
+insufficient temporarily.
+
+The policy will stop charging if available power drops too low even with the
+flex, and will not wake a car to start charging until there is sufficient power
+without considering the flex.
+
+Flex for the Track Green Energy policy can be set using the
+`greenEnergyFlexAmps` value; custom policies can include an `allowed_flex`
+attribute.
 
 # Defining Custom Policies
 
@@ -106,6 +125,9 @@ The values in a policy definition are:
   is in effect (optional)
 - `latch_period`:  If the conditions for this policy are ever matched, treat
   them as matched for this many minutes, even if they change. (optional)
+- `allowed_flex`:  If the available current is reduced below the minimum for
+  charging, continue to supply the minimum.  Only useful for policies where the
+  charge amps vary.
 
 ### Policy Values
 

--- a/docs/PolicyCustomization.md
+++ b/docs/PolicyCustomization.md
@@ -75,6 +75,11 @@ Note:
   true.  It also does not prevent the Track Green Energy policy from deciding
   there is insufficient power to charge, but see Flex below.
 
+Caution:
+: Exercise care with latching.  If a policy is restricted to apply only when the
+  grid is online, but latches, it will continue operating during the beginning
+  of a grid outage.
+
 The Track Green Energy policy can be latched using the `greenEnergyLatch` value.
 Custom policies can be latched using the `latch_period` attribute.
 

--- a/docs/PolicyCustomization.md
+++ b/docs/PolicyCustomization.md
@@ -55,6 +55,26 @@ the `config.json` file:
 - `greenEnergyLimit`
 - `nonScheduledLimit`
 
+## Latching
+
+Sometimes, the conditions that trigger a policy could cause those conditions no
+longer to be true.  This does not occur with the built-in policy conditions, but
+could with custom conditions.  For example, a policy that allows charging when
+power is being exported could increase consumption and eliminate the export.
+
+Alternatively, you might have a condition which occasionally fails to match. If
+you restrict Track Green Energy to run only when generation is above a certain
+level, a passing cloud might cause you to exit and later re-enter the policy.
+
+To handle these cases, policies support latching.  When a policy is defined to
+latch, the conditions are treated as continuing to be true for a specified
+number of minutes after they last evaluated true.  (Note:  This does not prevent
+a policy change if an earlier policy's conditions become true.)
+
+The Track Green Energy policy can be latched using the `greenEnergyLatch` value.
+Custom policies can be latched using the `latch_period` attribute.
+
+
 # Defining Custom Policies
 
 If you wish to add additional policies, they can be specified in the

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -101,6 +101,11 @@
         # of drawing energy from sources other than solar.
         "greenEnergyFlexAmps": 0,
 
+        # If the conditions for green energy briefly fail to match, how long should the
+        # Track Green Energy policy continue to run?  (Mainly useful if you're adding
+        # non-time-based restrictions below.)
+        #"greenEnergyLatch": 15,
+
         # In some environments, the consumption meter value that we obtain will
         # include the charger's consumption, whilst others will not.
         # This switch, if set to true, will subtract the charger's load from the

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -130,9 +130,11 @@ class Policy:
                 else:
                     del policy["__latchTime"]
 
-            if latched or self.checkConditions(
+            matched = self.checkConditions(
                 policy["match"], policy["condition"], policy["value"]
-            ):
+            )
+
+            if latched or matched:
                 # Yes, we will now enforce policy
                 self.master.debugLog(
                     7,
@@ -151,7 +153,7 @@ class Policy:
                     )
                     self.active_policy = str(policy["name"])
 
-                if not latched and "latch_period" in policy:
+                if matched and "latch_period" in policy:
                     policy["__latchTime"] = time.time() + policy["latch_period"] * 60
 
                 # Determine which value to set the charging to

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -91,6 +91,12 @@ class Policy:
                     for key in ("match", "condition", "value"):
                         restricted[key] += restrictions.get(key, [])
 
+                # Green Energy Latching
+                if "greenEnergyLatch" in self.config["config"]:
+                    self.charge_policy[2]["latch_period"] = self.config["config"][
+                        "greenEnergyLatch"
+                    ]
+
                 # Insert optional policy extensions into policy list:
                 #   After - Inserted before Non-Scheduled Charging
                 #   Before - Inserted after Charge Now


### PR DESCRIPTION
Two changes related to latching here:

- Rather than being latched for X minutes and ignoring the conditions, then checking again and deciding whether to go for X minutes, this makes latching persist for X minutes from the last time the conditions matched.
- A config value permits latching green energy, which is mainly useful if you're already extending the conditions for green energy.  This lets you ride out, say, brief dips in solar output when you have a solar output condition set.