### PR TITLE
Don't block the background thread

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -368,9 +368,6 @@ backgroundTasksThread = threading.Thread(target=background_tasks_thread, args=()
 backgroundTasksThread.daemon = True
 backgroundTasksThread.start()
 
-# Queue background task to regularly fetch slaves lifetime kWh readings
-master.queue_background_task({"cmd": "getLifetimekWh"})
-
 debugLog(
     1,
     "TWC Manager starting as fake %s with id %02X%02X and sign %02X"

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -22,6 +22,7 @@ class TWCMaster:
     debugLevel = 0
     generationValues = {}
     lastkWhMessage = time.time()
+    lastkWhPoll = 0
     lastTWCResponseMsg = None
     masterTWCID = ""
     maxAmpsToDivideAmongSlaves = 0
@@ -222,19 +223,20 @@ class TWCMaster:
         return self.settings.get("scheduledAmpsEndHour", -1)
 
     def getSlaveLifetimekWh(self):
-
+        
         # This function is called from a Scheduled Task
-        # We delay the thread for 1 minute, then query all known Slave TWCs
+        # If it's been at least 1 minute, then query all known Slave TWCs
         # to determine their lifetime kWh and per-phase voltages
-        time.sleep(60)
-
-        for slaveTWC in self.getSlaveTWCs():
-          self.getModuleByName("RS485").send(
-            bytearray(b"\xFB\xEB")
-            + self.TWCID
-            + slaveTWC.TWCID
-            + bytearray(b"\x00\x00\x00\x00\x00\x00\x00\x00")
-        )
+        now = time.time()
+        if now >= self.lastkWhPoll + 60:
+            for slaveTWC in self.getSlaveTWCs():
+                self.getModuleByName("RS485").send(
+                    bytearray(b"\xFB\xEB")
+                    + self.TWCID
+                    + slaveTWC.TWCID
+                    + bytearray(b"\x00\x00\x00\x00\x00\x00\x00\x00")
+                )
+            self.lastkWhPoll = now
 
     def getSlaveSign(self):
         return self.slaveSign

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -443,6 +443,8 @@ class TWCSlave:
     def receive_slave_heartbeat(self, heartbeatData):
         # Handle heartbeat message received from real slave TWC.
 
+        self.master.queue_background_task({"cmd": "getLifetimekWh"})
+
         now = self.time.time()
         self.timeLastRx = now
 


### PR DESCRIPTION
83bd6ff65b15bec45ce1c8811b5bb0f66c12da26 introduces a new background task that idles for 60 seconds, blocking all other background tasks.  This changes the activation mechanism so that it can still run every minute, but not block other tasks.