### PR TITLE
Races between limit changes and start/stop charging

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -565,9 +565,7 @@ class TeslaAPI:
 
         startOrStop = "start" if charge else "stop"
         result = "success"
-        self.master.debugLog(
-            8, "TeslaAPI", "startOrStop is set to " + str(startOrStop)
-        )
+        self.master.debugLog(8, "TeslaAPI", "startOrStop is set to " + str(startOrStop))
 
         for vehicle in self.getCarApiVehicles():
             if charge and vehicle.stopAskingToStartCharging:
@@ -583,7 +581,11 @@ class TeslaAPI:
             if not vehicle.ready():
                 continue
 
-            if vehicle.update_charge() and vehicle.batteryLevel < self.minChargeLevel:
+            if (
+                vehicle.update_charge()
+                and vehicle.batteryLevel < self.minChargeLevel
+                and not charge
+            ):
                 # If the vehicle's charge state is lower than the configured minimum,
                 #   don't stop it from charging, even if we'd otherwise not charge.
                 continue
@@ -622,6 +624,9 @@ class TeslaAPI:
                 # Waiting 2 seconds seems to consistently avoid the error, but let's
                 # wait 5 seconds in case of hardware differences between cars.
                 self.time.sleep(5)
+
+            if charge:
+                self.applyChargeLimit(self.lastChargeLimitApplied, checkArrival=True)
 
             url = "https://owner-api.teslamotors.com/api/1/vehicles/"
             url = url + str(vehicle.ID) + "/command/charge_" + startOrStop

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -816,6 +816,7 @@ class TeslaAPI:
             # only wake if they might be able to charge further now
             if wasAtHome and limit > (lastApplied if lastApplied != -1 else outside):
                 needToWake = True
+                vehicle.stopAskingToStartCharging = False
             if (
                 wasAtHome
                 and (


### PR DESCRIPTION
Two subtle race conditions here.

First:
- Initial condition:
    - Outside limit is high, say 90%
    - Current charge is below outside limit
- Car arrives and plugs up, gets told to stop charging
- Local limit gets applied, say 70%
- Some time later, a new limit gets applied that's greater than the car's current state of charge

Even though the car will be woken to be told about the new limit, it will still not charge -- because it has been asked not to charge.  This change says we should re-ask the car to charge any time we think it's worth waking it to tell it about a new limit, because we'd like it to try to charge to that limit.

Second:
- Initial condition:
    - Car's last known limit was high, say 90%
    - Car was told to stop charging when it arrived home because no current was available
- Policy change applies a limit of 50%, but offers current
- Apply charge limit of 50% doesn't wake the car, because its last known limit was higher
- Start charging *does* wake the car, because it was previously told to stop charging and current is available.
- The car starts charging.
- On the next cycle, the charge limit gets applied, and the car stops charging because it's already past the new limit.

The result is 30-60 seconds of high current usage at the start of a scheduled charge period when the car doesn't actually need to charge.  This change makes sure charge limits are up to date between waking vehicles and telling them to start charging.  Not a huge difference, but it saves an unneeded contactor cycle.

It does mean that, whenever TWCManager decides to send a start command, applyChargeLimit() runs several times (up to N+1 for N vehicles on the account), but I don't think it actually sends too many extra commands.