### PR TITLE
History

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -202,9 +202,18 @@ def background_tasks_thread(master):
                 )
             elif task["cmd"] == "checkCharge":
                 carapi.updateChargeAtHome()
+            elif task["cmd"] == "snapHistoryData":
+                master.snapHistoryData()
 
         except:
-            master.debugLog(1, 'TWCManager', colored('BackgroundError', 'red')+": "+traceback.format_exc()+", occurred when processing background task")
+            master.debugLog(
+                1,
+                "TWCManager",
+                colored("BackgroundError", "red")
+                + ": "
+                + traceback.format_exc()
+                + ", occurred when processing background task",
+            )
             pass
 
         # Delete task['cmd'] from backgroundTasksCmds such that

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -355,9 +355,9 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
         elif url.path == "/api/getHistory":
             output = []
             now = datetime.now().replace(second=0, microsecond=0).astimezone()
-            startTime = now - timedelta(days=2)
+            startTime = now - timedelta(days=2) + timedelta(minutes=5)
             endTime = now.replace(minute=math.floor(now.minute / 5) * 5)
-            startTime = startTime.replace(minute=math.ceil(startTime.minute / 5) * 5)
+            startTime = startTime.replace(minute=math.floor(startTime.minute / 5) * 5)
 
             source = (
                 self.server.master.settings["history"]

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -1,11 +1,13 @@
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from socketserver import ThreadingMixIn
 from termcolor import colored
+from datetime import datetime, timedelta
 import json
 import re
 import threading
 import time
 import urllib.parse
+import math
 from ww import f
 
 
@@ -38,8 +40,8 @@ class HTTPControl:
         self.status = self.configHTTP.get("enabled", False)
 
         # Unload if this module is disabled or misconfigured
-        if ((not self.status) or (int(self.httpPort) < 1)):
-          self.master.releaseModule("lib.TWCManager.Control","HTTPControl");
+        if (not self.status) or (int(self.httpPort) < 1):
+            self.master.releaseModule("lib.TWCManager.Control", "HTTPControl")
 
         if self.status:
             httpd = ThreadingSimpleServer(("", self.httpPort), HTTPControlHandler)
@@ -254,9 +256,8 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
             json_datas = re.sub(r'"password": ".*?",', "", json_data)
             json_data = re.sub(r'"apiKey": ".*?",', "", json_datas)
             self.wfile.write(json_data.encode("utf-8"))
-            return
 
-        if url.path == "/api/getPolicy":
+        elif url.path == "/api/getPolicy":
             self.send_response(200)
             self.send_header("Content-type", "application/json")
             self.end_headers()
@@ -265,9 +266,8 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
                 self.server.master.getModuleByName("Policy").charge_policy
             )
             self.wfile.write(json_data.encode("utf-8"))
-            return
 
-        if url.path == "/api/getSlaveTWCs":
+        elif url.path == "/api/getSlaveTWCs":
             data = {}
             totals = {
                 "lastAmpsOffered": 0,
@@ -311,9 +311,8 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
 
             json_data = json.dumps(data)
             self.wfile.write(json_data.encode("utf-8"))
-            return
 
-        if url.path == "/api/getStatus":
+        elif url.path == "/api/getStatus":
             data = {
                 "carsCharging": self.server.master.num_cars_charging_now(),
                 "chargerLoadWatts": "%.2f" % float(self.server.master.getChargerLoad()),
@@ -352,13 +351,51 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
 
             json_data = json.dumps(data)
             self.wfile.write(json_data.encode("utf-8"))
-            return
 
-        # All other routes missed, return 404
-        self.send_response(404)
-        self.end_headers()
-        self.wfile.write("".encode("utf-8"))
-        return
+        elif url.path == "/api/getHistory":
+            output = []
+            now = datetime.now().replace(second=0, microsecond=0).astimezone()
+            startTime = now - timedelta(days=2)
+            endTime = now.replace(minute=math.floor(now.minute / 5) * 5)
+            startTime = startTime.replace(minute=math.ceil(startTime.minute / 5) * 5)
+
+            source = (
+                self.server.master.settings["history"]
+                if "history" in self.server.master.settings
+                else []
+            )
+            data = {k: v for k, v in source if datetime.fromisoformat(k) >= startTime}
+
+            avgCurrent = 0
+            for slave in self.server.master.getSlaveTWCs():
+                avgCurrent += slave.historyAvgAmps
+            data[
+                endTime.isoformat(timespec="seconds")
+            ] = self.server.master.convertAmpsToWatts(avgCurrent)
+
+            output = [
+                {
+                    "timestamp": timestamp,
+                    "charger_power": data[timestamp] if timestamp in data else 0,
+                }
+                for timestamp in [
+                    (startTime + timedelta(minutes=5 * i)).isoformat(timespec="seconds")
+                    for i in range(48 * 12)
+                ]
+            ]
+
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+
+            json_data = json.dumps(output)
+            self.wfile.write(json_data.encode("utf-8"))
+
+        else:
+            # All other routes missed, return 404
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write("".encode("utf-8"))
 
     def do_API_POST(self):
 

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -85,8 +85,7 @@ class TWCMaster:
         return self.slaveTWCRoundRobin.append(slaveTWC)
 
     def advanceHistorySnap(self):
-        now = datetime.now().astimezone()
-        futureSnap = now + timedelta(minutes=5)
+        futureSnap = datetime.now().astimezone() + timedelta(minutes=5)
         self.nextHistorySnap = futureSnap.replace(
             minute=math.floor(futureSnap.minute / 5) * 5, second=0, microsecond=0
         )
@@ -917,7 +916,7 @@ class TWCMaster:
         now = datetime.now().astimezone()
         avgCurrent = 0
 
-        if datetime.now().astimezone() < snaptime:
+        if now < snaptime:
             return
 
         for slave in self.getSlaveTWCs():

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -1,7 +1,7 @@
 #! /usr/bin/python3
 
 from lib.TWCManager.TWCSlave import TWCSlave
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 import os.path
 import queue
@@ -29,6 +29,7 @@ class TWCMaster:
     masterTWCID = ""
     maxAmpsToDivideAmongSlaves = 0
     modules = {}
+    nextHistorySnap = 0
     overrideMasterHeartbeatData = b""
     protocolVersion = 2
     releasedModules = []
@@ -71,6 +72,7 @@ class TWCMaster:
         self.debugLevel = config["config"]["debugLevel"]
         self.TWCID = TWCID
         self.subtractChargerLoad = config["config"]["subtractChargerLoad"]
+        self.advanceHistorySnap()
 
         # Register ourself as a module, allows lookups via the Module architecture
         self.registerModule({"name": "master", "ref": self, "type": "Master"})
@@ -81,6 +83,13 @@ class TWCMaster:
     def addSlaveTWC(self, slaveTWC):
         # Adds the Slave TWC to the Round Robin list
         return self.slaveTWCRoundRobin.append(slaveTWC)
+
+    def advanceHistorySnap(self):
+        now = datetime.now().astimezone()
+        futureSnap = now + timedelta(minutes=5)
+        self.nextHistorySnap = futureSnap.replace(
+            minute=math.floor(futureSnap.minute / 5) * 5, second=0, microsecond=0
+        )
 
     def checkScheduledCharging(self):
 
@@ -416,7 +425,7 @@ class TWCMaster:
             # No slaves support returning voltage
             return (
                 self.config["config"].get("defaultVoltage", 240),
-                self.config["config"].get("numberOfPhases", 1)
+                self.config["config"].get("numberOfPhases", 1),
             )
 
         total = 0
@@ -646,11 +655,7 @@ class TWCMaster:
         if modules.get(fullname, None):
             del modules[fullname]
 
-        self.debugLog(
-            7,
-            "TWCMaster",
-            f("Released module {colored(module, 'red')}"),
-        )
+        self.debugLog(7, "TWCMaster", f("Released module {colored(module, 'red')}"))
 
     def removeNormalChargeLimit(self, ID):
         if "chargeLimits" in self.settings and str(ID) in self.settings["chargeLimits"]:
@@ -906,6 +911,39 @@ class TWCMaster:
 
     def setSpikeAmps(self, amps):
         self.spikeAmpsToCancel6ALimit = amps
+
+    def snapHistoryData(self):
+        snaptime = self.nextHistorySnap
+        now = datetime.now().astimezone()
+        avgCurrent = 0
+
+        if datetime.now().astimezone() < snaptime:
+            return
+
+        for slave in self.getSlaveTWCs():
+            avgCurrent += slave.historyAvgAmps
+            slave.historyNumSamples = 0
+        self.advanceHistorySnap()
+
+        if avgCurrent > 0:
+            periodTimestamp = snaptime - timedelta(minutes=5)
+
+            if not "history" in self.settings:
+                self.settings["history"] = []
+
+            self.settings["history"].append(
+                (
+                    periodTimestamp.isoformat(timespec="seconds"),
+                    self.convertAmpsToWatts(avgCurrent),
+                )
+            )
+
+            self.settings["history"] = [
+                e
+                for e in self.settings["history"]
+                if datetime.fromisoformat(e[0]) >= (now - timedelta(days=2))
+            ]
+            self.saveSettings()
 
     def startCarsCharging(self):
         # This function is the opposite functionality to the stopCarsCharging function

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -1,5 +1,6 @@
 from termcolor import colored
 from ww import f
+from datetime import datetime
 
 
 class TWCSlave:
@@ -26,6 +27,10 @@ class TWCSlave:
     reportedAmpsActual = 0
     reportedState = 0
 
+    # history* vars are used to track power usage over time
+    historyAvgAmps = 0
+    historyNumSamples = 0
+
     # reportedAmpsActual frequently changes by small amounts, like 5.14A may
     # frequently change to 5.23A and back.
     # reportedAmpsActualSignificantChangeMonitor is set to reportedAmpsActual
@@ -50,8 +55,8 @@ class TWCSlave:
     voltsPhaseA = 0
     voltsPhaseB = 0
     voltsPhaseC = 0
-    isCharging  = 0
-    VINData = [ "", "", "" ]
+    isCharging = 0
+    VINData = ["", "", ""]
     currentVIN = ""
     lastVIN = ""
 
@@ -459,6 +464,15 @@ class TWCSlave:
                 self.TWCID, "amps_max", "ampsMax", self.reportedAmpsMax
             )
             module["ref"].setStatus(self.TWCID, "state", "state", self.reportedState)
+
+        # Log current history
+        self.historyAvgAmps = (
+            (self.historyAvgAmps * self.historyNumSamples) + self.reportedAmpsActual
+        ) / (self.historyNumSamples + 1)
+        self.historyNumSamples += 1
+
+        if datetime.now().astimezone() >= self.master.nextHistorySnap:
+            self.master.queue_background_task({"cmd": "snapHistoryData"})
 
         # self.lastAmpsOffered is initialized to -1.
         # If we find it at that value, set it to the current value reported by the
@@ -1022,9 +1036,9 @@ class TWCSlave:
         return self.lastAmpsOffered
 
     def setLifetimekWh(self, kwh):
-      self.lifetimekWh = kwh
+        self.lifetimekWh = kwh
 
     def setVoltage(self, pa, pb, pc):
-      self.voltsPhaseA = pa
-      self.voltsPhaseB = pb
-      self.voltsPhaseC = pc
+        self.voltsPhaseA = pa
+        self.voltsPhaseB = pb
+        self.voltsPhaseC = pc


### PR DESCRIPTION
Had a chance to look at this over the weekend.  Fixes #100, plus some extraneous Black impacts.

This solution does increase writes of settings.json, but I think that's unavoidable if we want any persistence of data.  It minimizes the writes by:

- Only storing non-zero values; missing values are interpolated as zero by the response code
- Sampling every five minutes (for alignment with the Tesla API)

So at most, it's one write every five minutes while charging, and an idle system doesn't do any extra writes.