### PR TITLE
Fixing a python syntax error for getVoltageMeasurement with 3 phases

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -438,7 +438,7 @@ class TWCMaster:
             if all([slave.voltsPhaseC > 0 for slave in slavesWithVoltage]):
                 total = sum(
                     [
-                        sum(slave.voltsPhaseA, slave.voltsPhaseB, slave.voltsPhaseC)
+                        (slave.voltsPhaseA + slave.voltsPhaseB + slave.voltsPhaseC)
                         for slave in slavesWithVoltage
                     ]
                 )


### PR DESCRIPTION
It always throws an exception on execution