### PR TITLE
Calculation from amps to watts does not work for 3 phases with 240V

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -140,11 +140,11 @@ class TWCMaster:
 
     def convertAmpsToWatts(self, amps):
         (voltage, phases) = self.getVoltageMeasurement()
-        return math.sqrt(phases) * voltage * amps
+        return phases * voltage * amps
 
     def convertWattsToAmps(self, watts):
         (voltage, phases) = self.getVoltageMeasurement()
-        return watts / (math.sqrt(phases) * voltage)
+        return watts / (phases * voltage)
 
     def countSlaveTWC(self):
         return int(len(self.slaveTWCRoundRobin))


### PR DESCRIPTION
So I changed it to my observations and it works like a charm. It will work for 1 phases. But there is a big question about 400V 3 phases systems. How to they differ from the other two?