### PR TITLE
Adding real power to charger load and calculation of green energy

### DIFF
--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -83,6 +83,12 @@
         "defaultVoltage": 240,
         "numberOfPhases": 1,
 
+        # As I observed different reactive power changing with the the amps used,
+        # I introduce a real power variable for minAmps and maxAmps
+        # For my installation there was 0.90 at 6 amps and 0.93 at 20 amps        
+        "realPowerFactorMinAmps": 0.9,
+        "realPowerFactorMaxAmps": 0.93,
+
         # When determining how much green energy is available for charging, we count
         # greenEnergyAmpsOffset as consumption. This is most often given a value
         # equal to the average amount of power consumed by everything other than car

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -428,11 +428,11 @@
       
       # Perform rate limiting first (as there are some very chatty topics).
       # For each message that comes through, we take the sensor name and check
-      # when we last updated it. If it was less than msgRateSeconds
+      # when we last updated it. If it was less than msgRateInSeconds
       # seconds ago, we send it later.
-            "msgRateSeconds": 15,
+            "msgRateInSeconds": 60,
       
-      # Resends the last sensor value at least once every resendLastMsgRateInSeconds, 
+      # Resends the last sensor value at least once every resendRateInSeconds, 
       # so HASS does not forget the value ;-)
             "resendRateInSeconds": 3600,
       

--- a/lib/TWCManager/Status/HASSStatus.py
+++ b/lib/TWCManager/Status/HASSStatus.py
@@ -16,7 +16,7 @@ class HASSStatus:
     configHASS = None
     debugLevel = 0
     master = None
-    msgRateSeconds = 15
+    msgRateInSeconds = 60
     resendRateInSeconds = 3600 
     retryRateInSeconds = 60
     msgQueue = {}    
@@ -42,7 +42,7 @@ class HASSStatus:
         self.serverIP = self.configHASS.get("serverIP", None)
         self.serverPort = self.configHASS.get("serverPort", 8123)
         self.apiKey = self.configHASS.get("apiKey", None)
-        self.msgRateSeconds = self.configHASS.get("msgRateSeconds", 15)
+        self.msgRateInSeconds = self.configHASS.get("msgRateInSeconds", 60)
         self.resendRateInSeconds = self.configHASS.get("resendRateInSeconds", 3600)
         self.retryRateInSeconds = self.configHASS.get("retryRateInSeconds", 60)
         self.debugLevel = self.configConfig.get("debugLevel", 0)
@@ -65,7 +65,7 @@ class HASSStatus:
 
     def background_task_thread(self):
         while True:
-            self.time.sleep(self.msgRateSeconds)
+            self.time.sleep(self.msgRateInSeconds)
             self.backgroundTasksLock.acquire()
             for msgKey in self.msgQueue:
                 msg = self.msgQueue[msgKey]

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -382,9 +382,12 @@ class TWCMaster:
         # Fetches and uses consumptionW separately
         generationOffset = self.getGenerationOffset()
         solarW = float(generationW - generationOffset)
+        solarAmps = self.convertWattsToAmps(solarW)
 
         # Offer the smaller of the two, but not less than zero.
-        return max(min(newOffer, self.convertWattsToAmps(solarW)), 0)
+        amps = max(min(newOffer,solarAmps), 0)
+        amps = amps / self.getRealPowerFactor(amps)
+        return amps 
 
     def getNormalChargeLimit(self, ID):
         if "chargeLimits" in self.settings and str(ID) in self.settings["chargeLimits"]:

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -140,12 +140,11 @@ class TWCMaster:
 
     def convertAmpsToWatts(self, amps):
         (voltage, phases) = self.getVoltageMeasurement()
-        return phases * voltage * amps * self.getRealPowerFactor(amps)
+        return phases * voltage * amps
 
     def convertWattsToAmps(self, watts):
         (voltage, phases) = self.getVoltageMeasurement()
-        amps = watts / (phases * voltage)
-        return amps / self.getRealPowerFactor(amps)
+        return watts / (phases * voltage)
 
     def getRealPowerFactor(self, amps):
         realPowerFactorMinAmps = self.config["config"].get("realPowerFactorMinAmps", 1)
@@ -310,7 +309,8 @@ class TWCMaster:
     def getChargerLoad(self):
         # Calculate in watts the load that the charger is generating so
         # that we can exclude it from the consumption if necessary
-        return self.convertAmpsToWatts(self.getTotalAmpsInUse())
+        amps = self.getTotalAmpsInUse()
+        return self.convertAmpsToWatts(amps) * self.getRealPowerFactor(amps)
 
     def getConsumption(self):
         consumptionVal = 0

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -140,11 +140,22 @@ class TWCMaster:
 
     def convertAmpsToWatts(self, amps):
         (voltage, phases) = self.getVoltageMeasurement()
-        return phases * voltage * amps
+        return phases * voltage * amps * self.getRealPowerFactor(amps)
 
     def convertWattsToAmps(self, watts):
         (voltage, phases) = self.getVoltageMeasurement()
-        return watts / (phases * voltage)
+        amps = watts / (phases * voltage)
+        return amps / self.getRealPowerFactor(amps)
+
+    def getRealPowerFactor(self, amps):
+        realPowerFactorMinAmps = self.config["config"].get("realPowerFactorMinAmps", 1)
+        realPowerFactorMaxAmps = self.config["config"].get("realPowerFactorMaxAmps", 1)
+        minAmps = self.config["config"]["minAmpsPerTWC"]
+        maxAmps = self.config["config"]["wiringMaxAmpsAllTWCs"]
+        if (minAmps == maxAmps):
+            return 1
+        else:
+            return ((amps-minAmps)/(maxAmps-minAmps)*(realPowerFactorMaxAmps-realPowerFactorMinAmps))+realPowerFactorMinAmps
 
     def countSlaveTWC(self):
         return int(len(self.slaveTWCRoundRobin))

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -1099,4 +1099,4 @@ class TWCSlave:
             )                     
 
     def getCurrentChargerLoad(self):
-        return self.master.convertAmpsToWatts(self.reportedAmpsActual)
+        return self.master.convertAmpsToWatts(self.reportedAmpsActual) * self.master.getRealPowerFactor(self.reportedAmpsActual)

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -540,6 +540,10 @@ class TWCSlave:
         ):
             self.timeReportedAmpsActualChangedSignificantly = now
             self.reportedAmpsActualSignificantChangeMonitor = self.reportedAmpsActual
+            for module in self.master.getModulesByType("Status"):
+                module["ref"].setStatus(
+                    self.TWCID, "power", "power", self.reportedAmpsActual, "A"
+                )
 
         ltNow = self.time.localtime()
         hourNow = ltNow.tm_hour + (ltNow.tm_min / 60)


### PR DESCRIPTION
Loading with 6A results in about 5.4A reportedAmps but only takes around 4.88A in real - so there is 10% fake won't be taken from the grid. With 20A I have around 19.8A reportedAmps and 18.46A in real. So I have around 7% fake. 

Just added this two settings for calculating charger load and to calculate green energy. What are your experiences with the blind power? 

(Last 3 commits for this - all other commits from PR https://github.com/ngardiner/TWCManager/pull/122).