### PR TITLE
Set charge limit if car ignores Stop API

### DIFF
--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -217,6 +217,8 @@ class Policy:
         limit = None
         if self.limitOverride:
             limit = self.master.getModuleByName("TeslaAPI").minBatteryLevelAtHome
+            if limit < 50:
+                limit = 50
         else:
             limit = self.policyValue(policy.get("charge_limit", -1))
         if not (limit >= 50 and limit <= 100):

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -333,3 +333,6 @@ class Policy:
     
     def overrideLimit(self):
         self.limitOverride = True
+
+    def clearOverride(self):
+        self.limitOverride = False

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -216,7 +216,7 @@ class Policy:
         # If a charge limit is defined for this policy, apply it
         limit = None
         if self.limitOverride:
-            limit = self.master.getModuleByName("TeslaAPI").minBatteryLevelAtHome
+            limit = self.master.getModuleByName("TeslaAPI").minBatteryLevelAtHome - 1
             if limit < 50:
                 limit = 50
         else:

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -74,6 +74,7 @@ class Policy:
         },
     ]
     lastPolicyCheck = 0
+    limitOverride = False
     master = None
     policyCheckInterval = 30
 
@@ -172,12 +173,7 @@ class Policy:
                 continue
 
         # No policy has matched; keep the current policy
-        current_policy = next(
-            policy
-            for policy in self.charge_policy
-            if policy["name"] == self.active_policy
-        )
-        self.enforcePolicy(current_policy)
+        self.enforcePolicy(self.getPolicyByName(self.active_policy))
 
     def enforcePolicy(self, policy, updateLatch=False):
         if self.active_policy != str(policy["name"]):
@@ -187,6 +183,7 @@ class Policy:
                 f("New policy selected; changing to {colored(policy['name'], 'red')}"),
             )
             self.active_policy = str(policy["name"])
+            self.limitOverride = False
 
         if updateLatch and "latch_period" in policy:
             policy["__latchTime"] = time.time() + policy["latch_period"] * 60
@@ -217,7 +214,11 @@ class Policy:
             self.master.queue_background_task({"cmd": bgt})
 
         # If a charge limit is defined for this policy, apply it
-        limit = self.policyValue(policy.get("charge_limit", -1))
+        limit = None
+        if self.limitOverride:
+            limit = self.master.getModuleByName("TeslaAPI").minBatteryLevelAtHome
+        else:
+            limit = self.policyValue(policy.get("charge_limit", -1))
         if not (limit >= 50 and limit <= 100):
             limit = -1
         self.master.queue_background_task({"cmd": "applyChargeLimit", "limit": limit})
@@ -329,3 +330,6 @@ class Policy:
             if self.doesConditionMatch(match, condition, value, exitOn) == exitOn:
                 return exitOn
         return not exitOn
+    
+    def overrideLimit(self):
+        self.limitOverride = True

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -53,6 +53,7 @@ class TWCMaster:
     )
     slaveTWCs = {}
     slaveTWCRoundRobin = []
+    stopTimeout = datetime.max
     spikeAmpsToCancel6ALimit = 16
     subtractChargerLoad = False
     teslaLoginAskLater = False
@@ -591,22 +592,10 @@ class TWCMaster:
         self.debugLog(
             10, "TWCMaster", "Number of cars charging now: " + str(carsCharging)
         )
-        return carsCharging
 
-        carsCharging = len(
-            [
-                slaveTWC
-                for slaveTWC in self.getSlaveTWCs()
-                if slaveTWC.reportedAmpsActual >= 1.0
-            ]
-        )
-        self.debugLog(
-            10, "TWCMaster", "Number of cars charging now: " + str(carsCharging)
-        )
-        for module in self.getModulesByType("Status"):
-            module["ref"].setStatus(
-                slaveTWC.TWCID, "cars_charging", "carsCharging", carsCharging, ""
-            )
+        if carsCharging == 0:
+            self.stopTimeout = datetime.max
+
         return carsCharging
 
     def queue_background_task(self, task):
@@ -1073,6 +1062,10 @@ class TWCMaster:
         # 3 = Send TWC Stop command to each slave
         if self.settings.get("chargeStopMode", "1") == "1":
             self.queue_background_task({"cmd": "charge", "charge": False})
+            if self.stopTimeout == datetime.max:
+                self.stopTimeout = datetime.now() + timedelta(seconds = 10)
+            elif datetime.now() > self.stopTimeout:
+                self.getModuleByName("Policy").overrideLimit()
         if self.settings.get("chargeStopMode", "1") == "2":
             self.settings["respondToSlaves"] = 0
         if self.settings.get("chargeStopMode", "1") == "3":

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -1045,6 +1045,7 @@ class TWCMaster:
         # below
         if self.settings.get("chargeStopMode", "1") == "1":
             self.queue_background_task({"cmd": "charge", "charge": True})
+            self.getModuleByName("Policy").clearOverride()
         if self.settings.get("chargeStopMode", "1") == "2":
             self.settings["respondToSlaves"] = 1
         if self.settings.get("chargeStopMode", "1") == "3":


### PR DESCRIPTION
This starts a ten-second timer when asked to stop charging.  (For my car, there appears to be about a two second gap between the first non-zero SHB message and the stop charge response, so I think ten seconds is enough buffer.  Easy to increase if not.)  If asked to stop again after the ten seconds are up but before all cars have stopped charging, the charge limit for the current policy is overridden so that the cars will consider themselves fully charged (modulo the minimum charge limit of 50%).  This lasts until the next policy change.

Some minor cleanup incidental to the fix, too.

I tested by temporarily making the Stop command return immediately, and my car's limit was set to 61% when I manually started it charging with no power available.

Fixes #126.