### PR TITLE
Define excessW property on Powerwall

### DIFF
--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -68,6 +68,11 @@ class TeslaPowerwall2:
         return float(value.get("load", dict()).get("instant_power", 0))
 
     @property
+    def excessW(self):
+        excess = self.generatedW - self.consumedW
+        return excess if excess > 0 else 0
+
+    @property
     def importW(self):
         value = self.getPWValues()
         gridW = float(value.get("site", dict()).get("instant_power", 0))


### PR DESCRIPTION
I had previously had a policy that keys off of generatedW, but summer and A/C have driven home how variable a logical generation threshold can be.  This exposes one more property which is simply the difference between generation and consumption.