### PR TITLE
Delay after limit change

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -193,8 +193,9 @@ def background_tasks_thread(master):
                 carapi.setCarApiLastErrorTime(0)
                 carapi.car_api_available(task["email"], task["password"])
             elif task["cmd"] == "checkArrival":
+                limit = carapi.lastChargeLimitApplied if carapi.lastChargeLimitApplied != 0 else -1
                 carapi.applyChargeLimit(
-                    limit=carapi.lastChargeLimitApplied, checkArrival=True
+                    limit=limit, checkArrival=True
                 )
             elif task["cmd"] == "checkCharge":
                 carapi.updateChargeAtHome()

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -859,6 +859,7 @@ class TeslaAPI:
 
         self.carApiLastChargeLimitApplyTime = now
 
+        needSleep = False
         for vehicle in self.carApiVehicles:
             if vehicle.stopTryingToApplyLimit or not vehicle.ready():
                 continue
@@ -924,6 +925,16 @@ class TeslaAPI:
 
                 if vehicle.stopTryingToApplyLimit:
                     self.master.saveNormalChargeLimit(vehicle.ID, outside, limit)
+
+            if vehicle.atHome and vehicle.stopTryingToApplyLimit:
+                needSleep = True
+
+        if needSleep:
+            # If you start charging too quickly after setting the charge limit,
+            # the vehicle sometimes refuses the start command because it's
+            # "fully charged" under the old limit, but then continues to say
+            # charging was stopped once the new limit is in place.
+            self.time.sleep(5)
 
         if checkArrival:
             self.updateChargeAtHome()

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -782,6 +782,14 @@ class TeslaAPI:
 
     def applyChargeLimit(self, limit, checkArrival=False, checkDeparture=False):
 
+        if limit != -1 and (limit < 50 or limit > 100):
+            self.master.debugLog(
+                8,
+                "TeslaAPI",
+                "applyChargeLimit skipped"
+            )
+            return "error"
+            
         if self.car_api_available() == False:
             self.master.debugLog(
                 8,


### PR DESCRIPTION
Two charge limit refinements:

- It appears that under certain circumstances, checkArrival can fire before the policy has determined and set a limit.  In that case, it attempts to apply a limit of 0% to all vehicles, which is counterproductive.  This change makes the limit passed be -1, and adds a check to bail if an invalid value is passed in the future.
- It seems that there's a race condition where charging was previously stopped; when the limit is increased (such that the car would charge) *and* the car is told to start charging almost simultaneously.  The perverse response from the API is that the car accepts the limit change, says it can't start charging because it's fully charged (under the old limit), but then reports that it's not charging because it was told to stop.  This adds a delay between the limit change and the start command, which will hopefully enable the car to get itself figured out.