### PR TITLE
Limit Override should never *increase* the limit for a policy

### DIFF
--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -212,13 +212,12 @@ class Policy:
             self.master.queue_background_task({"cmd": bgt})
 
         # If a charge limit is defined for this policy, apply it
-        limit = None
+        limit = limit = self.policyValue(policy.get("charge_limit", -1))
         if self.limitOverride:
-            limit = self.master.getModuleByName("TeslaAPI").minBatteryLevelAtHome - 1
-            if limit < 50:
-                limit = 50
-        else:
-            limit = self.policyValue(policy.get("charge_limit", -1))
+            currentCharge = self.master.getModuleByName("TeslaAPI").minBatteryLevelAtHome - 1
+            if currentCharge < 50:
+                currentCharge = 50
+            limit = currentCharge if limit == -1 else min(limit, currentCharge)
         if not (limit >= 50 and limit <= 100):
             limit = -1
         self.master.queue_background_task({"cmd": "applyChargeLimit", "limit": limit})


### PR DESCRIPTION
I've triggered the limit override a time or two because of HVAC draw, and found that it was actually increasing the limit I had set for my non-charging policy.  Mostly a cosmetic fix, because regardless the limit causes the car not to charge, but this causes the policy's limit to win if it's lesser.