### PR TITLE
Rounding getMaxAmpsToDivideGreenEnergy to 2 digits

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -374,7 +374,7 @@ class TWCMaster:
         solarW = float(generationW - generationOffset)
 
         # Offer the smaller of the two, but not less than zero.
-        return max(min(newOffer, self.convertWattsToAmps(solarW)), 0)
+        return round(max(min(newOffer, self.convertWattsToAmps(solarW)), 0),2)
 
     def getNormalChargeLimit(self, ID):
         if "chargeLimits" in self.settings and str(ID) in self.settings["chargeLimits"]:


### PR DESCRIPTION
As this number is also used for status reporting and initially was an int - I think it's best to limit this to 2 digits.  