### PR TITLE
Web hook implementation

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -42,6 +42,7 @@ from datetime import datetime
 import threading
 from ww import f
 from lib.TWCManager.TWCMaster import TWCMaster
+import requests
 
 # Define available modules for the instantiator
 # All listed modules will be loaded at boot time
@@ -215,6 +216,9 @@ def background_tasks_thread(master):
                 master.snapHistoryData()
             elif task["cmd"] == "updateStatus":
                 update_statuses()
+            elif task["cmd"] == "webhook":
+                body = master.getStatus()
+                requests.post(task["url"], json=body)
 
         except:
             master.debugLog(

--- a/docs/PolicyCustomization.md
+++ b/docs/PolicyCustomization.md
@@ -106,6 +106,50 @@ Flex for the Track Green Energy policy can be set using the
 `greenEnergyFlexAmps` value; custom policies can include an `allowed_flex`
 attribute.
 
+## Webhooks
+
+If you want to trigger external actions based on TWCManager state changes
+(home automation, IFTTT, etc.), you can define a set of webhooks on each
+policy.  The URL you supply will receive a POST with the TWCManager status
+on the event you select.
+
+For each policy, the events are:
+
+- "enter" when the policy becomes selected
+- "start" when a vehicle begins charging with this policy selected
+- "stop" when a vehicle stops charging with this policy selected
+- "exit" when the policy is no longer selected
+
+For example, suppose Scheduled Charging is configured to charge for one hour
+beginning at midnight.  Two vehicles are connected, and one reaches its charge
+limit during this time.  The events fired would be:
+
+- "enter" for Scheduled Charging at midnight
+- "start" for Scheduled Charging when a vehicle begins charging shortly after
+  midnight; occurs twice
+- "stop" for Scheduled Charging when the first vehicle reaches its charge limit
+- "exit" for Scheduled Charging at 1 AM
+- "enter" for Non Scheduled Charging at 1 AM
+- "stop" for Non Scheduled Charging shortly after 1 AM when the second
+  vehicle stops due to the policy change
+
+Note that stops which occur due to the policy change will be attributed to the
+new policy.
+
+Webhooks can be set for built-in policies using the `webhooks` node under
+`policy.extend` in the `config.json` file.  For example:
+
+    "webhooks": {
+      "Scheduled Charging": {
+        "start": "http://IP/apps/api/737/trigger?access_token=TOKEN",
+        "exit": "http://IP/apps/api/866/trigger?access_token=TOKEN",
+        "stop": "http://IP/apps/api/866/trigger?access_token=TOKEN",
+      }
+    }
+
+For custom policies, they can be set using the `webhooks` property of the
+policy.
+
 # Defining Custom Policies
 
 If you wish to add additional policies, they can be specified in the
@@ -140,6 +184,7 @@ The values in a policy definition are:
 - `allowed_flex`:  If the available current is reduced below the minimum for
   charging, continue to supply the minimum.  Only useful for policies where the
   charge amps vary.
+- `webhooks`:  An object containing desired webhooks for the policy.  See above.
 
 ### Policy Values
 

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -265,6 +265,19 @@
             #  "condition":[],
             #  "value":[]
             #},
+        },
+
+        # This permits defining webhooks for the built-in policies
+        "webhooks": {
+          #"Scheduled Charging": {
+          #  "enter": "http://ift.tt/your_url_here",
+          #  "start": "http://ift.tt/your_url_here",
+          #  "stop": "http://ift.tt/your_url_here",
+          #  "exit": "http://ift.tt/your_url_here"
+          #}
+          #"Track Green Energy": etc.
+          #"Charge Now": etc.
+          #"Non Scheduled Charging": etc.
         }
       },
       # NOTE: Override and Extend are mutually exclusive options. Once you override, you
@@ -303,14 +316,6 @@
       #   "value": [3],
       #   "charge_amps": "settings.nonScheduledAmpsMax",
       #   "charge_limit": "config.nonScheduledLimit" },
-
-      # { "name": "Track Green Energy",
-      #   "match": ["settings.nonScheduledAction"],
-      #   "condition": ["eq"],
-      #   "value": [3],
-      #   "background_task": "checkGreenEnergy",
-      #   "allowed_flex": "config.greenEnergyFlexAmps",
-      #   "charge_limit": "config.greenEnergyLimit" }
 
       ]
     },

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -311,38 +311,7 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
             self.wfile.write(json_data.encode("utf-8"))
 
         elif url.path == "/api/getStatus":
-            data = {
-                "carsCharging": self.server.master.num_cars_charging_now(),
-                "chargerLoadWatts": "%.2f" % float(self.server.master.getChargerLoad()),
-                "currentPolicy": str(
-                    self.server.master.getModuleByName("Policy").active_policy
-                ),
-                "maxAmpsToDivideAmongSlaves": "%.2f"
-                % float(self.server.master.getMaxAmpsToDivideAmongSlaves()),
-            }
-            consumption = float(self.server.master.getConsumption())
-            if consumption:
-                data["consumptionAmps"] = (
-                    "%.2f" % self.server.master.convertWattsToAmps(consumption),
-                )
-                data["consumptionWatts"] = "%.2f" % consumption
-            else:
-                data["consumptionAmps"] = "%.2f" % 0
-                data["consumptionWatts"] = "%.2f" % 0
-            generation = float(self.server.master.getGeneration())
-            if generation:
-                data["generationAmps"] = (
-                    "%.2f" % self.server.master.convertWattsToAmps(generation),
-                )
-                data["generationWatts"] = "%.2f" % generation
-            else:
-                data["generationAmps"] = "%.2f" % 0
-                data["generationWatts"] = "%.2f" % 0
-            if self.server.master.getModuleByName("Policy").policyIsGreen():
-                data["isGreenPolicy"] = "Yes"
-            else:
-                data["isGreenPolicy"] = "No"
-
+            data = self.server.master.getStatus()
             self.send_response(200)
             self.send_header("Content-type", "application/json")
             self.end_headers()

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -264,6 +264,35 @@ class TWCMaster:
     def getSlaveSign(self):
         return self.slaveSign
 
+    def getStatus(self):
+        data = {
+            "carsCharging": self.num_cars_charging_now(),
+            "chargerLoadWatts": "%.2f" % float(self.getChargerLoad()),
+            "currentPolicy": str(self.getModuleByName("Policy").active_policy),
+            "maxAmpsToDivideAmongSlaves": "%.2f"
+            % float(self.getMaxAmpsToDivideAmongSlaves()),
+        }
+        consumption = float(self.getConsumption())
+        if consumption:
+            data["consumptionAmps"] = ("%.2f" % self.convertWattsToAmps(consumption),)
+            data["consumptionWatts"] = "%.2f" % consumption
+        else:
+            data["consumptionAmps"] = "%.2f" % 0
+            data["consumptionWatts"] = "%.2f" % 0
+        generation = float(self.getGeneration())
+        if generation:
+            data["generationAmps"] = ("%.2f" % self.convertWattsToAmps(generation),)
+            data["generationWatts"] = "%.2f" % generation
+        else:
+            data["generationAmps"] = "%.2f" % 0
+            data["generationWatts"] = "%.2f" % 0
+        if self.getModuleByName("Policy").policyIsGreen():
+            data["isGreenPolicy"] = "Yes"
+        else:
+            data["isGreenPolicy"] = "No"
+
+        return data
+
     def getSpikeAmps(self):
         return self.spikeAmpsToCancel6ALimit
 
@@ -374,7 +403,7 @@ class TWCMaster:
         solarW = float(generationW - generationOffset)
 
         # Offer the smaller of the two, but not less than zero.
-        return round(max(min(newOffer, self.convertWattsToAmps(solarW)), 0),2)
+        return round(max(min(newOffer, self.convertWattsToAmps(solarW)), 0), 2)
 
     def getNormalChargeLimit(self, ID):
         if "chargeLimits" in self.settings and str(ID) in self.settings["chargeLimits"]:

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -508,6 +508,7 @@ class TWCSlave:
             self.reportedAmpsActualSignificantChangeMonitor < 3
             and self.reportedAmpsActual > 3
         ):
+            self.master.getModuleByName("Policy").fireWebhook("start")
             self.master.queue_background_task({"cmd": "checkArrival"})
 
         # If power drops off, check whether a car leaves in the next little while
@@ -515,6 +516,7 @@ class TWCSlave:
             self.reportedAmpsActualSignificantChangeMonitor > 2
             and self.reportedAmpsActual < 2
         ):
+            self.master.getModuleByName("Policy").fireWebhook("stop")
             self.departureCheckTimes = [now + 5 * 60, now + 20 * 60, now + 45 * 60]
         if len(self.departureCheckTimes) > 0 and now >= self.departureCheckTimes[0]:
             self.master.queue_background_task({"cmd": "checkDeparture"})


### PR DESCRIPTION
Fixes #112, albeit with a little more moved code than I wanted.

Defines four webhooks which can be set on any policy, built-in or custom:
- "enter" when the policy becomes selected
- "start" when any vehicle begins charging while policy is selected (but not fired if vehicle was already charging when policy was selected)
- "stop" when any vehicle stops charging while policy is selected (but not fired if vehicle stops charging after the policy exits)
- "exit" when the policy is no longer selected

Currently, this is always a POST with the same content as /api/getStatus; if there's a need for more granularity, we can probably figure something out.