### PR TITLE
Don't stop quickly means exactly that

### DIFF
--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -772,10 +772,7 @@ class TWCSlave:
                         + str(self.reportedAmpsActual)
                         + " < 4",
                     )
-                    if self.master.getMaxAmpsToDivideAmongSlaves() < 1:
-                        desiredAmpsOffered = 0
-                    else:
-                        desiredAmpsOffered = minAmpsToOffer
+                    desiredAmpsOffered = minAmpsToOffer
             else:
                 # no cars are charging, and desiredAmpsOffered < minAmpsToOffer
                 # so we need to set desiredAmpsOffered to 0


### PR DESCRIPTION
The comment and debug output above says that we wait until all the following are true before asking cars to stop, in case the lack-of-power is temporary:

- At least one minute since we changed the amount of current being offered
- At least one minute since the car significantly changed the amount of current being drawn
- The car is drawing at least 4A

That's to ensure we don't stop a car immediately after plugging in, and to give some grace to ride out temporary dips in available power.  But the code actually doesn't wait if the available power is less than 1A.

This corrects the code to match the comments' described behavior; if the available power remains below the minimum, it will stop after at most one minute (and run at the minimum in the meantime).