### PR TITLE
Don't spike when increasing from zero to the value already offered

### DIFF
--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -853,7 +853,7 @@ class TWCSlave:
                     # a higher one less than spikeAmpsToCancel6ALimit.
                     (
                         desiredAmpsOffered < self.master.getSpikeAmps()
-                        and desiredAmpsOffered > self.lastAmpsOffered
+                        and desiredAmpsOffered > self.reportedAmpsMax
                     )
                     or (
                         # ...or if we've been offering the car more amps than it's


### PR DESCRIPTION
When `minAmpsPerTWC` <= `minAmpsTwcSupports`, TWCManager does the spike-amps dance when increasing from the minimum to the minimum.  This is because the last thing it offered was zero, even though the TWC is interpreting that as equivalent to the minimum.  By comparing against what the TWC says its maximum actually is, we can trigger the dance only when it is actually a difference as far as the car is concerned.