### PR TITLE
Open hab integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ EMS Interfaces read solar generation and/or consumption values from an external 
 | [SolarLog](docs/modules/EMS_SolarLog.md) | Available v1.2.0 | Supports SolarLog Base API |
 | [Tesla Powerwall2](docs/modules/EMS_Powerwall2.md) | Available v1.1.3 | Support for Tesla Powerwall 2 |
 | [The Energy Detective](docs/modules/EMS_TED.md) | Available v1.1.2 | Support for TED (The Energy Detective) |
+| [openHAB](docs/modules/EMS_OpenHab.md) | Available v1.0.0 | Supports openHAB items |
 
 ### Logging Interfaces
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ EMS Interfaces read solar generation and/or consumption values from an external 
 | [SolarLog](docs/modules/EMS_SolarLog.md) | Available v1.2.0 | Supports SolarLog Base API |
 | [Tesla Powerwall2](docs/modules/EMS_Powerwall2.md) | Available v1.1.3 | Support for Tesla Powerwall 2 |
 | [The Energy Detective](docs/modules/EMS_TED.md) | Available v1.1.2 | Support for TED (The Energy Detective) |
-| [openHAB](docs/modules/EMS_OpenHab.md) | Available v1.0.0 | Supports openHAB items |
+| [openHAB](docs/modules/EMS_OpenHab.md) | Available v1.2.0 | Supports openHAB items |
 
 ### Logging Interfaces
 

--- a/TWCManager.py
+++ b/TWCManager.py
@@ -62,6 +62,7 @@ modules_available = [
     "EMS.SolarLog",
     "EMS.TeslaPowerwall2",
     "EMS.TED",
+    "EMS.OpenHab",
     "Logging.ConsoleLogging",
     "Logging.CSVLogging",
     "Logging.MySQLLogging",

--- a/docs/modules/EMS_OpenHab.md
+++ b/docs/modules/EMS_OpenHab.md
@@ -4,18 +4,6 @@
 
 The openHAB EMS module allows fetching of solar Generation and Consumption values from openHAB items via the openHAB REST API.
 
-### Note
-
-In case that the TWC's power draw is included in the value of your **consumptionItem**, please ensure the following configuration setting is enabled in your ```config.json``` file:
-
-```
-{
-    "config": {
-        "subtractChargerLoad": true
-    }
-}
-```
-
 ### Status
 
 | Detail          | Value                          |
@@ -49,9 +37,21 @@ The following table shows the available configuration parameters for the openHAB
 }
 ```
 
+### Note
+
+In case that the TWC's power draw is included in the value of your **consumptionItem**, please ensure the following configuration setting is enabled in your ```config.json``` file:
+
+```
+{
+    "config": {
+        "subtractChargerLoad": true
+    }
+}
+```
+
 ### Item Names
 
-For openHAB, the two settings "consumptionItem" and "generationItem" must be customized to point to the specific item names you use within openHAB. There is no default or common value for this, so it will require customization to work correctly.
+The two settings "consumptionItem" and "generationItem" must be customized to point to the specific item names you use within openHAB. There is no default or common value for this, so it will require customization to work correctly.
 
 If you do not track one of these values (generation or consumption) via openHAB, leave the parameter blank, and it will not be retrieved.
 

--- a/docs/modules/EMS_OpenHab.md
+++ b/docs/modules/EMS_OpenHab.md
@@ -1,0 +1,69 @@
+# openHAB EMS Module
+
+## Introduction
+
+The openHAB EMS module allows fetching of solar Generation and Consumption values from openHAB items via the openHAB REST API.
+
+### Note
+
+In case that the TWC's power draw is included in the value of your **consumptionItem**, please ensure the following configuration setting is enabled in your ```config.json``` file:
+
+```
+{
+    "config": {
+        "subtractChargerLoad": true
+    }
+}
+```
+
+### Status
+
+| Detail          | Value                          |
+| --------------- | ------------------------------ |
+| **Module Name** | OpenHab                        |
+| **Module Type** | Energy Management System (EMS) |
+| **Features**    | Consumption, Generation        |
+| **Status**      | Implemented, *untested*        |
+
+## Configuration
+
+The following table shows the available configuration parameters for the openHAB EMS module.
+
+| Parameter   | Value         |
+| ----------- | ------------- |
+| enabled     | *required* Boolean value, ```true``` or ```false```. Determines whether we will poll openHAB items. |
+| consumptionItem | *optional* Name of openHAB item displaying consumption. |
+| generationItem  | *optional* Name of openHAB item displaying generation. |
+| serverIP    | *required* The IP address of the openHAB instance. We will poll the REST HTTP API. |
+| serverPort  | *optional* openHAB port. This is the port that we should connect to. Defaults to 8080. |
+
+### JSON Configuration Example
+
+```
+"openHAB": {
+  "enabled": true,
+  "consumptionItem": "Solar_Consumption",
+  "generationItem": "Solar_Generation",
+  "serverIP": "192.168.1.2",
+  "serverPort": "8080"
+}
+```
+
+### Item Names
+
+For openHAB, the two settings "consumptionItem" and "generationItem" must be customized to point to the specific item names you use within openHAB. There is no default or common value for this, so it will require customization to work correctly.
+
+If you do not track one of these values (generation or consumption) via openHAB, leave the parameter blank, and it will not be retrieved.
+
+### Item Types
+
+Make sure both items are of type *Number*. Using Number with a unit (*Number:\<dimension\>*) is also possible.
+
+### openHAB .items File Example
+
+```
+// Just as a number
+Number Solar_Generation "Generation [%d W]"
+// As a number with unit
+Number:Power Solar_Consumption "Consumption [%d W]"
+```

--- a/docs/modules/EMS_OpenHab.md
+++ b/docs/modules/EMS_OpenHab.md
@@ -19,7 +19,7 @@ The following table shows the available configuration parameters for the openHAB
 
 | Parameter   | Value         |
 | ----------- | ------------- |
-| enabled     | *required* Boolean value, ```true``` or ```false```. Determines whether we will poll openHAB items. |
+| enabled     | *required* Boolean value, `true` or `false`. Determines whether we will poll openHAB items. |
 | consumptionItem | *optional* Name of openHAB item displaying consumption. |
 | generationItem  | *optional* Name of openHAB item displaying generation. |
 | serverIP    | *required* The IP address of the openHAB instance. We will poll the REST HTTP API. |

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -433,6 +433,15 @@
           "enabled": false,
           "serverIP": "192.168.1.1",
           "serverPort": "80"
+        },
+      # The openHAB module allows fetching of consumption and generation data from openHAB items.
+      # If you do not track one of these values (generation or consumption) via openHAB, leave the parameter blank, and it will not be retrieved.
+        "openHAB": {
+          "enabled": false,
+          "consumptionItem": "Consumption item name",
+          "generationItem": "Generation item name",
+          "serverIP": "192.168.1.2",
+          "serverPort": "8080"
         }
     },
 

--- a/lib/TWCManager/EMS/OpenHab.py
+++ b/lib/TWCManager/EMS/OpenHab.py
@@ -32,7 +32,7 @@ class OpenHab:
         except KeyError:
             self.configConfig = {}
         try:
-            self.configOpenHab = master.config["sources"]["OpenHab"]
+            self.configOpenHab = master.config["sources"]["openHAB"]
         except KeyError:
             self.configOpenHab = {}
         self.status = self.configOpenHab.get("enabled", False)

--- a/lib/TWCManager/EMS/OpenHab.py
+++ b/lib/TWCManager/EMS/OpenHab.py
@@ -1,0 +1,154 @@
+class OpenHab:
+
+    # OpenHab EMS Module
+    # Fetches Consumption and Generation details from OpenHab
+
+    import requests
+    import time
+
+    apiKey = None
+    cacheTime = 10
+    config = None
+    configConfig = None
+    configOpenHab = None
+    consumedW = 0
+    debugLevel = 0
+    fetchFailed = False
+    generatedW = 0
+    consumptionItem = None
+    generationItem = None
+    lastFetch = 0
+    master = None
+    status = False
+    serverIP = None
+    serverPort = 8080
+    timeout = 2
+
+    def __init__(self, master):
+        self.master = master
+        self.config = master.config
+        try:
+            self.configConfig = master.config["config"]
+        except KeyError:
+            self.configConfig = {}
+        try:
+            self.configOpenHab = master.config["sources"]["OpenHab"]
+        except KeyError:
+            self.configOpenHab = {}
+        self.status = self.configOpenHab.get("enabled", False)
+        self.serverIP = self.configOpenHab.get("serverIP", None)
+        self.serverPort = self.configOpenHab.get("serverPort", 8080)
+        self.debugLevel = self.configConfig.get("debugLevel", 0)
+        self.consumptionItem = self.configOpenHab.get("consumptionItem", None)
+        self.generationItem = self.configOpenHab.get("generationItem", None)
+
+        # Unload if this module is disabled or misconfigured
+        if (not self.status) or (not self.serverIP) or (int(self.serverPort) < 1):
+            self.master.releaseModule("lib.TWCManager.EMS", "OpenHab")
+            return None
+
+    def debugLog(self, minlevel, message):
+        if self.debugLevel >= minlevel:
+            print("debugLog: (" + str(minlevel) + ") " + message)
+
+    def getConsumption(self):
+
+        if not self.status:
+            self.debugLog(10, "OpenHab EMS Module Disabled. Skipping getConsumption")
+            return 0
+
+        # Perform updates if necessary
+        self.update()
+
+        # Return consumption value
+        return self.consumedW
+
+    def getGeneration(self):
+
+        if not self.status:
+            self.debugLog(10, "OpenHab EMS Module Disabled. Skipping getGeneration")
+            return 0
+
+        # Perform updates if necessary
+        self.update()
+
+        # Return generation value
+        return self.generatedW
+
+    def getAPIValue(self, item):
+        url = ("http://" + self.serverIP + ":" + str(self.serverPort) + "/rest/items/" + item + "/state")
+
+        # Update fetchFailed boolean to False before fetch attempt
+        # This will change to true if the fetch failed, ensuring we don't then use the value to update our cache
+        self.fetchFailed = False
+
+        try:
+            self.debugLog(10, "Fetching OpenHab EMS sensor value " + str(item))
+            httpResponse = self.requests.get(url, timeout=self.timeout)
+        except self.requests.exceptions.ConnectionError as e:
+            self.debugLog(
+                4, "Error connecting to OpenHab to publish sensor values"
+            )
+            self.debugLog(10, str(e))
+            self.fetchFailed = True
+            return False
+        except self.requests.exceptions.ReadTimeout as e:
+            self.debugLog(
+                4, "Read Timeout occurred fetching OpenHab sensor value"
+            )
+            self.debugLog(10, str(e))
+            self.fetchFailed = True
+            return False
+
+        response = httpResponse.text
+        response = response.strip()
+
+        # Strip units like '12.3 W'
+        if " " in response:
+            return response.split(" ")[0]
+        return response
+
+    def setCacheTime(self, cacheTime):
+        self.cacheTime = cacheTime
+
+    def setTimeout(self, timeout):
+        self.timeout = timeout
+
+    def update(self):
+        # Update function - determine if an update is required
+
+        if (int(self.time.time()) - self.lastFetch) > self.cacheTime:
+            # Cache has expired. Fetch values from OpenHab sensor.
+
+            if self.consumptionItem:
+                apivalue = self.getAPIValue(self.consumptionItem)
+                if self.fetchFailed is not True:
+                    self.debugLog(10, "OpenHab getConsumption returns " + str(apivalue))
+                    self.consumedW = float(apivalue)
+                else:
+                    self.debugLog(
+                        10, "OpenHab getConsumption fetch failed, using cached values"
+                    )
+            else:
+                self.debugLog(10, "OpenHab Consumption Entity Not Supplied. Not Querying")
+
+            if self.generationItem:
+                apivalue = self.getAPIValue(self.generationItem)
+                if self.fetchFailed is not True:
+                    self.debugLog(10, "OpenHab getGeneration returns " + str(apivalue))
+                    self.generatedW = float(apivalue)
+                else:
+                    self.debugLog(
+                        10, "OpenHab getGeneration fetch failed, using cached values"
+                    )
+            else:
+                self.debugLog(10, "OpenHab Generation Entity Not Supplied. Not Querying")
+
+            # Update last fetch time
+            if self.fetchFailed is not True:
+                self.lastFetch = int(self.time.time())
+
+            return True
+        else:
+            # Cache time has not elapsed since last fetch, serve from cache.
+            return False

--- a/lib/TWCManager/EMS/OpenHab.py
+++ b/lib/TWCManager/EMS/OpenHab.py
@@ -102,7 +102,17 @@ class OpenHab:
         # Strip units like '12.3 W'
         if " " in response:
             return response.split(" ")[0]
-        return response
+
+        try:
+            responseAsFloat = float(response)
+            return responseAsFloat
+        except ValueError:
+            self.master.debugLog(
+                4, "OpenHab", "Fetched value from OpenHab item is not a number"
+            )
+            self.master.debugLog(10, "OpenHab", "Server response: " + str(response))
+            self.fetchFailed = True
+            return False
 
     def setCacheTime(self, cacheTime):
         self.cacheTime = cacheTime
@@ -120,7 +130,7 @@ class OpenHab:
                 apivalue = self.getAPIValue(self.consumptionItem)
                 if self.fetchFailed is not True:
                     self.master.debugLog(10, "OpenHab", "OpenHab getConsumption returns " + str(apivalue))
-                    self.consumedW = float(apivalue)
+                    self.consumedW = apivalue
                 else:
                     self.master.debugLog(
                         10, "OpenHab", "OpenHab getConsumption fetch failed, using cached values"
@@ -132,7 +142,7 @@ class OpenHab:
                 apivalue = self.getAPIValue(self.generationItem)
                 if self.fetchFailed is not True:
                     self.master.debugLog(10, "OpenHab", "OpenHab getGeneration returns " + str(apivalue))
-                    self.generatedW = float(apivalue)
+                    self.generatedW = apivalue
                 else:
                     self.master.debugLog(
                         10, "OpenHab", "OpenHab getGeneration fetch failed, using cached values"

--- a/lib/TWCManager/EMS/OpenHab.py
+++ b/lib/TWCManager/EMS/OpenHab.py
@@ -47,14 +47,10 @@ class OpenHab:
             self.master.releaseModule("lib.TWCManager.EMS", "OpenHab")
             return None
 
-    def debugLog(self, minlevel, message):
-        if self.debugLevel >= minlevel:
-            print("OpenHab: (" + str(minlevel) + ") " + message)
-
     def getConsumption(self):
 
         if not self.status:
-            self.debugLog(10, "OpenHab EMS Module Disabled. Skipping getConsumption")
+            self.master.debugLog(10, "OpenHab", "OpenHab EMS Module Disabled. Skipping getConsumption")
             return 0
 
         # Perform updates if necessary
@@ -66,7 +62,7 @@ class OpenHab:
     def getGeneration(self):
 
         if not self.status:
-            self.debugLog(10, "OpenHab EMS Module Disabled. Skipping getGeneration")
+            self.master.debugLog(10, "OpenHab", "OpenHab EMS Module Disabled. Skipping getGeneration")
             return 0
 
         # Perform updates if necessary
@@ -83,20 +79,20 @@ class OpenHab:
         self.fetchFailed = False
 
         try:
-            self.debugLog(10, "Fetching OpenHab EMS sensor value " + str(item))
+            self.master.debugLog(10, "OpenHab", "Fetching OpenHab EMS item value " + str(item))
             httpResponse = self.requests.get(url, timeout=self.timeout)
         except self.requests.exceptions.ConnectionError as e:
-            self.debugLog(
-                4, "Error connecting to OpenHab to publish sensor values"
+            self.master.debugLog(
+                4, "OpenHab", "Error connecting to OpenHab to fetch item values"
             )
-            self.debugLog(10, str(e))
+            self.master.debugLog(10, "OpenHab", str(e))
             self.fetchFailed = True
             return False
         except self.requests.exceptions.ReadTimeout as e:
-            self.debugLog(
-                4, "Read Timeout occurred fetching OpenHab sensor value"
+            self.master.debugLog(
+                4, "OpenHab", "Read Timeout occurred fetching OpenHab item value"
             )
-            self.debugLog(10, str(e))
+            self.master.debugLog(10, "OpenHab", str(e))
             self.fetchFailed = True
             return False
 
@@ -118,31 +114,31 @@ class OpenHab:
         # Update function - determine if an update is required
 
         if (int(self.time.time()) - self.lastFetch) > self.cacheTime:
-            # Cache has expired. Fetch values from OpenHab sensor.
+            # Cache has expired. Fetch values from OpenHab item.
 
             if self.consumptionItem:
                 apivalue = self.getAPIValue(self.consumptionItem)
                 if self.fetchFailed is not True:
-                    self.debugLog(10, "OpenHab getConsumption returns " + str(apivalue))
+                    self.master.debugLog(10, "OpenHab", "OpenHab getConsumption returns " + str(apivalue))
                     self.consumedW = float(apivalue)
                 else:
-                    self.debugLog(
-                        10, "OpenHab getConsumption fetch failed, using cached values"
+                    self.master.debugLog(
+                        10, "OpenHab", "OpenHab getConsumption fetch failed, using cached values"
                     )
             else:
-                self.debugLog(10, "OpenHab Consumption Entity Not Supplied. Not Querying")
+                self.master.debugLog(10, "OpenHab", "OpenHab Consumption Entity Not Supplied. Not Querying")
 
             if self.generationItem:
                 apivalue = self.getAPIValue(self.generationItem)
                 if self.fetchFailed is not True:
-                    self.debugLog(10, "OpenHab getGeneration returns " + str(apivalue))
+                    self.master.debugLog(10, "OpenHab", "OpenHab getGeneration returns " + str(apivalue))
                     self.generatedW = float(apivalue)
                 else:
-                    self.debugLog(
-                        10, "OpenHab getGeneration fetch failed, using cached values"
+                    self.master.debugLog(
+                        10, "OpenHab", "OpenHab getGeneration fetch failed, using cached values"
                     )
             else:
-                self.debugLog(10, "OpenHab Generation Entity Not Supplied. Not Querying")
+                self.master.debugLog(10, "OpenHab", "OpenHab Generation Entity Not Supplied. Not Querying")
 
             # Update last fetch time
             if self.fetchFailed is not True:

--- a/lib/TWCManager/EMS/OpenHab.py
+++ b/lib/TWCManager/EMS/OpenHab.py
@@ -7,7 +7,7 @@ class OpenHab:
     import time
 
     apiKey = None
-    cacheTime = 10
+    cacheTime = 10 # in seconds
     config = None
     configConfig = None
     configOpenHab = None
@@ -49,7 +49,7 @@ class OpenHab:
 
     def debugLog(self, minlevel, message):
         if self.debugLevel >= minlevel:
-            print("debugLog: (" + str(minlevel) + ") " + message)
+            print("OpenHab: (" + str(minlevel) + ") " + message)
 
     def getConsumption(self):
 


### PR DESCRIPTION
Added a EMS module for openHAB to retrieve the data of items via their REST API. Most of the code / documentation is just copy and paste from the HASS module, because both platforms are very similar.
I am currently using it with my openHAB setup and it works flawlessly.