### PR TITLE
Move HASS EMS module to new debugLog function

### DIFF
--- a/lib/TWCManager/EMS/HASS.py
+++ b/lib/TWCManager/EMS/HASS.py
@@ -90,7 +90,7 @@ class HASS:
             httpResponse = self.requests.get(url, headers=headers, timeout=self.timeout)
         except self.requests.exceptions.ConnectionError as e:
             self.master.debugLog(
-                4, "HASSEMS", "Error connecting to HomeAssistant to publish sensor values"
+                4, "HASSEMS", "Error connecting to HomeAssistant to fetch sensor values"
             )
             self.master.debugLog(10, "HASSEMS", str(e))
             self.fetchFailed = True

--- a/lib/TWCManager/EMS/HASS.py
+++ b/lib/TWCManager/EMS/HASS.py
@@ -48,14 +48,10 @@ class HASS:
             self.master.releaseModule("lib.TWCManager.EMS", "HASS")
             return None
 
-    def debugLog(self, minlevel, message):
-        if self.debugLevel >= minlevel:
-            print("debugLog: (" + str(minlevel) + ") " + message)
-
     def getConsumption(self):
 
         if not self.status:
-            self.debugLog(10, "HASS EMS Module Disabled. Skipping getConsumption")
+            self.master.debugLog(10, "HASSEMS", "Module Disabled. Skipping getConsumption")
             return 0
 
         # Perform updates if necessary
@@ -67,7 +63,7 @@ class HASS:
     def getGeneration(self):
 
         if not self.status:
-            self.debugLog(10, "HASS EMS Module Disabled. Skipping getGeneration")
+            self.master.debugLog(10, "HASSEMS", "Module Disabled. Skipping getGeneration")
             return 0
 
         # Perform updates if necessary
@@ -90,20 +86,20 @@ class HASS:
         self.fetchFailed = False
 
         try:
-            self.debugLog(10, "Fetching HomeAssistant EMS sensor value " + str(entity))
+            self.master.debugLog(10, "HASSEMS", "Fetching HomeAssistant EMS sensor value " + str(entity))
             httpResponse = self.requests.get(url, headers=headers, timeout=self.timeout)
         except self.requests.exceptions.ConnectionError as e:
-            self.debugLog(
-                4, "Error connecting to HomeAssistant to publish sensor values"
+            self.master.debugLog(
+                4, "HASSEMS", "Error connecting to HomeAssistant to publish sensor values"
             )
-            self.debugLog(10, str(e))
+            self.master.debugLog(10, "HASSEMS", str(e))
             self.fetchFailed = True
             return False
         except self.requests.exceptions.ReadTimeout as e:
-            self.debugLog(
-                4, "Read Timeout occurred fetching HomeAssistant sensor value"
+            self.master.debugLog(
+                4, "HASSEMS", "Read Timeout occurred fetching HomeAssistant sensor value"
             )
-            self.debugLog(10, str(e))
+            self.master.debugLog(10, "HASSEMS", str(e))
             self.fetchFailed = True
             return False
 
@@ -133,26 +129,26 @@ class HASS:
             if self.hassEntityConsumption:
                 apivalue = self.getAPIValue(self.hassEntityConsumption)
                 if self.fetchFailed is not True:
-                    self.debugLog(10, "HASS getConsumption returns " + str(apivalue))
+                    self.master.debugLog(10, "HASSEMS", "getConsumption returns " + str(apivalue))
                     self.consumedW = float(apivalue)
                 else:
-                    self.debugLog(
-                        10, "HASS getConsumption fetch failed, using cached values"
+                    self.master.debugLog(
+                        10, "HASSEMS", "getConsumption fetch failed, using cached values"
                     )
             else:
-                self.debugLog(10, "HASS Consumption Entity Not Supplied. Not Querying")
+                self.master.debugLog(10, "HASSEMS", "Consumption Entity Not Supplied. Not Querying")
 
             if self.hassEntityGeneration:
                 apivalue = self.getAPIValue(self.hassEntityGeneration)
                 if self.fetchFailed is not True:
-                    self.debugLog(10, "HASS getGeneration returns " + str(apivalue))
+                    self.master.debugLog(10, "HASSEMS", "getGeneration returns " + str(apivalue))
                     self.generatedW = float(apivalue)
                 else:
-                    self.debugLog(
-                        10, "HASS getGeneration fetch failed, using cached values"
+                    self.master.debugLog(
+                        10, "HASSEMS", "getGeneration fetch failed, using cached values"
                     )
             else:
-                self.debugLog(10, "HASS Generation Entity Not Supplied. Not Querying")
+                self.master.debugLog(10, "HASSEMS", "Generation Entity Not Supplied. Not Querying")
 
             # Update last fetch time
             if self.fetchFailed is not True:


### PR DESCRIPTION
This moves the HASS EMS module off of the local debugLog function, instead using the function exposed by TWCMaster