### PR TITLE
Select webhook method

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -219,8 +219,11 @@ def background_tasks_thread(master):
             elif task["cmd"] == "updateStatus":
                 update_statuses()
             elif task["cmd"] == "webhook":
-                body = master.getStatus()
-                requests.post(task["url"], json=body)
+                if(config["config"].get("webhookMethod", "POST") == "GET"):
+                    requests.get(task["url"])
+                else:
+                    body = master.getStatus()
+                    requests.post(task["url"], json=body)
 
         except:
             master.debugLog(

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -161,6 +161,10 @@
         # Choose whether to display milliseconds after time on each line of debug info.
         "displayMilliseconds": false,
 
+        # Webhooks can be triggered using either GET or POST methods.
+        # By default, they receive a POST of the current status; uncomment for GET.
+        #"webhookMethod": "GET",
+
         # Normally we fake being a TWC Master using fakeMaster = 1.
         # Two other settings are available, but are only useful for debugging and
         # experimenting:


### PR DESCRIPTION
Minor change; some webhook endpoints require a GET instead of a POST.  This is a global switch, since I'd rather not disrupt the webhook syntax by introducing a per-hook choice unless it's needed.