### PR TITLE
Delayed background tasks

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -205,7 +205,7 @@ class TWCMaster:
                 self.backgroundTasksDelayed
                 and self.backgroundTasksDelayed[0][0] <= datetime.now()
             ):
-                self.queue_background_task(self.backgroundTasksDelayed.pop(0))
+                self.queue_background_task(self.backgroundTasksDelayed.pop(0)[1])
 
             # Get the next task
             try:

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -12,6 +12,7 @@ import time
 from ww import f
 import math
 import random
+import bisect
 
 
 class TWCMaster:
@@ -20,6 +21,7 @@ class TWCMaster:
     backgroundTasksQueue = queue.Queue()
     backgroundTasksCmds = {}
     backgroundTasksLock = threading.Lock()
+    backgroundTasksDelayed = []
     config = None
     consumptionValues = {}
     debugLevel = 0
@@ -195,7 +197,23 @@ class TWCMaster:
         return self.allowedFlex
 
     def getBackgroundTask(self):
-        return self.backgroundTasksQueue.get()
+        result = None
+
+        while result is None:
+            # Insert any delayed tasks
+            while (
+                self.backgroundTasksDelayed
+                and self.backgroundTasksDelayed[0][0] <= datetime.now()
+            ):
+                self.queue_background_task(self.backgroundTasksDelayed.pop(0))
+
+            # Get the next task
+            try:
+                result = self.backgroundTasksQueue.get(timeout=30)
+            except queue.Empty:
+                continue
+
+        return result
 
     def getBackgroundTasksLock(self):
         self.backgroundTasksLock.acquire()
@@ -732,7 +750,14 @@ class TWCMaster:
 
         return carsCharging
 
-    def queue_background_task(self, task):
+    def queue_background_task(self, task, delay=0):
+
+        if delay > 0:
+            bisect.insort(
+                self.backgroundTasksDelayed,
+                (datetime.now() + timedelta(seconds=delay), task),
+            )
+            return
 
         if task["cmd"] in self.backgroundTasksCmds:
             # Some tasks, like cmd='charge', will be called once per second until

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -55,7 +55,6 @@ class TWCSlave:
     lastHeartbeatDebugOutput = ""
     timeLastHeartbeatDebugOutput = 0
     wiringMaxAmps = 0
-    departureCheckTimes = list()
     lifetimekWh = 0
     voltsPhaseA = 0
     voltsPhaseB = 0
@@ -524,10 +523,9 @@ class TWCSlave:
             and self.reportedAmpsActual < 2
         ):
             self.master.getModuleByName("Policy").fireWebhook("stop")
-            self.departureCheckTimes = [now + 5 * 60, now + 20 * 60, now + 45 * 60]
-        if len(self.departureCheckTimes) > 0 and now >= self.departureCheckTimes[0]:
-            self.master.queue_background_task({"cmd": "checkDeparture"})
-            self.departureCheckTimes.pop(0)
+            self.master.queue_background_task({"cmd": "checkDeparture"}, 5 * 60)
+            self.master.queue_background_task({"cmd": "checkDeparture"}, 20 * 60)
+            self.master.queue_background_task({"cmd": "checkDeparture"}, 45 * 60)
 
         # Keep track of the amps the slave is actually using and the last time it
         # changed by more than 0.8A.


### PR DESCRIPTION
I've noticed we have several activities where we do something after a delay, and use various circumlocutions in the code to accomplish that.  This adds a `delay=` parameter to `queue_background_task`, such that the queued task will be added to the queue after at least the specified time has passed.

Caveats:
- **Precision.**  The task will be added to the queue *no earlier* than the specified delay, but might be as much as 30 seconds later.
- **Shutdown.**  Delayed tasks which haven't entered the queue yet will never run if the program shuts down before they do.
- **Deduplication.**  The background task queue has logic to avoid having multiple instances of the same task.  The delayed tasks are explicitly not deduped, since you might want to have the same task running with different delays.  (E.g. check departure, which schedules the same task to run three times at progressively later points.)  However, when the delay expires and they get added to the queue, normal deduping applies, so the newly-added task might get deduped away at that point.