### PR TITLE
Move saveSettings to a background task

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -230,6 +230,8 @@ def background_tasks_thread(master):
                 else:
                     body = master.getStatus()
                     requests.post(task["url"], json=body)
+            elif task["cmd"] == "saveSettings":
+                master.saveSettings()
 
         except:
             master.debugLog(
@@ -1165,7 +1167,7 @@ while True:
                             % (master.getkWhDelivered()),
                         )
                         # Save settings to file
-                        master.saveSettings()
+                        master.queue_background_task({"cmd": "saveSettings"})
 
                     if heartbeatData[0] == 0x07:
                         # Lower amps in use (not amps allowed) by 2 for 10
@@ -1431,6 +1433,8 @@ while True:
         # Sleep 5 seconds so the user might see the error.
         time.sleep(5)
 
+# Make sure any volatile data is written to disk before exiting
+master.queue_background_task({"cmd": "saveSettings"})
 
 # Wait for background tasks thread to finish all tasks.
 # Note that there is no such thing as backgroundTasksThread.stop(). Because we

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -395,14 +395,14 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
             else:
                 self.server.master.setChargeNowAmps(rate)
                 self.server.master.setChargeNowTimeEnd(durn)
-                self.server.master.saveSettings()
+                self.server.master.queue_background_task({"cmd": "saveSettings"})
                 self.send_response(202)
                 self.end_headers()
                 self.wfile.write("".encode("utf-8"))
 
         elif self.url.path == "/api/cancelChargeNow":
             self.server.master.resetChargeNowAmps()
-            self.server.master.saveSettings()
+            self.server.master.queue_background_task({"cmd": "saveSettings"})
             self.send_response(202)
             self.end_headers()
             self.wfile.write("".encode("utf-8"))
@@ -474,7 +474,7 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
                 self.server.master.setScheduledAmpsDaysBitmap(weekDaysBitmap)
             self.server.master.setScheduledAmpsBatterySize(batterySize)
             self.server.master.setScheduledAmpsFlexStart(flexStart)
-            self.server.master.saveSettings()
+            self.server.master.queue_background_task({"cmd": "saveSettings"})
             self.send_response(202)
             self.end_headers()
             self.wfile.write("".encode("utf-8"))
@@ -852,7 +852,7 @@ class HTTPControlHandler(BaseHTTPRequestHandler):
         # Track Green Energy, set Non-Scheduled power rate to 0
         if int(self.server.master.settings.get("nonScheduledAction", 1)) > 1:
             self.server.master.settings["nonScheduledAmpsMax"] = 0
-        self.server.master.saveSettings()
+        self.server.master.queue_background_task({"cmd": "saveSettings"})
 
         # Redirect to the index page
         self.send_response(302)

--- a/lib/TWCManager/Control/WebIPCControl.py
+++ b/lib/TWCManager/Control/WebIPCControl.py
@@ -200,7 +200,7 @@ class WebIPCControl:
 
                         # Save nonScheduledAmpsMax to SD card so the setting
                         # isn't lost on power failure or script restart.
-                        self.master.saveSettings()
+                        self.master.queue_background_task({"cmd": "saveSettings"})
                 elif webMsg[0:17] == b"setScheduledAmps=":
                     m = re.search(
                         b"([-0-9]+)\nstartTime=([-0-9]+):([0-9]+)\nendTime=([-0-9]+):([0-9]+)\ndays=([0-9]+)",
@@ -216,7 +216,7 @@ class WebIPCControl:
                             int(m.group(4)) + (int(m.group(5)) / 60)
                         )
                         self.master.setScheduledAmpsDaysBitmap(int(m.group(6)))
-                        self.master.saveSettings()
+                        self.master.queue_background_task({"cmd": "saveSettings"})
                 elif webMsg[0:30] == b"setResumeTrackGreenEnergyTime=":
                     m = re.search(
                         b"([-0-9]+):([0-9]+)", webMsg[30 : len(webMsg)], re.MULTILINE
@@ -225,7 +225,7 @@ class WebIPCControl:
                         self.master.setHourResumeTrackGreenEnergy(
                             int(m.group(1)) + (int(m.group(2)) / 60)
                         )
-                        self.master.saveSettings()
+                        self.master.queue_background_task({"cmd": "saveSettings"})
                 elif webMsg[0:11] == b"sendTWCMsg=":
                     m = re.search(
                         b"([0-9a-fA-F]+)", webMsg[11 : len(webMsg)], re.MULTILINE
@@ -296,7 +296,7 @@ class WebIPCControl:
                         self.master.config["config"]["wiringMaxAmpsAllTWCs"]
                     )
                     self.master.setChargeNowTimeEnd(60 * 60 * 24)
-                    self.master.saveSettings()
+                    self.master.queue_background_task({"cmd": "saveSettings"})
                 elif webMsg == b"chargeNowCancel":
                     self.master.resetChargeNowAmps()
                 elif webMsg == b"dumpState":

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -798,7 +798,7 @@ class TWCMaster:
                 )
                 self.settings["Vehicles"][slaveTWC.lastVIN]["startkWh"] = 0
                 self.settings["Vehicles"][slaveTWC.lastVIN]["totalkWh"] += delta
-                self.saveSettings()
+                self.queue_background_task({"cmd": "saveSettings"})
 
         # Update Charge Session details in logging modules
         for module in self.getModulesByType("Logging"):
@@ -833,7 +833,7 @@ class TWCMaster:
             self.settings["SlaveTWCs"][twcid] = {}
         if not self.settings["SlaveTWCs"][twcid].get("supportsVINQuery", 0):
             self.settings["SlaveTWCs"][twcid]["supportsVINQuery"] = 1
-            self.saveSettings()
+            self.queue_background_task({"cmd": "saveSettings"})
 
         # Increment sessions counter for this VIN in persistent settings file
         if not self.settings.get("Vehicles", None):
@@ -851,7 +851,7 @@ class TWCMaster:
             ] = slaveTWC.lifetimekWh
             if not self.settings["Vehicles"][slaveTWC.currentVIN].get("totalkWh", None):
                 self.settings["Vehicles"][slaveTWC.currentVIN]["totalkWh"] = 0
-        self.saveSettings()
+        self.queue_background_task({"cmd": "saveSettings"})
 
         # Update Charge Session details in logging modules
         for module in self.getModulesByType("Logging"):
@@ -879,13 +879,14 @@ class TWCMaster:
     def removeNormalChargeLimit(self, ID):
         if "chargeLimits" in self.settings and str(ID) in self.settings["chargeLimits"]:
             del self.settings["chargeLimits"][str(ID)]
-            self.saveSettings()
+            self.queue_background_task({"cmd": "saveSettings"})
 
     def resetChargeNowAmps(self):
         # Sets chargeNowAmps back to zero, so we follow the green energy
         # tracking again
         self.settings["chargeNowAmps"] = 0
         self.settings["chargeNowTimeEnd"] = 0
+        self.queue_background_task({"cmd": "saveSettings"})
 
     def retryVINQuery(self):
         # For each Slave TWC, check if it's been more than 60 seconds since the last
@@ -915,7 +916,8 @@ class TWCMaster:
             self.settings["chargeLimits"] = dict()
 
         self.settings["chargeLimits"][str(ID)] = (outsideLimit, lastApplied)
-        self.saveSettings()
+        self.queue_background_task({"cmd": "saveSettings"})
+
 
     def saveSettings(self):
         # Saves the volatile application settings (such as charger timings,
@@ -1200,7 +1202,7 @@ class TWCMaster:
                 for e in self.settings["history"]
                 if datetime.fromisoformat(e[0]) >= (now - timedelta(days=2))
             ]
-            self.saveSettings()
+            self.queue_background_task({"cmd": "saveSettings"})
 
     def startCarsCharging(self):
         # This function is the opposite functionality to the stopCarsCharging function

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -168,7 +168,7 @@ class TeslaAPI:
                 self.setCarApiBearerToken("")
                 self.setCarApiRefreshToken("")
 
-            self.master.saveSettings()
+            self.master.queue_background_task({"cmd": "saveSettings"})
 
         if self.getCarApiBearerToken() != "":
             if self.getVehicleCount() < 1:
@@ -518,7 +518,7 @@ class TeslaAPI:
             )
             self.master.setHomeLat(lat)
             self.master.setHomeLon(lon)
-            self.master.saveSettings()
+            self.master.queue_background_task({"cmd": "saveSettings"})
             return True
 
         # 1 lat or lon = ~364488.888 feet. The exact feet is different depending


### PR DESCRIPTION
Three pieces to this:

- New `saveSettings` background task, does just what you'd imagine
- Existing synchronous calls to `saveSettings()` enqueue the background task instead; this allows them to move on more quickly and to take advantage of dedupe logic to potentially avoid writing to disk as often.
- The new task is added to the queue immediately before the `join()` call as the program shuts down, ensuring data is written to disk before exiting.