### PR TITLE
Adjust raw values for Powerwall SoC

### DIFF
--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -92,7 +92,7 @@ class TeslaPowerwall2:
     @property
     def batteryLevel(self):
         value = self.getSOE()
-        return float(value.get("percentage", 0))
+        return self.adjustPercentage(float(value.get("percentage", 0)))
 
     @property
     def operatingMode(self):
@@ -102,7 +102,7 @@ class TeslaPowerwall2:
     @property
     def reservePercent(self):
         value = self.getOperation()
-        return float(value.get("backup_reserve_percent", 0))
+        return self.adjustPercentage(float(value.get("backup_reserve_percent", 0)))
 
     @property
     def stormWatch(self):
@@ -112,6 +112,9 @@ class TeslaPowerwall2:
     def debugLog(self, minlevel, message):
         if self.debugLevel >= minlevel:
             self.master.debugLog(minlevel, "Powerwall2", message)
+
+    def adjustPercentage(self, raw_value):
+        return (raw_value - 5) / .95
 
     def doPowerwallLogin(self):
         # If we have password authentication configured, this function will submit


### PR DESCRIPTION
The conversion between what the API shows and what the app shows turns out to be ridiculously simple.  This adjusts the numbers so matches will behave as expected.