### PR TITLE
Lean on background queue for history snap

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -1173,11 +1173,15 @@ class TWCMaster:
 
     def snapHistoryData(self):
         snaptime = self.nextHistorySnap
-        now = datetime.now().astimezone()
         avgCurrent = 0
 
-        if now < snaptime:
-            return
+        now = None
+        try:
+            now = datetime.now().astimezone()
+            if now < snaptime:
+                return
+        except ValueError as e:
+            self.master.debugLog(10, "TWCSlave  ", str(e))
 
         for slave in self.getSlaveTWCs():
             avgCurrent += slave.historyAvgAmps

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -1182,6 +1182,7 @@ class TWCMaster:
                 return
         except ValueError as e:
             self.master.debugLog(10, "TWCSlave  ", str(e))
+            return
 
         for slave in self.getSlaveTWCs():
             avgCurrent += slave.historyAvgAmps

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -497,12 +497,7 @@ class TWCSlave:
             (self.historyAvgAmps * self.historyNumSamples) + self.reportedAmpsActual
         ) / (self.historyNumSamples + 1)
         self.historyNumSamples += 1
-
-        try:
-            if datetime.now().astimezone() >= self.master.nextHistorySnap:
-                self.master.queue_background_task({"cmd": "snapHistoryData"})
-        except ValueError as e:
-            self.master.debugLog(10, "TWCSlave  ", str(e))
+        self.master.queue_background_task({"cmd": "snapHistoryData"})
 
         # self.lastAmpsOffered is initialized to -1.
         # If we find it at that value, set it to the current value reported by the


### PR DESCRIPTION
I was looking to see whether it would make sense to move this to a delayed background task, but realized it makes more sense with the paradigm of repeatedly submitting the task to the queue.  This is functionally equivalent to the existing code, but is more consistent with how things currently work.  (And the busy work happens on the background thread now, which is nice.)