### PR TITLE
Adding another quarter to flex time, when we started charging

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -308,6 +308,9 @@ class TWCMaster:
                 # adding half an hour if battery should be charged over 98%
                 if vehicle.chargeLimit >= 98:
                     startHour -= 0.5
+                # As soon we start charge, we set start charging another quarter of an hour back - so it won't start and stop charging the whole time 
+                if slave.isCharging==1:
+                    startHour -= 0.25                    
                 if startHour < 0:
                     startHour = startHour + 24
                 # if startHour is smaller than the intial startHour, then it should begin beginn charging a day later

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -293,6 +293,10 @@ class TWCMaster:
             slave = next(iter(self.slaveTWCs.values()))
             vehicle = slave.getLastVehicle()
             if vehicle != None:
+                # we update current SOC - but only when charging 
+                if slave.isCharging==1:
+                    vehicle.update_charge()
+
                 amps = self.getScheduledAmpsMax()
                 watts = self.convertAmpsToWatts(amps) * self.getRealPowerFactor(amps)
                 hoursForFullCharge = self.getScheduledAmpsBatterySize() / (watts / 1000)
@@ -309,7 +313,7 @@ class TWCMaster:
                 if vehicle.chargeLimit >= 98:
                     startHour -= 0.5
                 # As soon we start charge, we set start charging another quarter of an hour back - so it won't start and stop charging the whole time 
-                if slave.isCharging==1:
+                if slave.isCharging==1:                    
                     startHour -= 0.25                    
                 if startHour < 0:
                     startHour = startHour + 24


### PR DESCRIPTION
With this I prevent when charging is too fast, it sometimes send a stop and then a minute later a start again. Just added an update_carge to the call just before calculating flex starts