### PR TITLE
Powerwall reserve vs. Backup

### DIFF
--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -101,8 +101,11 @@ class TeslaPowerwall2:
 
     @property
     def reservePercent(self):
-        value = self.getOperation()
-        return self.adjustPercentage(float(value.get("backup_reserve_percent", 0)))
+        if self.operatingMode == "backup":
+            return float(98)
+        else:
+            value = self.getOperation()
+            return self.adjustPercentage(float(value.get("backup_reserve_percent", 0)))
 
     @property
     def stormWatch(self):

--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -102,7 +102,7 @@ class TeslaPowerwall2:
     @property
     def reservePercent(self):
         if self.operatingMode == "backup":
-            return float(98)
+            return float(96)
         else:
             value = self.getOperation()
             return self.adjustPercentage(float(value.get("backup_reserve_percent", 0)))


### PR DESCRIPTION
The Powerwall API reports the backup reserve that's configured for Self-Powered / TOU mode while in Backup, but it doesn't actually behave as if that's the backup reserve.  Backup mode implicitly seems to be a backup reserve of 98% or so.  (The Tesla app displays it as an unchangeable 100%.)

This makes the module's export track the behavior, not what the API reports.