### PR TITLE
Update ConsoleLogging.py to show different logging when subtractChargerLoad is True

### DIFF
--- a/lib/TWCManager/Logging/ConsoleLogging.py
+++ b/lib/TWCManager/Logging/ConsoleLogging.py
@@ -58,13 +58,24 @@ class ConsoleLogging:
         conwattsDisplay = f("{data.get('conWatts', 0):.0f}W")
         chgwattsDisplay = f("{data.get('chgWatts', 0):.0f}W")
 
-        self.master.debugLog(
-            1,
-            "TWCManager",
-            f(
-                "Green energy generates {colored(genwattsDisplay, 'magenta')}, Consumption {colored(conwattsDisplay, 'magenta')}, Charger Load {colored(chgwattsDisplay, 'magenta')}"
-            ),
-        )
+        if self.config["config"]["subtractChargerLoad"]:
+            othwatts = data.get('conWatts', 0) - data.get('chgWatts', 0)
+            othwattsDisplay = f("{othwatts:.0f}W")
+            self.master.debugLog(
+                1,
+                "TWCManager",
+                f(
+                    "Green energy generates {colored(genwattsDisplay, 'magenta')}, Consumption {colored(conwattsDisplay, 'magenta')} (Other Load {colored(othwattsDisplay, 'magenta')}, Charger Load {colored(chgwattsDisplay, 'magenta')})"
+                ),
+            )
+        else:
+            self.master.debugLog(
+                1,
+                "TWCManager",
+                f(
+                    "Green energy generates {colored(genwattsDisplay, 'magenta')}, Consumption {colored(conwattsDisplay, 'magenta')}, Charger Load {colored(chgwattsDisplay, 'magenta')}"
+                ),
+            )
 
     def slavePower(self, data):
         # Not yet implemented


### PR DESCRIPTION
Tweak to the printout in the console so that when the charger load is included in the consumption (subtractChargerLoad=true in config.json) that it is split out 

...
12:54:40 TWCManager 1 Green energy generates 5042W, Consumption 4922W (Other Load 754W, Charger Load 4168W)
12:54:40 TWCManager 1 Limiting charging to 21.92A - 3.28A = 18.64A.
...