### PR TITLE
Limit applications of Max Amps during check_green_energy

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -282,7 +282,10 @@ def check_green_energy():
     for module in master.getModulesByType("EMS"):
         master.setConsumption(module["name"], module["ref"].getConsumption())
         master.setGeneration(module["name"], module["ref"].getGeneration())
-    master.setMaxAmpsToDivideAmongSlaves(master.getMaxAmpsToDivideGreenEnergy())
+
+    # Set max amps iff charge_amps isn't specified on the policy.
+    if master.getModuleByName("Policy").policyIsGreen():
+        master.setMaxAmpsToDivideAmongSlaves(master.getMaxAmpsToDivideGreenEnergy())
 
 
 def update_statuses():

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -288,12 +288,13 @@ class Policy:
         return value
 
     def policyIsGreen(self):
-        if self.getPolicyByName(self.active_policy):
+        current = self.getPolicyByName(self.active_policy)
+        if current:
             return (
-                self.getPolicyByName(self.active_policy).get("background_task", "")
-                == "checkGreenEnergy"
+                current.get("background_task", "") == "checkGreenEnergy" and
+                not current.get("charge_amps", None)
             )
-        return 0
+        return False
 
     def doesConditionMatch(self, match, condition, value, exitOn):
         matchValue = self.policyValue(match)

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -292,7 +292,7 @@ class Policy:
         if current:
             return (
                 current.get("background_task", "") == "checkGreenEnergy" and
-                not current.get("charge_amps", None)
+                current.get("charge_amps", None) == None
             )
         return False
 


### PR DESCRIPTION
@hopfi2k, I haven't tested this change, but this should make the check_green_energy not override a `charge_amps` in the policy, so adding the background task to a policy should now be safe.  Hopefully this unblocks you on #211.