### PR TITLE
Use serial_for_url for opening serial port

### DIFF
--- a/lib/TWCManager/Interface/RS485.py
+++ b/lib/TWCManager/Interface/RS485.py
@@ -49,7 +49,7 @@ class RS485:
             self.port = porta
 
         # Connect to serial port
-        self.ser = self.serial.Serial(self.port, self.baud, timeout=0)
+        self.ser = self.serial.serial_for_url(self.port, self.baud, timeout=0)
 
     def close(self):
         # Close the serial interface


### PR DESCRIPTION
With this change, you can fill in, for example, `socket://localhost:7778` as the RS485 port in config.json. This opens up some possibilities:
- You have an RS485 to tcp converter near your TWC, and run TWCManager somewhere else, only connected with TCP/IP
  I would only recommend this on a secure LAN, since you have no autentication/authorization
- For testing TWCManager, you can run 2 instances of TWCManager, one as a master and one as a slave. I use this for example with the help of socat:
    `socat TCP-LISTEN:7777,reuseaddr TCP-LISTEN:7778,reuseaddr` to open 2 listening ports 7778 and 7777 that are connected to one another.
    Then, it is just a matter of having 2 TWCManagers, where you connect to 7777 first and then to 7778 with the second instance.

If you use a normal device, like `/dev/ttyUSB0` as port, this works exactly as before

Related to #4