### PR TITLE
High-pri log if Powerwall auth needed

### DIFF
--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -453,7 +453,7 @@
         "Powerwall2": {
           "enabled": false,
           "serverIP": "192.168.1.2",
-      # Password is optional. Specify it if authentication is enabled.
+      # Password is required starting in firmware 20.49.0
           "password": "test123",
       # The following value specifies the minimum battery level of the 
       # Powerwall2 before the car will be able to charge. This avoids a

--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -117,7 +117,7 @@ class TeslaPowerwall2:
             self.master.debugLog(minlevel, "Powerwall2", message)
 
     def adjustPercentage(self, raw_value):
-        return (raw_value - 5) / .95
+        return (raw_value - 5) / 0.95
 
     def doPowerwallLogin(self):
         # If we have password authentication configured, this function will submit
@@ -219,10 +219,15 @@ class TeslaPowerwall2:
                 )
                 r.raise_for_status()
             except Exception as e:
-                self.debugLog(
-                    4, "Error connecting to Tesla Powerwall 2 to fetch " + path
-                )
-                self.debugLog(10, str(e))
+                if hasattr(e,"response") and e.response.status_code == 403:
+                    self.debugLog(
+                        1, "Authentication required to access local Powerwall API"
+                    )
+                else:
+                    self.debugLog(
+                        4, "Error connecting to Tesla Powerwall 2 to fetch " + path
+                    )
+                    self.debugLog(10, str(e))
                 return lastData
 
             lastData = r.json()


### PR DESCRIPTION
When a request to the Powerwall fails, this checks if it failed due to lack of authentication and raises a more explicit error in the log.  Since authentication was previously optional for nearly everything and is now required for nearly everything, I suspect there will be some users who were running without auth and got bitten when Tesla pushed the most recent firmware update.

Fixes #235.