### PR TITLE
Update reinserted tasks

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -769,11 +769,12 @@ class TWCMaster:
             # a charge starts or we determine the car is done charging.  To avoid
             # wasting memory queing up a bunch of these tasks when we're handling
             # a charge cmd already, don't queue two of the same task.
+            self.backgroundTasksCmds[task["cmd"]].update(task)
             return
 
         # Insert task['cmd'] in backgroundTasksCmds to prevent queuing another
         # task['cmd'] till we've finished handling this one.
-        self.backgroundTasksCmds[task["cmd"]] = True
+        self.backgroundTasksCmds[task["cmd"]] = task
 
         # Queue the task to be handled by background_tasks_thread.
         self.backgroundTasksQueue.put(task)


### PR DESCRIPTION
Minor improvement.  Currently, when a task is queued and a previous instance of the task is in the queue, the earlier task instance remains in the queue and the later task instance gets ignored.  That's a problem when the task has parameters; the surviving task will act on the less-current parameters.

This change makes the task retain the position in the queue of the earlier task, but run with the parameters of the later task.