### PR TITLE
fix 0 padding for twcid for modern theme html (ie: twcid of 5403)

### DIFF
--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -193,7 +193,7 @@ wcmanager/settings.json and try saving your settings again.</b>
                             </svg>
                         </div>
                         <div class="col pt-1">
-                            {% set twcid = '%0x%0x' % (charger.TWCID[0], charger.TWCID[1]) %}
+                            {% set twcid = '%02x%02x' % (charger.TWCID[0], charger.TWCID[1]) %}
                             <div class="row">
                                 <small>{{ twcid }}</small>
                             </div>


### PR DESCRIPTION
My TWC had an ID of `5403` and it kept showing up in the modern theme as `543` and therefore had no charger data on the home page. This should fix the rendering of the html elements on the page so that the api calls match by ensuring 0 padding is done on both parts of the twc id.