### PR TITLE
Update Volkszahler.py

### DIFF
--- a/lib/TWCManager/EMS/Volkszahler.py
+++ b/lib/TWCManager/EMS/Volkszahler.py
@@ -1,6 +1,7 @@
 import logging
 import requests
 import time
+import re
 
 logger = logging.getLogger(__name__.rsplit(".")[-1])
 
@@ -107,10 +108,10 @@ class Volkszahler:
 
         else:
 
-            msgMatch = re.search("^(.+) W$", httpResponse.text(), re.DOTALL)
+            msgMatch = re.search("^(.+) W$", httpResponse.text, re.DOTALL)
 
             if msgMatch:
-                self.generatedW = msgMatch.group(1)
+                self.generatedW = -float( msgMatch.group(1) )
             else:
                 logger.log(logging.INFO4, "Did not find expected value inside of Volkszahler API response.")
 


### PR DESCRIPTION
added line4:
import re

changed line 111:
msgMatch = re.search("^(.+) W$", httpResponse.text(), re.DOTALL)
msgMatch = re.search("^(.+) W$", httpResponse.text, re.DOTALL)

changed line 114:
self.generatedW = msgMatch.group(1)
self.generatedW = -float( msgMatch.group(1) )

**Result:
15:49:01 TWCManager 20 Green energy generates 2710W, Consumption 0W, Charger Load 0W**

Personal notes:
The port of Volkszahler is 80 - the default in config.json is correct.
Use an channel UUID as total overall grid watt. At night you should get positive values and while sun is shining the values are negative.
