### PR TITLE
Configure debounce

### DIFF
--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -64,6 +64,11 @@
         # rates really does.
         "minAmpsPerTWC": 12,
 
+        # By default, TWCManager won't start or stop charging more frequently than
+        # once per minute.  You can increase this value if you want to start/stop
+        # less frequently; it's not recommended to decrease it.
+        #"startStopDelay": 60,
+
         # When you have more than one vehicle associated with the Tesla car API and
         # onlyChargeMultiCarsAtHome = True, cars will only be controlled by the API when
         # parked at home. For example, when one vehicle is plugged in at home and

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -64,9 +64,9 @@
         # rates really does.
         "minAmpsPerTWC": 12,
 
-        # By default, TWCManager won't start or stop charging more frequently than
-        # once per minute.  You can increase this value if you want to start/stop
-        # less frequently; it's not recommended to decrease it.
+        # If the system rapidly changes its mind about whether to start or stop charging,
+        # this parameter keeps charging / not charging until the decision remains stable
+        # for this many seconds.
         #"startStopDelay": 60,
 
         # When you have more than one vehicle associated with the Tesla car API and

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -53,7 +53,7 @@ class TWCSlave:
 
     lastAmpsOffered = -1
     useFlexAmpsToStartCharge = False
-    timeLastAmpsOfferedChanged = time.time()
+    timeLastAmpsOfferedChanged = 0
     lastHeartbeatDebugOutput = ""
     timeLastHeartbeatDebugOutput = 0
     wiringMaxAmps = 0
@@ -596,7 +596,7 @@ class TWCSlave:
         # If we find it at that value, set it to the current value reported by the
         # TWC.
         if self.lastAmpsOffered < 0:
-            self.lastAmpsOffered = self.set_last_amps_offered(self.reportedAmpsMax)
+            self.lastAmpsOffered = self.reportedAmpsMax
 
         # If power starts flowing, check whether a car has arrived
         if (

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -596,7 +596,7 @@ class TWCSlave:
         # If we find it at that value, set it to the current value reported by the
         # TWC.
         if self.lastAmpsOffered < 0:
-            self.lastAmpsOffered = self.reportedAmpsMax
+            self.lastAmpsOffered = self.set_last_amps_offered(self.reportedAmpsMax)
 
         # If power starts flowing, check whether a car has arrived
         if (

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -680,6 +680,7 @@ class TeslaAPI:
 
         if (now - self.getLastStartOrStopChargeTime() < 60) or (
             now - self.carApiLastStartOrStopFlipTime < self.startStopDelay
+            and charge != self.carApiLastStartOrStopChargeAction
         ):
             if self.carApiLastStartOrStopChargeAction != charge:
                 # If we're repeatedly changing our minds about whether to charge or not,

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -928,12 +928,12 @@ class TeslaAPI:
         if (
             not checkArrival
             and not checkDeparture
-            and now - self.carApiLastChargeLimitApplyTime < self.startStopDelay
+            and now - self.carApiLastChargeLimitApplyTime < 60
         ):
             # Don't change limits more often than once a minute
             logger.log(
                 logging.DEBUG2,
-                "applyChargeLimit return because not long enough since last carApiLastChargeLimitApplyTime",
+                "applyChargeLimit return because under 60 sec since last carApiLastChargeLimitApplyTime",
             )
             return "error"
 

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -26,6 +26,7 @@ class TeslaAPI:
     lastChargeLimitApplied = 0
     lastChargeCheck = 0
     chargeUpdateInterval = 1800
+    startStopDelay = 60
     carApiVehicles = []
     config = None
     master = None
@@ -57,6 +58,7 @@ class TeslaAPI:
         try:
             self.config = master.config
             self.minChargeLevel = self.config["config"].get("minChargeLevel", -1)
+            self.startStopDelay = self.config["config"].get("startStopDelay", 60)
             self.chargeUpdateInterval = self.config["config"].get(
                 "cloudUpdateInterval", 1800
             )
@@ -674,11 +676,11 @@ class TeslaAPI:
             for vehicle in self.getCarApiVehicles():
                 vehicle.stopAskingToStartCharging = False
 
-        if now - self.getLastStartOrStopChargeTime() < 60:
+        if now - self.getLastStartOrStopChargeTime() < self.startStopDelay:
             # Don't start or stop more often than once a minute
             logger.log(
                 logging.DEBUG2,
-                "car_api_charge return because under 60 sec since last carApiLastStartOrStopChargeTime",
+                "car_api_charge return because not long enough since last carApiLastStartOrStopChargeTime",
             )
             return "error"
 
@@ -911,12 +913,12 @@ class TeslaAPI:
         if (
             not checkArrival
             and not checkDeparture
-            and now - self.carApiLastChargeLimitApplyTime < 60
+            and now - self.carApiLastChargeLimitApplyTime < self.startStopDelay
         ):
             # Don't change limits more often than once a minute
             logger.log(
                 logging.DEBUG2,
-                "applyChargeLimit return because under 60 sec since last carApiLastChargeLimitApplyTime",
+                "applyChargeLimit return because not long enough since last carApiLastChargeLimitApplyTime",
             )
             return "error"
 


### PR DESCRIPTION
This was also sitting on a working branch.  It attempts to deal with the problem where intermittent house load causes the TWC to start and/or stop very frequently.  It dampens the action -- it tracks when you last flipped from wanting to start charging to wanting to stop charging, and won't let you flip back if the last flip was within the configured time period.