### PR TITLE
Power Factor adjustment only on de novo

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -511,8 +511,7 @@ class TWCMaster:
         solarAmps = self.convertWattsToAmps(solarW)
 
         # Offer the smaller of the two, but not less than zero.
-        amps = max(min(newOffer, solarAmps), 0)
-        amps = amps / self.getRealPowerFactor(amps)
+        amps = max(min(newOffer, solarAmps / self.getRealPowerFactor(solarAmps)), 0)
         return round(amps, 2)
 
     def getNormalChargeLimit(self, ID):


### PR DESCRIPTION
The `newOffer` is calculated based on EMS-reported values and an already-adjusted value.  It doesn't need to be adjusted for PF; doing so causes it to lose the comparison every time.