### PR TITLE
Add new consumption offset UI to web interface, update green energy l…

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -350,7 +350,7 @@ def update_statuses():
         if conoffset > 0:
             conwatts -= conoffset
         elif conoffset < 0:
-            getwatts += conoffset
+            genwatts += (-1 * conoffset)
         chgwatts = master.getChargerLoad()
         othwatts = 0
 
@@ -405,7 +405,7 @@ def update_statuses():
             logger.info(
                 "Green energy Generates %s (Offset %s), Consumption %s (Charger Load %s, Other Load %s)",
                 f("{genwatts:.0f}W"),
-                f("{conoffset:.0f}W"),
+                f("{(-1 * conoffset):.0f}W"),
                 f("{conwatts:.0f}W"),
                 f("{chgwatts:.0f}W"),
                 f("{othwatts:.0f}W"),

--- a/TWCManager.py
+++ b/TWCManager.py
@@ -322,10 +322,6 @@ def check_green_energy():
     # to match those used in your environment. This is configured
     # in the config section at the top of this file.
     #
-    if master.getConsumptionOffset() >= 0:
-        master.setConsumption("Offset", master.getConsumptionOffset())
-    elif master.getConsumptionOffset() < 0:
-        master.setGeneration("Manual", -1 * master.getConsumptionOffset())
 
     # Poll all loaded EMS modules for consumption and generation values
     for module in master.getModulesByType("EMS"):
@@ -347,16 +343,15 @@ def update_statuses():
         genwatts = master.getGeneration()
         conwatts = master.getConsumption()
         conoffset = master.getConsumptionOffset()
-        if conoffset > 0:
-            conwatts -= conoffset
-        elif conoffset < 0:
-            genwatts += (-1 * conoffset)
         chgwatts = master.getChargerLoad()
         othwatts = 0
 
         if config["config"]["subtractChargerLoad"]:
             if conwatts > 0:
                 othwatts = conwatts - chgwatts
+
+            if conoffset > 0:
+                othwatts -= conoffset
 
         # Extra parameters to send with logs
         logExtra = {

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -56,7 +56,17 @@ This setting specifies that any vehicle which requests to start charging will be
 
 ### Consumption Offsets
 
-Consumption Offsets are values which are applied to the Consumption value retrieved from EMS modules. Consumption Offsets can be either positive or negative values, and are often used to control the behaviour of TWCManager by making it appear as though the consumption is higher or lower than it is, or allows specifying an average consumption value for installations where 
+Consumption Offsets are values which are applied to the Consumption value retrieved from EMS modules. Consumption Offsets can be either positive or negative values, and are often used to control the behaviour of TWCManager by making it appear as though the consumption is higher or lower than it is, or allows specifying an average consumption value for installations where it is not possible to query consumption data.
+
+This is most often given a value equal to the average amount of power consumed by everything other than car charging. 
+
+For example, if your house uses an average of 2.8A to power computers, lights, etc while you expect the car to be charging, you could add an offset of 2.8A.
+
+If you have solar panels, look at your utility meter while your car charges.
+
+If it says you're using 0.67kW, that means you should add an offset for 0.67kW * 1000 / 240V = 2.79A assuming you're on the North American 240V grid. In other words, during car charging, you want your utility meter to show a value close to 0kW meaning no energy is being sent to or from the grid.
+
+If you are able to obtain consumption details from an energy management system, don't add consumption offsets (unless you need them for other purposes), as TWCManager will query your EMS to determine the power being consumed.
 
 ### Manual Tesla API key override
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2,6 +2,10 @@
 
 The following settings (outside of the configuration file) are available via the inbuilt Web Interface:
 
+## Web Interface Theme
+
+Allows you to select which theme you'd like to use for the TWCManager interface.
+
 ## Stop Charging Method
 
 This option, which defaults to using the Tesla API, allows you to specify how you would like TWCManager to stop a car from charging. The following options exist, and each has some information to help you decide on which approach to use:
@@ -22,7 +26,7 @@ This option, which defaults to using the Tesla API, allows you to specify how yo
       * [This thread](https://teslamotorsclub.com/tmc/threads/new-wall-connector-load-sharing-protocol.72830/page-24) provides the observations of those who have tested this command.
       * Whilst this option is offered primarily for the benefit of non-Tesla vehicles, it's not recommended for use with Tesla vehicles.
 
-### Non-Scheduled Power Action
+### Non-Scheduled Power Action & Charge Rate
 
 This setting determines what TWCManager should do if there is no scheduled charging rate and outside of the Track Green Energy hours. The available options are:
 
@@ -37,6 +41,22 @@ The Do not Charge action states that outside of scheduled or Track Green Energy 
       * Track Green Energy
 
 This is an option that currently does not operate (and will only set Non-Scheduled Charging rate to 0). In future, this will allow continuing of Track Green Energy behaviour outside of the hard-coded daylight hours (6am - 8pm).
+
+### Charge Authorization Mode
+
+The Charge Authorization Mode determines how we determine if a vehicle that starts to charge from a TWC should be allowed to do so. There are two options available:
+
+   * Vehicles can charge unless explicitly blocked
+
+This setting is the default, and specifies that any vehicle which requests to start charging can do so, unless it is explicitly added to the Deny Charging group.
+
+   * Vehicles can only charge if explicitly allowed
+
+This setting specifies that any vehicle which requests to start charging will be blocked, unless it has been added to the Allow Charging group.
+
+### Consumption Offsets
+
+Consumption Offsets are values which are applied to the Consumption value retrieved from EMS modules. Consumption Offsets can be either positive or negative values, and are often used to control the behaviour of TWCManager by making it appear as though the consumption is higher or lower than it is, or allows specifying an average consumption value for installations where 
 
 ### Manual Tesla API key override
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -58,13 +58,25 @@ This setting specifies that any vehicle which requests to start charging will be
 
 Consumption Offsets are values which are applied to the Consumption value retrieved from EMS modules. Consumption Offsets can be either positive or negative values, and are often used to control the behaviour of TWCManager by making it appear as though the consumption is higher or lower than it is, or allows specifying an average consumption value for installations where it is not possible to query consumption data.
 
+The value supplied can be:
+
+   * Expressed in Amps. This is internally converted into watts by TWCManager, by multiplying with the current grid voltage, meaning the actual applied value of this offset will vary with voltage variations.
+      * You would use an offset in Amps if you wanted to express an offset in circuit capacity - for example, if you already have a 1A load on a 20A circuit which is not metered, specifying +1A of consumption offset will treat that 1A as metered consumption.
+
+   * Expressed in Watts. This allows for a specific power value to be specified. There will be no variance to offsets expressed this way.
+      * You might use an offset like this to control the way that you treat Generation and Consumption data from Solar installations. For example, if you wanted to reduce the value measured from a Solar Array by 500W, you could add 500W of consumption via an offset.
+
 This is most often given a value equal to the average amount of power consumed by everything other than car charging. 
 
 For example, if your house uses an average of 2.8A to power computers, lights, etc while you expect the car to be charging, you could add an offset of 2.8A.
 
 If you have solar panels, look at your utility meter while your car charges.
 
-If it says you're using 0.67kW, that means you should add an offset for 0.67kW * 1000 / 240V = 2.79A assuming you're on the North American 240V grid. In other words, during car charging, you want your utility meter to show a value close to 0kW meaning no energy is being sent to or from the grid.
+If it says you're using 0.67kW, that means you could either:
+   * Add an offset for 0.67kW * 1000 / 240V = 2.79A assuming you're on the North American 240V grid. 
+   * Add an offset for 670W, which would universally treat that 0.67kW as consumption regardless of grid voltage.
+
+In other words, during car charging, you want your utility meter to show a value close to 0kW meaning no energy is being sent to or from the grid.
 
 If you are able to obtain consumption details from an energy management system, don't add consumption offsets (unless you need them for other purposes), as TWCManager will query your EMS to determine the power being consumed.
 

--- a/docs/modules/Control_HTTP.md
+++ b/docs/modules/Control_HTTP.md
@@ -66,9 +66,11 @@ The following API endpoints exist:
 
 | Endpoint  | Method | Description                                       |
 | --------- | ------ | ------------------------------------------------- |
+| [addConsumptionOffset](control_HTTP_API/addConsumptionOffset.md) | POST | Add or Edit a Consumption Offset value | 
 | <a href="/docs/modules/control_HTTP_API/cancelChargeNow.md">cancelChargeNow</a> | POST | Cancels active chargeNow configuration        |
 | <a href="/docs/modules/control_HTTP_API/chargeNow.md">chargeNow</a> | POST   | Instructs charger to start charging at specified rate |
 | getConfig | GET    | Provides the current configuration                |
+| [getConsumptionOffsets](control_HTTP_API/getConsumptionOffsets.md) | GET | List configured offsets               |
 | getPolicy | GET    | Provides the policy configuration                 |
 | getSlaveTWCs | GET | Provides a list of connected Slave TWCs and their state |
 | getStatus | GET    | Provides the current status (Charge Rate, Policy) |

--- a/docs/modules/control_HTTP_API/addConsumptionOffset.md
+++ b/docs/modules/control_HTTP_API/addConsumptionOffset.md
@@ -1,0 +1,15 @@
+# addConsumptionOffset API Command
+
+## Introduction
+
+The addConsumptionOffset API command requests TWCManager to add a new consumption offset, or edit an existing consumption offset. The Primary Key is the name of the offset.
+
+## Format of request
+
+The addConsumptionOffset API command is not accompanied by any payload. You should send a blank payload when requesting this command.
+
+An example of how to call this function via cURL is:
+
+```
+curl -X POST -d "" http://192.168.1.1:8080/api/addConsumptionOffset
+

--- a/docs/modules/control_HTTP_API/getConsumptionOffsets.md
+++ b/docs/modules/control_HTTP_API/getConsumptionOffsets.md
@@ -1,0 +1,16 @@
+# getConsumptionOffsets API Command
+
+## Introduction
+
+The getConsumptionOffsets API command requests TWCManager to provide a list of Consumption Offsets configured.
+
+## Format of request
+
+The getConsumptionOffsets API command is not accompanied by any payload. You should send a blank payload when requesting this command.
+
+An example of how to call this function via cURL is:
+
+```
+curl -X GET -d "" http://192.168.1.1:8080/api/getConsumptionOffsets
+```
+

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -90,24 +90,6 @@
         # "realPowerFactorMinAmps": 0.9,
         # "realPowerFactorMaxAmps": 0.93,
 
-        # When determining how much green energy is available for charging, we count
-        # greenEnergyAmpsOffset as consumption. This is most often given a value
-        # equal to the average amount of power consumed by everything other than car
-        # charging. For example, if your house uses an average of 2.8A to power
-        # computers, lights, etc while you expect the car to be charging, set
-        # greenEnergyAmpsOffset = 2.8.
-        #
-        # If you have solar panels, look at your utility meter while your car charges.
-        # If it says you're using 0.67kW, that means you should set
-        # greenEnergyAmpsOffset = 0.67kW * 1000 / 240V = 2.79A assuming you're on the
-        # North American 240V grid. In other words, during car charging, you want your
-        # utility meter to show a value close to 0kW meaning no energy is being sent to
-        # or from the grid.
-        #
-        # If you are able to obtain consumption details from an energy management system,
-        # this value can be set to 0 unless you wish to manually adjust what it returns.
-        "greenEnergyAmpsOffset": 0,
-
         # If green energy dips below the target charge amount while already charging,
         # how much extra current should be drawn to keep charging?  This avoids frequently
         # stopping and starting charging on a day with variable solar output, at the cost

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -213,6 +213,17 @@ def CreateHTTPHandlerClass(master):
                 json_data = re.sub(r'"apiKey": ".*?",', "", json_datas)
                 self.wfile.write(json_data.encode("utf-8"))
 
+            elif self.url.path == "/api/getConsumptionOffsets":
+                self.send_response(200)
+                self.send_header("Content-type", "application/json")
+                self.end_headers()
+
+                if not master.settings.get("consumptionOffset", None):
+                    master.settings["consumptionOffset"] = {}
+
+                json_data = json.dumps(master.settings["consumptionOffset"])
+                self.wfile.write(json_data.encode("utf-8"))
+
             elif self.url.path == "/api/getLastTWCResponse":
                 self.send_response(200)
                 self.send_header("Content-type", "text/plain")
@@ -348,6 +359,29 @@ def CreateHTTPHandlerClass(master):
 
             self.debugLogAPI("Starting API POST")
 
+            if self.url.path == "/api/addConsumptionOffset":
+                data = json.loads(self.post_data.decode("UTF-8"))
+                name = str(data.get("offsetName", None))
+                value = float(data.get("offsetValue", 0))
+                unit = str(data.get("offsetUnit", None))
+
+                if (name and value):
+                    if not master.settings.get("consumptionOffset", None):
+                        master.settings["consumptionOffset"] = {}
+                    master.settings["consumptionOffset"][name] = {}
+                    master.settings["consumptionOffset"][name]["value"] = value
+                    master.settings["consumptionOffset"][name]["unit"] = unit
+                    master.queue_background_task({"cmd": "saveSettings"})
+
+                    self.send_response(204)
+                    self.end_headers()
+                    self.wfile.write("".encode("utf-8"))
+
+                else:
+                    self.send_response(400)
+                    self.end_headers()
+                    self.wfile.write("".encode("utf-8"))
+
             if self.url.path == "/api/chargeNow":
                 data = json.loads(self.post_data.decode("UTF-8"))
                 rate = int(data.get("chargeNowRate", 0))
@@ -374,6 +408,23 @@ def CreateHTTPHandlerClass(master):
                 self.send_response(204)
                 self.end_headers()
                 self.wfile.write("".encode("utf-8"))
+
+            elif self.url.path == "/api/deleteConsumptionOffset":
+                data = json.loads(self.post_data.decode("UTF-8"))
+                name = str(data.get("offsetName", None))
+
+                if master.settings.get("consumptionOffset", None):
+                    del master.settings["consumptionOffset"][name]
+
+                    self.send_response(204)
+                    self.end_headers()
+                    self.wfile.write("".encode("utf-8"))
+
+                else:
+
+                    self.send_response(400)
+                    self.end_headers()
+                    self.wfile.write("".encode("utf-8"))
 
             elif self.url.path == "/api/sendDebugCommand":
                 data = json.loads(self.post_data.decode("UTF-8"))

--- a/lib/TWCManager/Control/static/js/commonUI.js
+++ b/lib/TWCManager/Control/static/js/commonUI.js
@@ -1,4 +1,4 @@
-function loadVIN(twc, vin) {
-  window.open("/vehicleDetails/" + document.getElementById(twc+"_"+vin+"VIN").innerHTML, '_blank');
-}
-
+// Enable tooltips
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})

--- a/lib/TWCManager/Control/static/js/settings.js
+++ b/lib/TWCManager/Control/static/js/settings.js
@@ -11,14 +11,18 @@ $(document).ready(function() {
       }),
       dataType: "json"
     });
-    getConsumptionOffset();
   });
 });
 
 // Draw the buttons which appear in the Action column next to each entry in the Consumption Offset
 // table
-function offsetActionButtons(key) {
-  return "<td><button type='button' class='btn btn-danger btn-sm' onClick='deleteOffset(\"" + key + "\")'>Delete</button></td>";
+function offsetActionButtons(key, value, unit) {
+  var actionButtons = "<td colspan = 2>";
+  actionButtons += "<button type='button' class='btn btn-danger btn-sm' onClick='deleteOffset(\"" + key + "\")'>Delete</button>";
+  actionButtons += " &nbsp; ";
+  actionButtons += "<button type='button' class='btn btn-success btn-sm' onClick='editOffset(\"" + key + "\",\"" + value +"\",\"" + unit + "\")'>Edit</button>";
+  actionButtons += "</td>";
+  return actionButtons;
 }
 
 function deleteOffset(key) {
@@ -30,7 +34,12 @@ function deleteOffset(key) {
     }),
     dataType: "json"
   });
-  getConsumptionOffset();
+}
+
+function editOffset(key, value, unit) {
+  $("#offsetName").val(key)
+  $("#offsetValue").val(value)
+  $("#offsetUnit").val(unit)
 }
 
 // AJAJ refresh for getConsumptionOffset call
@@ -44,11 +53,11 @@ $(document).ready(function() {
                 var json = $.parseJSON(data);
                 $("#consumptionOffsets tbody").empty();
                 Object.keys(json).sort().forEach(function(key) {
-                  $('#consumptionOffsets tbody').append("<tr><td>"+key+"</td><td>"+json[key]['value']+ " " + json[key]["unit"] + "</td>" + offsetActionButtons(key) + "</tr>");
+                  $('#consumptionOffsets tbody').append("<tr><td>"+key+"</td><td>"+json[key]['value']+ " " + json[key]["unit"] + "</td>" + offsetActionButtons(key, json[key]['value'], json[key]["unit"]) + "</tr>");
                 });
             }
         });
-        setTimeout(getConsumptionOffset, 3000);
+        setTimeout(getConsumptionOffset, 2000);
     }
 
     getConsumptionOffset();

--- a/lib/TWCManager/Control/static/js/settings.js
+++ b/lib/TWCManager/Control/static/js/settings.js
@@ -1,0 +1,56 @@
+$(document).ready(function() {
+  $("#addOffset").click(function(e) {
+    e.preventDefault();
+    $.ajax({
+      type: "POST",
+      url: "/api/addConsumptionOffset",
+      data: JSON.stringify({
+        offsetName: $("#offsetName").val(),
+        offsetValue: $("#offsetValue").val(),
+        offsetUnit: $("#offsetUnit").val()
+      }),
+      dataType: "json"
+    });
+    getConsumptionOffset();
+  });
+});
+
+// Draw the buttons which appear in the Action column next to each entry in the Consumption Offset
+// table
+function offsetActionButtons(key) {
+  return "<td><button type='button' class='btn btn-danger btn-sm' onClick='deleteOffset(\"" + key + "\")'>Delete</button></td>";
+}
+
+function deleteOffset(key) {
+  $.ajax({
+    type: "POST",
+    url: "/api/deleteConsumptionOffset",
+    data: JSON.stringify({
+      offsetName: key
+    }),
+    dataType: "json"
+  });
+  getConsumptionOffset();
+}
+
+// AJAJ refresh for getConsumptionOffset call
+$(document).ready(function() {
+    function getConsumptionOffset() {
+        $.ajax({
+            url: "/api/getConsumptionOffsets",
+            dataType: "text",
+            cache: false,
+            success: function(data) {
+                var json = $.parseJSON(data);
+                $("#consumptionOffsets tbody").empty();
+                Object.keys(json).sort().forEach(function(key) {
+                  $('#consumptionOffsets tbody').append("<tr><td>"+key+"</td><td>"+json[key]['value']+ " " + json[key]["unit"] + "</td>" + offsetActionButtons(key) + "</tr>");
+                });
+            }
+        });
+        setTimeout(getConsumptionOffset, 3000);
+    }
+
+    getConsumptionOffset();
+});
+

--- a/lib/TWCManager/Control/static/js/status.js
+++ b/lib/TWCManager/Control/static/js/status.js
@@ -1,0 +1,37 @@
+
+$(document).ready(function() {
+  $("#cancel_chargenow").click(function(e) {
+    e.preventDefault();
+    $.ajax({
+      type: "POST",
+      url: "/api/cancelChargeNow",
+      data: {}
+    });
+  });
+});
+
+$(document).ready(function() {
+  $("#send_start_command").click(function(e) {
+    e.preventDefault();
+    $.ajax({
+      type: "POST",
+      url: "/api/sendStartCommand",
+      data: {}
+    });
+  });
+});
+
+$(document).ready(function() {
+  $("#send_stop_command").click(function(e) {
+    e.preventDefault();
+    $.ajax({
+      type: "POST",
+      url: "/api/sendStopCommand",
+      data: {}
+    });
+  });
+});
+
+function loadVIN(twc, vin) {
+  window.open("/vehicleDetails/" + document.getElementById(twc+"_"+vin+"VIN").innerHTML, '_blank');
+}

--- a/lib/TWCManager/Control/themes/Default/bootstrap.html.j2
+++ b/lib/TWCManager/Control/themes/Default/bootstrap.html.j2
@@ -3,7 +3,8 @@
 <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+<script type="text/javascript" src="/static/js/commonUI.js"></script>
 <link rel='stylesheet' href='https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css' integrity='sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T' crossorigin='anonymous'>
 <link rel='stylesheet' href='/static/css/styles.css'>
 
-<link rel='icon' type='image/png' href='https://raw.githubusercontent.com/ngardiner/TWCManager/master/tree/v{{ master.version }}/html/favicon.png'>
+<link rel='icon' type='image/png' href='https://raw.githubusercontent.com/ngardiner/TWCManager/main/html/favicon.png'>

--- a/lib/TWCManager/Control/themes/Default/debug.html.j2
+++ b/lib/TWCManager/Control/themes/Default/debug.html.j2
@@ -3,7 +3,6 @@
   <head>
     <title>TWCManager</title>
     {% include 'bootstrap.html.j2' %}
-    <script type="text/javascript" src="/static/js/commonUI.js"></script>
     <script type="text/javascript" src="/static/js/debug.js"></script>
   </head>
   <body>

--- a/lib/TWCManager/Control/themes/Default/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Default/jsrefresh.html.j2
@@ -74,41 +74,4 @@ $(document).ready(function() {
   });
 });
 
-$(document).ready(function() {
-  $("#cancel_chargenow").click(function(e) {
-    e.preventDefault();
-    $.ajax({
-      type: "POST",
-      url: "/api/cancelChargeNow",
-      data: {}
-    });
-  });
-});
-
-$(document).ready(function() {
-  $("#send_start_command").click(function(e) {
-    e.preventDefault();
-    $.ajax({
-      type: "POST",
-      url: "/api/sendStartCommand",
-      data: {}
-    });
-  });
-});
-
-$(document).ready(function() {
-  $("#send_stop_command").click(function(e) {
-    e.preventDefault();
-    $.ajax({
-      type: "POST",
-      url: "/api/sendStopCommand",
-      data: {}
-    });
-  });
-});
-
-// Enable tooltips
-$(function () {
-  $('[data-toggle="tooltip"]').tooltip()
-})
 </script>

--- a/lib/TWCManager/Control/themes/Default/main.html.j2
+++ b/lib/TWCManager/Control/themes/Default/main.html.j2
@@ -4,7 +4,7 @@
     <title>TWCManager</title>
     {% include 'bootstrap.html.j2' %}
     {% include 'jsrefresh.html.j2' %}
-    <script type="text/javascript" src="/static/js/commonUI.js"></script>
+    <script type="text/javascript" src="/static/js/status.js"></script>
   </head>
   <body>
     {% include 'navbar.html.j2' %}

--- a/lib/TWCManager/Control/themes/Default/settings.html.j2
+++ b/lib/TWCManager/Control/themes/Default/settings.html.j2
@@ -3,6 +3,7 @@
   <head>
     <title>TWCManager</title>
     {% include 'bootstrap.html.j2' %}
+    <script type="text/javascript" src="/static/js/settings.js"></script>
   </head>
   <body>
     {% include 'navbar.html.j2' %}
@@ -78,6 +79,44 @@
                 "name": "chargeAuthorizationMode",
                 "value": master.settings.get("chargeAuthorizationMode", "1")
               })|safe }}
+          </td>
+        </tr>
+        <tr>
+          <th>Consumption Offsets</th>
+          <td>
+            <table id="consumptionOffsets">
+              <thead>
+                <tr>
+                  <th>Offset Name</th>
+                  <th>Offset</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+              </tbody>
+              <thead>
+                <tr>
+                  <td><input type="text" class='form-control' id="offsetName" size=8 value="Name"></td>
+                  <td><input type="text" class='form-control' id="offsetValue" size=3 value="0" /></td>
+                  <td>
+                    {{ optionList(
+                      [
+                        ["A", "Amps"],
+                        ["W", "Watts"],
+                      ],
+                      {
+                        "name": "offsetUnit",
+                    })|safe }}
+                    </td>
+                    <td>
+                    {{ addButton(
+                      ["addOffset", "Add / Edit", { "buttonType": "button" }],
+                      "class='btn btn-outline-success'",
+                      )|safe }}
+                  </td>
+                </tr>
+              </thead>
+            </table>
           </td>
         </tr>
         <tr>

--- a/lib/TWCManager/Control/themes/Modern/bootstrap.js.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/bootstrap.js.html.j2
@@ -1,7 +1,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <link rel='stylesheet' href='https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css' integrity='sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T' crossorigin='anonymous'>
+<script type="text/javascript" src="/static/js/commonUI.js"></script>
 <style type="text/css">
 {% include 'css/styles.css'%}
 </style>
-<link rel='icon' type='image/png' href='https://github.com/ngardiner/TWCManager/blob/v{{ master.version }}/html/favicon.png'>
+<link rel='icon' type='image/png' href='https://raw.githubusercontent.com/ngardiner/TWCManager/main/html/favicon.png'>

--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -1,8 +1,4 @@
 <script>
-    // enable tooltips
-    $(function () {
-        $('[data-toggle="tooltip"]').tooltip();
-    });
 
     // AJAJ refresh for getStatus API call
     $(document).ready(function() {
@@ -112,36 +108,4 @@
         });
     });
 
-    $(document).ready(function() {
-        $("#cancel_chargenow").click(function(e) {
-            e.preventDefault();
-            $.ajax({
-                type: "POST",
-                url: "/api/cancelChargeNow",
-                data: {}
-            });
-        });
-    });
-
-    $(document).ready(function() {
-        $("#send_start_command").click(function(e) {
-            e.preventDefault();
-            $.ajax({
-                type: "POST",
-                url: "/api/sendStartCommand",
-                data: {}
-            });
-        });
-    });
-
-    $(document).ready(function() {
-        $("#send_stop_command").click(function(e) {
-            e.preventDefault();
-            $.ajax({
-                type: "POST",
-                url: "/api/sendStopCommand",
-                data: {}
-            });
-        });
-    });
 </script>

--- a/lib/TWCManager/Control/themes/Modern/master.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/master.html.j2
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     {% include "bootstrap.html.j2" %}
     <title>{% block pagetitle %}{% endblock %}</title>
-    <script type="text/javascript" src="/static/js/commonUI.js"></script>
+    <script type="text/javascript" src="/static/js/status.js"></script>
 </head>
 <body>
     {% include "navbar.html.j2" %}

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -235,7 +235,19 @@ class TWCMaster:
             return 0
 
     def getConsumptionOffset(self):
-        return 1
+        # Start by reading the offset value from config, if it exists
+        # This is a legacy value but it doesn't hurt to keep it
+        offset = self.convertAmpsToWatts(
+            self.config["config"].get("greenEnergyAmpsOffset", 0))
+
+        # Iterate through the offsets listed in settings
+        for offsetName in self.settings.get("consumptionOffset", {}).keys():
+            if self.settings["consumptionOffset"][offsetName]["unit"] == "W":
+                offset += self.settings["consumptionOffset"][offsetName]["value"]
+            else:
+                offset += self.convertAmpsToWatts(
+                    self.settings["consumptionOffset"][offsetName]["value"])
+        return offset
 
     def getHourResumeTrackGreenEnergy(self):
         return self.settings.get("hourResumeTrackGreenEnergy", -1)

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -234,6 +234,9 @@ class TWCMaster:
         else:
             return 0
 
+    def getConsumptionOffset(self):
+        return 1
+
     def getHourResumeTrackGreenEnergy(self):
         return self.settings.get("hourResumeTrackGreenEnergy", -1)
 

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -493,6 +493,10 @@ class TWCMaster:
         if consumptionVal < 0:
             consumptionVal = 0
 
+        offset = self.getConsumptionOffset()
+        if offset > 0:
+            consumptionVal += offset
+
         return float(consumptionVal)
 
     def getFakeTWCID(self):
@@ -507,6 +511,10 @@ class TWCMaster:
 
         if generationVal < 0:
             generationVal = 0
+
+        offset = self.getConsumptionOffset()
+        if offset < 0:
+            generationVal += (-1 * offset)
 
         return float(generationVal)
 


### PR DESCRIPTION
**WIP - Overhaul Consumption offsets**

**Rationale:**
   * Current consumption offset setting is statically defined in the TWCManager configuration file, as a value defined in amps only
      * Lack of flexibility - doesn't provide the ability to specify power, fluctuates with voltage reading
      * Requires TWCManager to be stopped to adjust the offset value
      * Single value - doesn't allow for multiple offsets to be applied, or to interface with external systems
   * Allows us future expansion to do things such as artificially increasing generation if we detect weather events, or introduce offsets based on electricity pricing information (potentially - this may be done through policy)

**Features:**
   * New API calls to add, edit or delete consumption offsets, positive (adds to consumption) or negative (adds to generation)
   * Conditionals for logging output to display offsets beside generation or consumption value (fixes #258)
   * Entirely backwards compatible - still operates with configuration file parameter for existing installs
      * We'll remove the example from the configuration file to discourage use

**Status:**
   - [ ] - Implement Web UI for adding, editing or deleting offsets (positive or negative, A or W)
   * Fix up the text "Name" being populated in the edit box - clear on focus
   - [x] - Show offset values in logging next to the appropriate value (Generation/Consumption)
   - [x] - Update documentation for the Settings page to accurately describe offsets and how / why to use them
   - [ ] - Update documentation to reflect new API calls
   - [ ] - Document how API calls could be used to integrate with external systems
   - [x] - Remove existing offset example from configuration file

**Tests:**
   - [ ] Test with single config in ```config.json```
   - [ ] Add positive offset
   - [ ] Add negative offset greater than existing offsets
   - [ ] Confirm logging output is appropriate in all cases

**CI Test Suite:**
   - [ ] Add test for adding offsets with various names and lengths. May require name length enforcement
   - [ ] Check that Amps to Watts is accurate. May need to extend Dummy module to allow voltage variance
   - [ ] Check edit functionality using ```addOffset```
   - [ ] Generate below and over ```minAmps``` generation offsets and check ```getStatus```. May require pre-configuration to ensure we are in TGE mode.