### PR TITLE
Make config not found an error.

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -125,7 +125,7 @@ else:
 if jsonconfig:
     config = commentjson.load(jsonconfig)
 else:
-    logger.info("Unable to find a configuration file.")
+    logger.error("Unable to find a configuration file.")
     sys.exit()
 
 


### PR DESCRIPTION
This soon in the process, default loglevel is still in place, and this
means only warning and higher are printed to stderr.
Fixes #278