### PR TITLE
Background modules

### DIFF
--- a/TWCManager.py
+++ b/TWCManager.py
@@ -231,6 +231,8 @@ def unescape_msg(inmsg: bytearray, msgLen):
 
 
 def background_tasks_thread(master):
+    load_modules_and_settings(master)
+
     carapi = master.getModuleByName("TeslaAPI")
 
     while True:
@@ -527,9 +529,6 @@ timeToRaise2A = 0
 # Instantiate necessary classes
 master = TWCMaster(fakeTWCID, config)
 
-loadModulesThread = threading.Thread(target=load_modules_and_settings, args=(master,))
-loadModulesThread.start()
-
 # Create a background thread to handle tasks that take too long on the main
 # thread.  For a primer on threads in Python, see:
 # http://www.laurentluce.com/posts/python-threads-synchronization-locks-rlocks-semaphores-conditions-events-and-queues/
@@ -559,7 +558,10 @@ while True:
 
         # Add a 25ms sleep to prevent pegging pi's CPU at 100%. Lower CPU means
         # less power used and less waste heat.
-        time.sleep(0.025)
+        interface = None
+        while interface is None:
+            time.sleep(0.025)
+            interface = master.getInterfaceModule()
 
         now = time.time()
 

--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -219,9 +219,7 @@ class TeslaPowerwall2:
                 r.raise_for_status()
             except Exception as e:
                 if hasattr(e, "response") and e.response.status_code == 403:
-                    logger.info(
-                        "Authentication required to access local Powerwall API"
-                    )
+                    logger.info("Authentication required to access local Powerwall API")
                 else:
                     logger.log(
                         logging.INFO4,
@@ -249,6 +247,9 @@ class TeslaPowerwall2:
 
     def getStormWatch(self):
         carapi = self.master.getModuleByName("TeslaAPI")
+        if carapi is None:
+            return dict()
+
         token = carapi.getCarApiBearerToken()
         expiry = carapi.getCarApiTokenExpireTime()
         now = self.time.time()

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -267,7 +267,11 @@ class TWCMaster:
         return matched
 
     def getInterfaceModule(self):
-        return self.getModulesByType("Interface")[0]["ref"]
+        interfaceModules = self.getModulesByType("Interface")
+        if len(interfaceModules) > 0:
+            return interfaceModules[0]["ref"]
+        else:
+            return None
 
     def getScheduledAmpsDaysBitmap(self):
         return self.settings.get("scheduledAmpsDaysBitmap", 0x7F)

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -317,12 +317,14 @@ class TWCSlave:
                 # Increase array length to 9
                 self.master.slaveHeartbeatData.append(0x00)
 
-        self.master.getModulesByType("Interface")[0]["ref"].send(
-            bytearray(b"\xFD\xE0")
-            + self.master.getFakeTWCID()
-            + bytearray(masterID)
-            + bytearray(self.master.slaveHeartbeatData)
-        )
+        interface = self.master.getInterfaceModule()
+        if interface:
+            interface.send(
+                bytearray(b"\xFD\xE0")
+                + self.master.getFakeTWCID()
+                + bytearray(masterID)
+                + bytearray(self.master.slaveHeartbeatData)
+            )
 
     def send_master_heartbeat(self):
         # Send our fake master's heartbeat to this TWCSlave.
@@ -549,12 +551,14 @@ class TWCSlave:
                 ).getCarApiVehicles():
                     vehicle.stopAskingToStartCharging = False
 
-        self.master.getModulesByType("Interface")[0]["ref"].send(
-            bytearray(b"\xFB\xE0")
-            + self.master.getFakeTWCID()
-            + bytearray(self.TWCID)
-            + bytearray(self.masterHeartbeatData)
-        )
+        interface = self.master.getInterfaceModule()
+        if interface:
+            interface.send(
+                bytearray(b"\xFB\xE0")
+                + self.master.getFakeTWCID()
+                + bytearray(self.TWCID)
+                + bytearray(self.masterHeartbeatData)
+            )
 
     def receive_slave_heartbeat(self, heartbeatData):
         # Handle heartbeat message received from real slave TWC.


### PR DESCRIPTION
Just as an experiment, load modules from the background thread instead of the foreground.  The foreground thread has to wait to make sure the interface module gets loaded, but this should make the RS485 loop start a bit sooner.  I haven't timed it -- I don't have a good method to do that -- but I can restart TWCManager without interrupting a charge now.

I encountered a few random errors; I think they're mostly addressed, but I'm sure this opens up more race conditions around startup, especially for any modules with cross-module dependencies.  Mostly they're addressed by assuming that a request to `getModuleByX()` might not find it, and handling that case.  Technically, we should have been doing that anyway.

I wouldn't merge it until a few more of us have tried it, at least.  Fixes #285, potentially.