### PR TITLE
Bound how long the backoff can be

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1056,7 +1056,7 @@ class TeslaAPI:
         errorCount = self.errorCount
         if vehicle:
             errorCount = max(vehicle.errorCount, errorCount)
-        return pow(2, max(errorCount - 1, 0))
+        return pow(2, min(max(errorCount - 1, 0), 6))
 
     def getCarApiLastErrorTime(self):
         return self.carApiLastErrorTime
@@ -1093,9 +1093,6 @@ class TeslaAPI:
                     + str(lastError),
                 )
                 return int(backoff - lasterrortime)
-
-    def getCarApiTransientErrors(self):
-        return self.carApiTransientErrors
 
     def getCarApiTokenExpireTime(self):
         return self.carApiTokenExpireTime


### PR DESCRIPTION
I'm uncertain why the 3.4 test failed.  This change just keeps the retry time from getting longer than an hour.  (Roughly -- powers of 2, so 64 minutes.)