### PR TITLE
EMS Volkszähler: Now show always both values Generation and Consumption.

### DIFF
--- a/lib/TWCManager/EMS/Volkszahler.py
+++ b/lib/TWCManager/EMS/Volkszahler.py
@@ -1,6 +1,3 @@
-# /home/pi/TWCManager/lib/TWCManager/EMS/Volkszahler.py
-# File from Saftwerk 2021-06-03
-
 import logging
 import requests
 import time
@@ -17,18 +14,17 @@ class Volkszahler:
     cacheTime = 10
     config = None
     configConfig = None
-    uuidPhotovoltaikW = None
-    PhotovoltaikW = 0
-    uuidTotalGridW = None
-    TotalGridW = 0
     configVolkszahler = None
+    consumedW = 0
     fetchFailed = False
+    generatedW = 0
     lastFetch = 0
     master = None
     serverIP = None
     serverPort = 80
     status = False
     timeout = 2
+    uuid = None
 
     def __init__(self, master):
         self.master = master
@@ -38,41 +34,43 @@ class Volkszahler:
         self.serverIP = self.configVolkszahler.get("serverIP", None)
         self.serverPort = self.configVolkszahler.get("serverPort", 80)
         self.status = self.configVolkszahler.get("enabled", False)
-        self.uuidPhotovoltaikW = self.configVolkszahler.get("uuidPhotovoltaikW", None)
-        self.uuidTotalGridW = self.configVolkszahler.get("uuidTotalGridW", None)
+        self.uuid = self.configVolkszahler.get("uuid", None)
 
         # Unload if this module is disabled or misconfigured
-        if (not self.status) or (not self.serverIP) or (not self.uuidTotalGridW):
+        if (not self.status) or (not self.serverIP) or (not self.uuid):
             self.master.releaseModule("lib.TWCManager.EMS", self.__class__.__name__)
             return None
 
-    def getGeneration(self):
-        if not self.status:
-            logger.debug("EMS Module Disabled. Skipping getGeneration")
-            return 0
-        # Perform updates if necessary
-        self.update()
-        # Return generation value
-        if self.PhotovoltaikW > 0:
-            return self.PhotovoltaikW
-        else:
-            return 0
-
     def getConsumption(self):
+
         if not self.status:
             logger.debug("EMS Module Disabled. Skipping getConsumption")
             return 0
-        # Perform updates if necessary
-        self.update()
-        # Return consumption value
-        # negative 'TotalGridW' is 'Export to Grid'
-        if (self.PhotovoltaikW + self.TotalGridW) > 0:
-            return (self.PhotovoltaikW + self.TotalGridW)
+
+        # While we don't have separate generation or consumption values, if
+        # the value is a positive value we report it as consumption
+        if self.generatedW < 0:
+            return self.generatedW * -1
         else:
             return 0
 
-    def getPhotovoltaikW(self):
-        url = "http://" + self.serverIP + ":" + self.serverPort + "/api/data.txt?from=now&uuid=" + uuidPhotovoltaikW
+    def getGeneration(self):
+
+        if not self.status:
+            logger.debug("EMS Module Disabled. Skipping getGeneration")
+            return 0
+
+        # Perform updates if necessary
+        self.update()
+
+        # Return generation value
+        if self.generatedW > 0:
+            return self.generatedW
+        else:
+            return 0
+
+    def getGenerationValues(self):
+        url = "http://" + self.serverIP + ":" + self.serverPort + "/api/data.txt?from=now&uuid=" + self.uuid
         headers = {"content-type": "text/plain"}
 
         # Update fetchFailed boolean to False before fetch attempt
@@ -83,61 +81,37 @@ class Volkszahler:
             logger.debug("Fetching Volkszahler EMS sensor values")
             httpResponse = requests.get(url, headers=headers, timeout=self.timeout)
         except requests.exceptions.ConnectionError as e:
-            logger.log(logging.INFO4, "Error connecting to Volkszahler to getPhotovoltaikW")
+            logger.log(
+                logging.INFO4, "Error connecting to Volkszahler to fetch sensor values"
+            )
             logger.debug(str(e))
             self.fetchFailed = True
             return False
         except requests.exceptions.ReadTimeout as e:
-            logger.log(logging.INFO4, "Read Timeout occurred getPhotovoltaikW")
+            logger.log(
+                logging.INFO4, "Read Timeout occurred fetching Volkszahler sensor values"
+            )
             logger.debug(str(e))
             self.fetchFailed = True
             return False
+
         if httpResponse.status_code != 200:
-            logger.log(logging.INFO4, "Volkszahler API reports HTTP Status Code " + str(httpResponse.status_code))
+            logger.log(
+                logging.INFO4,
+                "Volkszahler API reports HTTP Status Code " + str(httpResponse.status_code),
+            )
             return False
+
         if not httpResponse:
             logger.log(logging.INFO4, "Empty HTTP Response from Volkszahler API")
-            self.fetchFailed = True
             return False
+
         else:
+
             msgMatch = re.search("^(.+) W$", httpResponse.text, re.DOTALL)
+
             if msgMatch:
-                self.PhotovoltaikW = float( msgMatch.group(1) )
-            else:
-                logger.log(logging.INFO4, "Did not find expected value inside of Volkszahler API response.")
-
-   def getTotalGridW(self):
-        url = "http://" + self.serverIP + ":" + self.serverPort + "/api/data.txt?from=now&uuid=" + uuidTotalGridW
-        headers = {"content-type": "text/plain"}
-
-        # Update fetchFailed boolean to False before fetch attempt
-        # This will change to true if the fetch failed, ensuring we don't then use the value to update our cache
-        self.fetchFailed = False
-
-        try:
-            logger.debug("Fetching Volkszahler EMS sensor values")
-            httpResponse = requests.get(url, headers=headers, timeout=self.timeout)
-        except requests.exceptions.ConnectionError as e:
-            logger.log(logging.INFO4, "Error connecting to Volkszahler to getTotalGridW")
-            logger.debug(str(e))
-            self.fetchFailed = True
-            return False
-        except requests.exceptions.ReadTimeout as e:
-            logger.log(logging.INFO4, "Read Timeout occurred getTotalGridW")
-            logger.debug(str(e))
-            self.fetchFailed = True
-            return False
-        if httpResponse.status_code != 200:
-            logger.log(logging.INFO4, "Volkszahler API reports HTTP Status Code " + str(httpResponse.status_code))
-            return False
-        if not httpResponse:
-            logger.log(logging.INFO4, "Empty HTTP Response from Volkszahler API")
-            self.fetchFailed = True
-            return False
-        else:
-            msgMatch = re.search("^(.+) W$", httpResponse.text, re.DOTALL)
-            if msgMatch:
-                self.TotalGridW = float( msgMatch.group(1) )
+                self.generatedW = -float( msgMatch.group(1) )
             else:
                 logger.log(logging.INFO4, "Did not find expected value inside of Volkszahler API response.")
 
@@ -152,11 +126,12 @@ class Volkszahler:
 
         if (int(time.time()) - self.lastFetch) > self.cacheTime:
             # Cache has expired. Fetch values from Volkszahler.
-            self.getPhotovoltaikW()
-            self.getTotalGridW()
+            self.getGenerationValues()
+
             # Update last fetch time
             if self.fetchFailed is not True:
                 self.lastFetch = int(time.time())
+
             return True
         else:
             # Cache time has not elapsed since last fetch, serve from cache.

--- a/lib/TWCManager/EMS/Volkszahler.py
+++ b/lib/TWCManager/EMS/Volkszahler.py
@@ -1,3 +1,6 @@
+# /home/pi/TWCManager/lib/TWCManager/EMS/Volkszahler.py
+# File from Saftwerk 2021-06-03
+
 import logging
 import requests
 import time
@@ -14,17 +17,18 @@ class Volkszahler:
     cacheTime = 10
     config = None
     configConfig = None
+    uuidPhotovoltaikW = None
+    PhotovoltaikW = 0
+    uuidTotalGridW = None
+    TotalGridW = 0
     configVolkszahler = None
-    consumedW = 0
     fetchFailed = False
-    generatedW = 0
     lastFetch = 0
     master = None
     serverIP = None
     serverPort = 80
     status = False
     timeout = 2
-    uuid = None
 
     def __init__(self, master):
         self.master = master
@@ -34,43 +38,41 @@ class Volkszahler:
         self.serverIP = self.configVolkszahler.get("serverIP", None)
         self.serverPort = self.configVolkszahler.get("serverPort", 80)
         self.status = self.configVolkszahler.get("enabled", False)
-        self.uuid = self.configVolkszahler.get("uuid", None)
+        self.uuidPhotovoltaikW = self.configVolkszahler.get("uuidPhotovoltaikW", None)
+        self.uuidTotalGridW = self.configVolkszahler.get("uuidTotalGridW", None)
 
         # Unload if this module is disabled or misconfigured
-        if (not self.status) or (not self.serverIP) or (not self.uuid):
+        if (not self.status) or (not self.serverIP) or (not self.uuidTotalGridW):
             self.master.releaseModule("lib.TWCManager.EMS", self.__class__.__name__)
             return None
 
-    def getConsumption(self):
-
-        if not self.status:
-            logger.debug("EMS Module Disabled. Skipping getConsumption")
-            return 0
-
-        # While we don't have separate generation or consumption values, if
-        # the value is a positive value we report it as consumption
-        if self.generatedW < 0:
-            return self.generatedW * -1
-        else:
-            return 0
-
     def getGeneration(self):
-
         if not self.status:
             logger.debug("EMS Module Disabled. Skipping getGeneration")
             return 0
-
         # Perform updates if necessary
         self.update()
-
         # Return generation value
-        if self.generatedW > 0:
-            return self.generatedW
+        if self.PhotovoltaikW > 0:
+            return self.PhotovoltaikW
         else:
             return 0
 
-    def getGenerationValues(self):
-        url = "http://" + self.serverIP + ":" + self.serverPort + "/api/data.txt?from=now&uuid=" + self.uuid
+    def getConsumption(self):
+        if not self.status:
+            logger.debug("EMS Module Disabled. Skipping getConsumption")
+            return 0
+        # Perform updates if necessary
+        self.update()
+        # Return consumption value
+        # negative 'TotalGridW' is 'Export to Grid'
+        if (self.PhotovoltaikW + self.TotalGridW) > 0:
+            return (self.PhotovoltaikW + self.TotalGridW)
+        else:
+            return 0
+
+    def getPhotovoltaikW(self):
+        url = "http://" + self.serverIP + ":" + self.serverPort + "/api/data.txt?from=now&uuid=" + self.uuidPhotovoltaikW
         headers = {"content-type": "text/plain"}
 
         # Update fetchFailed boolean to False before fetch attempt
@@ -81,37 +83,61 @@ class Volkszahler:
             logger.debug("Fetching Volkszahler EMS sensor values")
             httpResponse = requests.get(url, headers=headers, timeout=self.timeout)
         except requests.exceptions.ConnectionError as e:
-            logger.log(
-                logging.INFO4, "Error connecting to Volkszahler to fetch sensor values"
-            )
+            logger.log(logging.INFO4, "Error connecting to Volkszahler to getPhotovoltaikW")
             logger.debug(str(e))
             self.fetchFailed = True
             return False
         except requests.exceptions.ReadTimeout as e:
-            logger.log(
-                logging.INFO4, "Read Timeout occurred fetching Volkszahler sensor values"
-            )
+            logger.log(logging.INFO4, "Read Timeout occurred getPhotovoltaikW")
             logger.debug(str(e))
             self.fetchFailed = True
             return False
-
         if httpResponse.status_code != 200:
-            logger.log(
-                logging.INFO4,
-                "Volkszahler API reports HTTP Status Code " + str(httpResponse.status_code),
-            )
+            logger.log(logging.INFO4, "Volkszahler API reports HTTP Status Code " + str(httpResponse.status_code))
             return False
-
         if not httpResponse:
             logger.log(logging.INFO4, "Empty HTTP Response from Volkszahler API")
+            self.fetchFailed = True
             return False
-
         else:
-
             msgMatch = re.search("^(.+) W$", httpResponse.text, re.DOTALL)
-
             if msgMatch:
-                self.generatedW = -float( msgMatch.group(1) )
+                self.PhotovoltaikW = float( msgMatch.group(1) )
+            else:
+                logger.log(logging.INFO4, "Did not find expected value inside of Volkszahler API response.")
+
+    def getTotalGridW(self):
+        url = "http://" + self.serverIP + ":" + self.serverPort + "/api/data.txt?from=now&uuid=" + self.uuidTotalGridW
+        headers = {"content-type": "text/plain"}
+
+        # Update fetchFailed boolean to False before fetch attempt
+        # This will change to true if the fetch failed, ensuring we don't then use the value to update our cache
+        self.fetchFailed = False
+
+        try:
+            logger.debug("Fetching Volkszahler EMS sensor values")
+            httpResponse = requests.get(url, headers=headers, timeout=self.timeout)
+        except requests.exceptions.ConnectionError as e:
+            logger.log(logging.INFO4, "Error connecting to Volkszahler to getTotalGridW")
+            logger.debug(str(e))
+            self.fetchFailed = True
+            return False
+        except requests.exceptions.ReadTimeout as e:
+            logger.log(logging.INFO4, "Read Timeout occurred getTotalGridW")
+            logger.debug(str(e))
+            self.fetchFailed = True
+            return False
+        if httpResponse.status_code != 200:
+            logger.log(logging.INFO4, "Volkszahler API reports HTTP Status Code " + str(httpResponse.status_code))
+            return False
+        if not httpResponse:
+            logger.log(logging.INFO4, "Empty HTTP Response from Volkszahler API")
+            self.fetchFailed = True
+            return False
+        else:
+            msgMatch = re.search("^(.+) W$", httpResponse.text, re.DOTALL)
+            if msgMatch:
+                self.TotalGridW = float( msgMatch.group(1) )
             else:
                 logger.log(logging.INFO4, "Did not find expected value inside of Volkszahler API response.")
 
@@ -126,12 +152,11 @@ class Volkszahler:
 
         if (int(time.time()) - self.lastFetch) > self.cacheTime:
             # Cache has expired. Fetch values from Volkszahler.
-            self.getGenerationValues()
-
+            self.getPhotovoltaikW()
+            self.getTotalGridW()
             # Update last fetch time
             if self.fetchFailed is not True:
                 self.lastFetch = int(time.time())
-
             return True
         else:
             # Cache time has not elapsed since last fetch, serve from cache.

--- a/lib/TWCManager/EMS/Volkszahler.py
+++ b/lib/TWCManager/EMS/Volkszahler.py
@@ -1,3 +1,6 @@
+# /home/pi/TWCManager/lib/TWCManager/EMS/Volkszahler.py
+# File from Saftwerk 2021-06-03
+
 import logging
 import requests
 import time
@@ -14,17 +17,18 @@ class Volkszahler:
     cacheTime = 10
     config = None
     configConfig = None
+    uuidPhotovoltaikW = None
+    PhotovoltaikW = 0
+    uuidTotalGridW = None
+    TotalGridW = 0
     configVolkszahler = None
-    consumedW = 0
     fetchFailed = False
-    generatedW = 0
     lastFetch = 0
     master = None
     serverIP = None
     serverPort = 80
     status = False
     timeout = 2
-    uuid = None
 
     def __init__(self, master):
         self.master = master
@@ -34,43 +38,41 @@ class Volkszahler:
         self.serverIP = self.configVolkszahler.get("serverIP", None)
         self.serverPort = self.configVolkszahler.get("serverPort", 80)
         self.status = self.configVolkszahler.get("enabled", False)
-        self.uuid = self.configVolkszahler.get("uuid", None)
+        self.uuidPhotovoltaikW = self.configVolkszahler.get("uuidPhotovoltaikW", None)
+        self.uuidTotalGridW = self.configVolkszahler.get("uuidTotalGridW", None)
 
         # Unload if this module is disabled or misconfigured
-        if (not self.status) or (not self.serverIP) or (not self.uuid):
+        if (not self.status) or (not self.serverIP) or (not self.uuidTotalGridW):
             self.master.releaseModule("lib.TWCManager.EMS", self.__class__.__name__)
             return None
 
-    def getConsumption(self):
-
-        if not self.status:
-            logger.debug("EMS Module Disabled. Skipping getConsumption")
-            return 0
-
-        # While we don't have separate generation or consumption values, if
-        # the value is a positive value we report it as consumption
-        if self.generatedW < 0:
-            return self.generatedW * -1
-        else:
-            return 0
-
     def getGeneration(self):
-
         if not self.status:
             logger.debug("EMS Module Disabled. Skipping getGeneration")
             return 0
-
         # Perform updates if necessary
         self.update()
-
         # Return generation value
-        if self.generatedW > 0:
-            return self.generatedW
+        if self.PhotovoltaikW > 0:
+            return self.PhotovoltaikW
         else:
             return 0
 
-    def getGenerationValues(self):
-        url = "http://" + self.serverIP + ":" + self.serverPort + "/api/data.txt?from=now&uuid=" + self.uuid
+    def getConsumption(self):
+        if not self.status:
+            logger.debug("EMS Module Disabled. Skipping getConsumption")
+            return 0
+        # Perform updates if necessary
+        self.update()
+        # Return consumption value
+        # negative 'TotalGridW' is 'Export to Grid'
+        if (self.PhotovoltaikW + self.TotalGridW) > 0:
+            return (self.PhotovoltaikW + self.TotalGridW)
+        else:
+            return 0
+
+    def getPhotovoltaikW(self):
+        url = "http://" + self.serverIP + ":" + self.serverPort + "/api/data.txt?from=now&uuid=" + uuidPhotovoltaikW
         headers = {"content-type": "text/plain"}
 
         # Update fetchFailed boolean to False before fetch attempt
@@ -81,37 +83,61 @@ class Volkszahler:
             logger.debug("Fetching Volkszahler EMS sensor values")
             httpResponse = requests.get(url, headers=headers, timeout=self.timeout)
         except requests.exceptions.ConnectionError as e:
-            logger.log(
-                logging.INFO4, "Error connecting to Volkszahler to fetch sensor values"
-            )
+            logger.log(logging.INFO4, "Error connecting to Volkszahler to getPhotovoltaikW")
             logger.debug(str(e))
             self.fetchFailed = True
             return False
         except requests.exceptions.ReadTimeout as e:
-            logger.log(
-                logging.INFO4, "Read Timeout occurred fetching Volkszahler sensor values"
-            )
+            logger.log(logging.INFO4, "Read Timeout occurred getPhotovoltaikW")
             logger.debug(str(e))
             self.fetchFailed = True
             return False
-
         if httpResponse.status_code != 200:
-            logger.log(
-                logging.INFO4,
-                "Volkszahler API reports HTTP Status Code " + str(httpResponse.status_code),
-            )
+            logger.log(logging.INFO4, "Volkszahler API reports HTTP Status Code " + str(httpResponse.status_code))
             return False
-
         if not httpResponse:
             logger.log(logging.INFO4, "Empty HTTP Response from Volkszahler API")
+            self.fetchFailed = True
             return False
-
         else:
-
             msgMatch = re.search("^(.+) W$", httpResponse.text, re.DOTALL)
-
             if msgMatch:
-                self.generatedW = -float( msgMatch.group(1) )
+                self.PhotovoltaikW = float( msgMatch.group(1) )
+            else:
+                logger.log(logging.INFO4, "Did not find expected value inside of Volkszahler API response.")
+
+   def getTotalGridW(self):
+        url = "http://" + self.serverIP + ":" + self.serverPort + "/api/data.txt?from=now&uuid=" + uuidTotalGridW
+        headers = {"content-type": "text/plain"}
+
+        # Update fetchFailed boolean to False before fetch attempt
+        # This will change to true if the fetch failed, ensuring we don't then use the value to update our cache
+        self.fetchFailed = False
+
+        try:
+            logger.debug("Fetching Volkszahler EMS sensor values")
+            httpResponse = requests.get(url, headers=headers, timeout=self.timeout)
+        except requests.exceptions.ConnectionError as e:
+            logger.log(logging.INFO4, "Error connecting to Volkszahler to getTotalGridW")
+            logger.debug(str(e))
+            self.fetchFailed = True
+            return False
+        except requests.exceptions.ReadTimeout as e:
+            logger.log(logging.INFO4, "Read Timeout occurred getTotalGridW")
+            logger.debug(str(e))
+            self.fetchFailed = True
+            return False
+        if httpResponse.status_code != 200:
+            logger.log(logging.INFO4, "Volkszahler API reports HTTP Status Code " + str(httpResponse.status_code))
+            return False
+        if not httpResponse:
+            logger.log(logging.INFO4, "Empty HTTP Response from Volkszahler API")
+            self.fetchFailed = True
+            return False
+        else:
+            msgMatch = re.search("^(.+) W$", httpResponse.text, re.DOTALL)
+            if msgMatch:
+                self.TotalGridW = float( msgMatch.group(1) )
             else:
                 logger.log(logging.INFO4, "Did not find expected value inside of Volkszahler API response.")
 
@@ -126,12 +152,11 @@ class Volkszahler:
 
         if (int(time.time()) - self.lastFetch) > self.cacheTime:
             # Cache has expired. Fetch values from Volkszahler.
-            self.getGenerationValues()
-
+            self.getPhotovoltaikW()
+            self.getTotalGridW()
             # Update last fetch time
             if self.fetchFailed is not True:
                 self.lastFetch = int(time.time())
-
             return True
         else:
             # Cache time has not elapsed since last fetch, serve from cache.


### PR DESCRIPTION
Purpose: Split single value from Volkszähler into two separate values to see always both Generation and Consumption.
1. Parameter in file "config.json" > "sources" > "Volkszahler" was renamed from "uuid" to "uuidTotalGridW".
2. Parameter in file "config.json" > "sources" > "Volkszahler" added: "uuidPhotovoltaikW".
3. Calculation changed in functions: getGeneration(self), getConsumption(self)
4. Functions added: getPhotovoltaikW(self), getTotalGridW(self).   They are almost like old function "getGenerationValues(self)"
5. Other functions changed: update(self)
6. Some empty lines were removed.

Result:
![image](https://user-images.githubusercontent.com/19615255/120665643-42327280-c48c-11eb-8e2b-c37690f3ac15.png)
