### PR TITLE
Add support for Charging Amps & Available from total

### DIFF
--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -25,6 +25,9 @@
                         }
                         $('#'+key).html(json[key]);
                     });
+		    var chargingAmps = 0;
+		    chargingAmps = parseFloat(json['chargerLoadAmps']);
+		    $('#chargerLoadAmps').html(chargingAmps.toFixed(2));
 
                     // calculate power surplus
                     var surplusAmps = 0.0;
@@ -82,6 +85,10 @@
                           $(twc+'_'+key).html(slvtwc[key]);
                         });
                     });
+		    var chargerAvailAmps = 0;
+		    var tot = json['total'];
+		    chargerAvailAmps = parseFloat(tot['lastAmpsOffered']);
+		    $('#chargerAvailAmps').html(chargerAvailAmps.toFixed(2));
                 }
             });
             setTimeout(requestSlaves, 3000);

--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -104,7 +104,7 @@ wcmanager/settings.json and try saving your settings again.</b>
                 <h1 class="meter"><span id="chargerLoadWatts">0.0</span></h1>
             </div>
             <div class="row justify-content-center display-watt text-muted">
-                <span id="chargerLoadAmps">0.0</span>&nbsp;A&nbsp;|&nbsp;0&nbsp;A&nbsp;<small class="mt-1">avail.</small>
+                <span id="chargerLoadAmps">0.0</span>&nbsp;A&nbsp;|&nbsp;<span id="chargerAvailAmps">0</span>&nbsp;A&nbsp;<small class="mt-1">offered.</small>
             </div>
         </div>
 

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -368,10 +368,11 @@ class TWCMaster:
         return self.slaveSign
 
     def getStatus(self):
-
+        chargerLoad = float(self.getChargerLoad())
         data = {
             "carsCharging": self.num_cars_charging_now(),
-            "chargerLoadWatts": "%.2f" % float(self.getChargerLoad()),
+            "chargerLoadWatts": "%.2f" % chargerLoad,
+            "chargerLoadAmps:": ("%.2f" % self.convertWattsToAmps(chargerLoad),),
             "currentPolicy": str(self.getModuleByName("Policy").active_policy),
             "maxAmpsToDivideAmongSlaves": "%.2f"
             % float(self.getMaxAmpsToDivideAmongSlaves()),


### PR DESCRIPTION
Added chargerLoadAmps to the ajax data source
Added support for chargerLoadAmps in the JSRefresh code to populate the unused field
Added new <span> for "avail" amps, changed wording to "offered" (If this isn't the intent of the "avail" field, let me know and I can update accordingly)
Pulled Total data into var tot
Use total -> lastAmpsOffered for Offered Amps
Populate new chargerAvailAmps span with value