### PR TITLE
Show SoC state in Modern UI

### DIFF
--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -85,7 +85,8 @@
                             if (key === 'lastVIN' && slvtwc[key] !== '') {
                                 $(twc+'_'+lastSocState).html($(twc+'_'+socState).html());
                                 $(twc+'_'+lastSocState).show();
-                            } else {
+                            }
+                          } else {
                                 $(twc+'_'+socState).show();
                                 $(twc+'_'+lastSocState).hide();
                             }

--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -85,11 +85,10 @@
                             if (key === 'lastVIN' && slvtwc[key] !== '') {
                                 $(twc+'_'+lastSocState).html($(twc+'_'+socState).html());
                                 $(twc+'_'+lastSocState).show();
+                            } else {
+                                $(twc+'_'+socState).show();
+                                $(twc+'_'+lastSocState).hide();
                             }
-                          } else {
-                            $(twc+'_'+socState).show();
-                            $(twc+'_'+lastSocState).hide();
-                          }
                           }
                         });
                     });

--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -80,18 +80,13 @@
                         var twc = '#' + slvtwc['TWCID']
                         Object.keys(slvtwc).forEach(function(key) {
                           $(twc+'_'+key).html(slvtwc[key]);
-                          if (key === 'currentVIN' && slvtwc[key] === '') {
-                            $(twc+'_'+socState).hide();
-                            if (key === 'lastVIN' && slvtwc[key] !== '') {
-                                $(twc+'_'+lastSocState).html($(twc+'_'+socState).html());
-                                $(twc+'_'+lastSocState).show();
-                            }
-                          } else {
-                                $(twc+'_'+socState).show();
-                                $(twc+'_'+lastSocState).hide();
+                          if (key === 'lastBatterySOC' && slvtwc[key] === '') {
+                              //no SOC data
+                              $(twc+'__socState').hide();
                           }
                         });
                     });
+                    
 		            var chargerAvailAmps = 0;
 		            var tot = json['total'];
 		            chargerAvailAmps = parseFloat(tot['lastAmpsOffered']);

--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -89,7 +89,6 @@
                           } else {
                                 $(twc+'_'+socState).show();
                                 $(twc+'_'+lastSocState).hide();
-                            }
                           }
                         });
                     });

--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -80,14 +80,18 @@
                         var twc = '#' + slvtwc['TWCID']
                         Object.keys(slvtwc).forEach(function(key) {
                           $(twc+'_'+key).html(slvtwc[key]);
+                          if (key === 'currentVIN' && slvtwc[key] === '') {
+                            $(twc+'_'+socState).hide();
+                          }
                         });
                     });
-		    var chargerAvailAmps = 0;
-		    var tot = json['total'];
-		    chargerAvailAmps = parseFloat(tot['lastAmpsOffered']);
-		    $('#chargerAvailAmps').html(chargerAvailAmps.toFixed(2));
+		            var chargerAvailAmps = 0;
+		            var tot = json['total'];
+		            chargerAvailAmps = parseFloat(tot['lastAmpsOffered']);
+		            $('#chargerAvailAmps').html(chargerAvailAmps.toFixed(2));
                 }
             });
+
             setTimeout(requestSlaves, 3000);
         }
         requestSlaves();

--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -82,6 +82,14 @@
                           $(twc+'_'+key).html(slvtwc[key]);
                           if (key === 'currentVIN' && slvtwc[key] === '') {
                             $(twc+'_'+socState).hide();
+                            if (key === 'lastVIN' && slvtwc[key] !== '') {
+                                $(twc+'_'+lastSocState).html($(twc+'_'+socState).html());
+                                $(twc+'_'+lastSocState).show();
+                            }
+                          } else {
+                            $(twc+'_'+socState).show();
+                            $(twc+'_'+lastSocState).hide();
+                          }
                           }
                         });
                     });

--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -25,9 +25,6 @@
                         }
                         $('#'+key).html(json[key]);
                     });
-		    var chargingAmps = 0;
-		    chargingAmps = parseFloat(json['chargerLoadAmps']);
-		    $('#chargerLoadAmps').html(chargingAmps.toFixed(2));
 
                     // calculate power surplus
                     var surplusAmps = 0.0;

--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -262,8 +262,9 @@ wcmanager/settings.json and try saving your settings again.</b>
                     <div class="row">
                         <div class="col-12 text-left" style="line-height: 1.37em;">
                             <strong>Vehicle</strong>:<br>
-                            Current: <span id="{{ twcid }}_currentVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','current');"></span><span id="{{ twcid }}_socState"> (<span id="{{ twcid }}_lastBatterySOC"></span>/<span id="{{ twcid }}_lastChargeLimit"></span>%)</span><br>
-                            Last: <span id="{{ twcid }}_lastVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','last');"><span id="{{ twcid }}_lastSocState"></span></span>
+                            Current: <span id="{{ twcid }}_currentVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','current');"></span><br>
+                            Last: <span id="{{ twcid }}_lastVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','last');"></span><br>
+                            SoC: <span id="{{ twcid }}_socState"><span id="{{ twcid }}_lastBatterySOC"></span>/<span id="{{ twcid }}_lastChargeLimit"></span>%</span>
                         </div>
                     </div>
                 </div>

--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -263,7 +263,7 @@ wcmanager/settings.json and try saving your settings again.</b>
                         <div class="col-12 text-left" style="line-height: 1.37em;">
                             <strong>Vehicle</strong>:<br>
                             Current: <span id="{{ twcid }}_currentVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','current');"></span><span id="{{ twcid }}_socState"> (<span id="{{ twcid }}_lastBatterySOC"></span>/<span id="{{ twcid }}_lastChargeLimit"></span>%)</span><br>
-                            Last: <span id="{{ twcid }}_lastVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','last');"></span>
+                            Last: <span id="{{ twcid }}_lastVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','last');"><span id="{{ twcid }}_lastSocState"></span></span>
                         </div>
                     </div>
                 </div>

--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -262,7 +262,7 @@ wcmanager/settings.json and try saving your settings again.</b>
                     <div class="row">
                         <div class="col-12 text-left" style="line-height: 1.37em;">
                             <strong>Vehicle</strong>:<br>
-                            Current: <span id="{{ twcid }}_currentVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','current');"></span> (<span id="{{ twcid }}_lastBatterySOC"></span>/<span id="{{ twcid }}_lastChargeLimit"></span>%)<br>
+                            Current: <span id="{{ twcid }}_currentVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','current');"></span><span id="{{ twcid }}_socState"> (<span id="{{ twcid }}_lastBatterySOC"></span>/<span id="{{ twcid }}_lastChargeLimit"></span>%)</span><br>
                             Last: <span id="{{ twcid }}_lastVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','last');"></span>
                         </div>
                     </div>

--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -261,7 +261,7 @@ wcmanager/settings.json and try saving your settings again.</b>
                 <div class="col"><!-- Vehicle -->
                     <div class="row">
                         <div class="col-12 text-left" style="line-height: 1.37em;">
-                            Vehicle:<br>
+                            <strong>Vehicle</strong>:<br>
                             Current: <span id="{{ twcid }}_currentVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','current');"></span> (<span id="{{ twcid }}_lastBatterySOC"></span>/<span id="{{ twcid }}_lastChargeLimit"></span>%)<br>
                             Last: <span id="{{ twcid }}_lastVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','last');"></span>
                         </div>

--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -262,7 +262,7 @@ wcmanager/settings.json and try saving your settings again.</b>
                     <div class="row">
                         <div class="col-12 text-left" style="line-height: 1.37em;">
                             Vehicle:<br>
-                            Current: <span id="{{ twcid }}_currentVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','current');"></span><br>
+                            Current: <span id="{{ twcid }}_currentVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','current');"></span> (<span id="{{ twcid }}_lastBatterySOC"></span>/<span id="{{ twcid }}_lastChargeLimit"></span>%)<br>
                             Last: <span id="{{ twcid }}_lastVIN" class='VINClick' onClick="loadVIN('{{ twcid }}','last');"></span>
                         </div>
                     </div>

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -372,7 +372,7 @@ class TWCMaster:
         data = {
             "carsCharging": self.num_cars_charging_now(),
             "chargerLoadWatts": "%.2f" % chargerLoad,
-            "chargerLoadAmps:": ("%.2f" % self.convertWattsToAmps(chargerLoad),),
+            "chargerLoadAmps": ("%.2f" % self.convertWattsToAmps(chargerLoad),),
             "currentPolicy": str(self.getModuleByName("Policy").active_policy),
             "maxAmpsToDivideAmongSlaves": "%.2f"
             % float(self.getMaxAmpsToDivideAmongSlaves()),


### PR DESCRIPTION
Added ability to render current (last polled) State of Charge and the cars target SoC

I understand this is affected by the frequency of polling the Tesla API (default 30 minutes), so is a little bit lagged behind, but if the polling frequency is increased, this becomes more accurate. 

Also set bold on the Vehicle overall heading, to make it stand out a little clearer from the Current/Last sub-headings

![image](https://user-images.githubusercontent.com/3220618/123224216-f5830a00-d514-11eb-93da-16c167b7a228.png)
