### PR TITLE
Charge now duration

### DIFF
--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -283,6 +283,7 @@ wcmanager/settings.json and try saving your settings again.</b>
                 <div class="form-group p-2">
                     <label for="chargeNowDuration" class="text-muted mb-0">Charge duration <span class="text-dark font-weight-bold" id="{{ twcid }}_durationVal">1</span> hours</label>
                     <input type="range" class="custom-range" id="chargeNowDuration" name="chargeNowDuration" min="1" max="24" step="1" value="1" onInput="$('#{{ twcid }}_durationVal').html($(this).val())">
+                    <span class="text-muted mb-0" id="chargeNowTimeEnd"></span>
                 </div>
             </form>
         </div>
@@ -293,6 +294,7 @@ wcmanager/settings.json and try saving your settings again.</b>
                 <div class="form-group p-2">
                     <label for="chargeNowRate" class="text-muted mb-0">Charge with <span class="text-dark font-weight-bold" id="{{ twcid }}_ampsVal">{{ ampsMin[0] }}</span> A</label>
                     <input type="range" class="custom-range" id="chargeNowRate" name="chargeNowRate" min="{{ ampsMin[0]}}" max="{{ ampsMax[0] }}" step="1" value="{{ ampsMin[0] }}" onInput="$('#{{ twcid }}_ampsVal').html($(this).val())">
+                    <span class="text-muted mb-0" id="chargeNowAmps"></span>
                 </div>
             </form>
         </div>

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -447,6 +447,10 @@ class TWCMaster:
             "flexSunday": (scheduledFlexTime[2] & 64) == 64,
             "flexBatterySize": self.getScheduledAmpsBatterySize(),
         }
+        if self.settings["chargeNowTimeEnd"] > 0:
+            data["chargeNowTimeEnd"] = "Ending: " + datetime.fromtimestamp(self.settings["chargeNowTimeEnd"]).strftime("%Y-%m-%d, %H:%M") + " (HH:MM)"
+        if self.settings["chargeNowAmps"] > 0:
+            data["chargeNowAmps"] = "Currently: " + str(self.settings["chargeNowAmps"]) + "A"
         return data
 
     def getSpikeAmps(self):

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -448,7 +448,11 @@ class TWCMaster:
             "flexBatterySize": self.getScheduledAmpsBatterySize(),
         }
         if self.settings["chargeNowTimeEnd"] > 0:
-            data["chargeNowTimeEnd"] = "Ending: " + datetime.fromtimestamp(self.settings["chargeNowTimeEnd"]).strftime("%Y-%m-%d, %H:%M") + " (HH:MM)"
+            chargingEndDTM = datetime.fromtimestamp(self.settings["chargeNowTimeEnd"])
+            if chargingEndDTM > datetime.now():
+                diff = chargingEndDTM - datetime.now()
+                diffMinutes = int(round(diff.total_seconds() / 60))
+                data["chargeNowTimeEnd"] = "Ending: " + chargingEndDTM.strftime("%Y-%m-%d, %H:%M") + " ("+str(diffMinutes)+" Minutes)"
         if self.settings["chargeNowAmps"] > 0:
             data["chargeNowAmps"] = "Currently: " + str(self.settings["chargeNowAmps"]) + "A"
         return data


### PR DESCRIPTION
added support to show remaining duration of active Charge Now. 
Shows Date/time, and minutes remaining, as well as the currently set amps. 

Desktop:
<img width="892" alt="image" src="https://user-images.githubusercontent.com/3220618/123579188-c0c7c900-d81a-11eb-8d3a-de4eb91e8b9b.png">
Mobile:
<img width="333" alt="image" src="https://user-images.githubusercontent.com/3220618/123579202-c9b89a80-d81a-11eb-89e0-2195f1b4c6f1.png">
