### PR TITLE
Fix charge_update: vehicleVIN between quotes and string replace using…

### DIFF
--- a/lib/TWCManager/Logging/MySQLLogging.py
+++ b/lib/TWCManager/Logging/MySQLLogging.py
@@ -66,7 +66,7 @@ class MySQLHandler(logging.Handler):
                 chgid = self.slaveSession.get(twcid, 0)
                 if getattr(record, "vehicleVIN", None):
                     query = """
-                        UPDATE charge_sessions SET vehicleVIN = %s
+                        UPDATE charge_sessions SET vehicleVIN = '%s'
                         WHERE chargeid = %s AND slaveTWC = %s"
                     """
 
@@ -76,7 +76,7 @@ class MySQLHandler(logging.Handler):
                     cur = self.db.cursor()
                     rows = 0
                     try:
-                        rows = cur.execute(query, (getattr(record, "vehicleVIN", ""), chgid, twcid))
+                        rows = cur.execute(query % (getattr(record, "vehicleVIN", ""), chgid, twcid))
                     except Exception as e:
                         logger.error("Error updating MySQL database: %s", e)
                     if rows:


### PR DESCRIPTION
Pull request regarding issue #332

The vehicleVIN in the update query is now between brackets and the string replacement is done via a ```%``` (percentage) character instead of a ```,``` (comma).  

I'm not sure why the previous was not working, because the insert statement at charge_start is working well. Probably something with the string itself.