### PR TITLE
Feature /api/getUUID

### DIFF
--- a/docs/modules/Control_HTTP.md
+++ b/docs/modules/Control_HTTP.md
@@ -75,6 +75,7 @@ The following API endpoints exist:
 | getPolicy                | GET  | Provides the policy configuration                 |
 | getSlaveTWCs             | GET  | Provides a list of connected Slave TWCs and their state |
 | getStatus                | GET  | Provides the current status (Charge Rate, Policy) |
+| getUUID                  | GET  | Provides a unique ID for this particular master, based on the physical MAC address |
 | [saveSettings](control_HTTP_API/saveSettings.md)         | POST | Saves settings to settings file |
 | [sendStartCommand](control_HTTP_API/sendStartCommand.md) | POST | Sends the Start command to all Slave TWCs    |
 | setSetting               | POST | Set settings |

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -11,6 +11,7 @@ import re
 import threading
 import time
 import urllib.parse
+import uuid
 import math
 from ww import f
 
@@ -362,6 +363,13 @@ def CreateHTTPHandlerClass(master):
 
                 json_data = json.dumps(output)
                 self.wfile.write(json_data.encode("utf-8"))
+            
+            elif self.url.path == "/api/getUUID":
+                self.send_response(200)
+                self.send_header("Content-type", "text/plain")
+                self.end_headers()
+
+                self.wfile.write(str(uuid.getnode()).encode("utf-8"))
 
             else:
                 # All other routes missed, return 404


### PR DESCRIPTION
It is useful to have a unique identifier for a given TWCManager installation. Individual TWCs have a TWCID, but the master currently can not be distinguished from other TWCManager instances. Using IP addresses is problematic because they can change, and the Mac address (which this uses, under the hood) is not necessarily discoverable when the TWCManager is on a different network segment.

Use cases: Centralized logging, Home Assistant sensor unique identifiers.