### PR TITLE
Move debounce

### DIFF
--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -54,7 +54,7 @@ class TWCSlave:
     lastAmpsDesired = -1
     useFlexAmpsToStartCharge = False
     timeLastAmpsOfferedChanged = 0
-    timeLastAmpsOfferedFlipped = 0
+    timeLastAmpsDesiredFlipped = 0
     lastHeartbeatDebugOutput = ""
     startStopDelay = 0
     timeLastHeartbeatDebugOutput = 0
@@ -700,7 +700,7 @@ class TWCSlave:
 
         dampenChanges = (
             True
-            if now - self.timeLastAmpsOfferedFlipped < self.startStopDelay
+            if now - self.timeLastAmpsDesiredFlipped < self.startStopDelay
             else False
         )
 
@@ -935,7 +935,7 @@ class TWCSlave:
             self.lastAmpsDesired > 0 and desiredAmpsOffered == 0
         ):
             self.lastAmpsDesired = desiredAmpsOffered
-            self.timeLastAmpsOfferedFlipped = now
+            self.timeLastAmpsDesiredFlipped = now
             logger.info("lastAmpsDesired flipped - now " + str(desiredAmpsOffered))
 
         # Keep charger on or off if dampening changes. See reasoning above where
@@ -953,7 +953,7 @@ class TWCSlave:
             self.lastAmpsDesired > 0 and desiredAmpsOffered == 0
         ):
             self.lastAmpsDesired = desiredAmpsOffered
-            self.timeLastAmpsOfferedFlipped = now
+            self.timeLastAmpsDesiredFlipped = now
             logger.debug("lastAmpsDesired flipped - now " + str(desiredAmpsOffered))
 
         # Keep charger on or off if dampening changes. See reasoning above where

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -941,24 +941,6 @@ class TWCSlave:
         # Keep charger on or off if dampening changes. See reasoning above where
         # I don't turn the charger off till it's been on for a bit.
         if self.reportedAmpsActual > 0 and desiredAmpsOffered == 0 and dampenChanges:
-            logger.info("Don't stop TWC " + self.master.hex_str(self.TWCID) + " yet.")
-            desiredAmpsOffered = self.minAmpsTWCSupports
-        elif self.lastAmpsOffered == 0 and desiredAmpsOffered > 0 and dampenChanges:
-            logger.info(
-                "Don't start charging TWC " + self.master.hex_str(self.TWCID) + " yet."
-            )
-            desiredAmpsOffered = 0
-
-        if (self.lastAmpsDesired <= 0 and desiredAmpsOffered > 0) or (
-            self.lastAmpsDesired > 0 and desiredAmpsOffered == 0
-        ):
-            self.lastAmpsDesired = desiredAmpsOffered
-            self.timeLastAmpsDesiredFlipped = now
-            logger.debug("lastAmpsDesired flipped - now " + str(desiredAmpsOffered))
-
-        # Keep charger on or off if dampening changes. See reasoning above where
-        # I don't turn the charger off till it's been on for a bit.
-        if self.reportedAmpsActual > 0 and desiredAmpsOffered == 0 and dampenChanges:
             logger.debug("Don't stop TWC " + self.master.hex_str(self.TWCID) + " yet.")
             desiredAmpsOffered = self.minAmpsTWCSupports
         elif self.lastAmpsOffered == 0 and desiredAmpsOffered > 0 and dampenChanges:

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -940,18 +940,12 @@ class TWCSlave:
 
         # Keep charger on or off if dampening changes. See reasoning above where
         # I don't turn the charger off till it's been on for a bit.
-        if self.lastAmpsOffered > 0 and desiredAmpsOffered == 0 and dampenChanges:
-            logger.info(
-                "Don't stop charging TWC "
-                + self.master.hex_str(self.TWCID)
-                + " yet."
-            )
+        if self.reportedAmpsActual > 0 and desiredAmpsOffered == 0 and dampenChanges:
+            logger.info("Don't stop TWC " + self.master.hex_str(self.TWCID) + " yet.")
             desiredAmpsOffered = self.minAmpsTWCSupports
         elif self.lastAmpsOffered == 0 and desiredAmpsOffered > 0 and dampenChanges:
             logger.info(
-                "Don't start charging TWC "
-                + self.master.hex_str(self.TWCID)
-                + " yet."
+                "Don't start charging TWC " + self.master.hex_str(self.TWCID) + " yet."
             )
             desiredAmpsOffered = 0
 
@@ -965,17 +959,11 @@ class TWCSlave:
         # Keep charger on or off if dampening changes. See reasoning above where
         # I don't turn the charger off till it's been on for a bit.
         if self.reportedAmpsActual > 0 and desiredAmpsOffered == 0 and dampenChanges:
-            logger.debug(
-                "Don't stop TWC "
-                + self.master.hex_str(self.TWCID)
-                + " yet."
-            )
+            logger.debug("Don't stop TWC " + self.master.hex_str(self.TWCID) + " yet.")
             desiredAmpsOffered = self.minAmpsTWCSupports
         elif self.lastAmpsOffered == 0 and desiredAmpsOffered > 0 and dampenChanges:
             logger.debug(
-                "Don't start charging TWC "
-                + self.master.hex_str(self.TWCID)
-                + " yet."
+                "Don't start charging TWC " + self.master.hex_str(self.TWCID) + " yet."
             )
             desiredAmpsOffered = 0
 

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -82,7 +82,6 @@ class TWCSlave:
         )
         self.startStopDelay = self.configConfig.get("startStopDelay", 60)
 
-
     def print_status(self, heartbeatData):
 
         try:
@@ -799,12 +798,18 @@ class TWCSlave:
             # stick with whole amps.
             desiredAmpsOffered = int(desiredAmpsOffered)
 
-            dampenChanges = True if now - self.timeLastAmpsOfferedFlipped < self.startStopDelay else False
+            dampenChanges = (
+                True
+                if now - self.timeLastAmpsOfferedFlipped < self.startStopDelay
+                else False
+            )
 
-            if (self.lastAmpsDesired == 0 and desiredAmpsOffered > 0) or (self.lastAmpsDesired > 0 and desiredAmpsOffered == 0):
+            if (self.lastAmpsDesired <= 0 and desiredAmpsOffered > 0) or (
+                self.lastAmpsDesired > 0 and desiredAmpsOffered == 0
+            ):
                 self.lastAmpsDesired = desiredAmpsOffered
                 self.timeLastAmpsOfferedFlipped = now
-                logger.info("lastAmpsDesired flipped - now " + desiredAmpsOffered)
+                logger.info("lastAmpsDesired flipped - now " + str(desiredAmpsOffered))
 
             if self.lastAmpsOffered > 0 and desiredAmpsOffered == 0 and dampenChanges:
                 # Keep charger on or off for at least startStopDelay before

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -700,7 +700,9 @@ class TWCSlave:
 
         dampenChanges = (
             True
-            if now - self.timeLastAmpsDesiredFlipped < self.startStopDelay
+            if now
+            - min(self.timeLastAmpsDesiredFlipped, self.timeLastAmpsOfferedChanged)
+            < self.startStopDelay
             else False
         )
 
@@ -936,7 +938,7 @@ class TWCSlave:
         ):
             self.lastAmpsDesired = desiredAmpsOffered
             self.timeLastAmpsDesiredFlipped = now
-            logger.info("lastAmpsDesired flipped - now " + str(desiredAmpsOffered))
+            logger.debug("lastAmpsDesired flipped - now " + str(desiredAmpsOffered))
 
         # Keep charger on or off if dampening changes. See reasoning above where
         # I don't turn the charger off till it's been on for a bit.

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -704,7 +704,7 @@ class TeslaAPI:
             for vehicle in self.getCarApiVehicles():
                 vehicle.stopAskingToStartCharging = False
 
-        if (now - self.getLastStartOrStopChargeTime() < 60):
+        if now - self.getLastStartOrStopChargeTime() < 60:
 
             # Don't start or stop more often than once a minute
             logger.log(

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -24,15 +24,12 @@ class TeslaAPI:
     carApiRefreshToken = ""
     carApiTokenExpireTime = time.time()
     carApiLastStartOrStopChargeTime = 0
-    carApiLastStartOrStopChargeAction = None
-    carApiLastStartOrStopFlipTime = 0
     carApiLastChargeLimitApplyTime = 0
     clientID = "81527cff06843c8634fdc09e8ac0abefb46ac849f38fe1e431c2ef2106796384"
     clientSecret = "c7257eb71a564034f9419ee651c7d0e5f7aa6bfbd18bafb5c5c033b093bb2fa3"
     lastChargeLimitApplied = 0
     lastChargeCheck = 0
     chargeUpdateInterval = 1800
-    startStopDelay = 60
     carApiVehicles = []
     config = None
     master = None
@@ -70,7 +67,6 @@ class TeslaAPI:
         try:
             self.config = master.config
             self.minChargeLevel = self.config["config"].get("minChargeLevel", -1)
-            self.startStopDelay = self.config["config"].get("startStopDelay", 60)
             self.chargeUpdateInterval = self.config["config"].get(
                 "cloudUpdateInterval", 1800
             )
@@ -708,15 +704,7 @@ class TeslaAPI:
             for vehicle in self.getCarApiVehicles():
                 vehicle.stopAskingToStartCharging = False
 
-        if (now - self.getLastStartOrStopChargeTime() < 60) or (
-            now - self.carApiLastStartOrStopFlipTime < self.startStopDelay
-            and charge != self.carApiLastStartOrStopChargeAction
-        ):
-            if self.carApiLastStartOrStopChargeAction != charge:
-                # If we're repeatedly changing our minds about whether to charge or not,
-                # stay how we are until the system settles down.
-                self.carApiLastStartOrStopChargeAction = charge
-                self.carApiLastStartOrStopFlipTime = now
+        if (now - self.getLastStartOrStopChargeTime() < 60):
 
             # Don't start or stop more often than once a minute
             logger.log(
@@ -762,10 +750,6 @@ class TeslaAPI:
             # to wake cars.  Setting this prevents any command below from being sent
             # more than once per minute.
             self.updateLastStartOrStopChargeTime()
-
-            if self.carApiLastStartOrStopChargeAction != charge:
-                self.carApiLastStartOrStopChargeAction = charge
-                self.carApiLastStartOrStopFlipTime = now
 
             if (
                 self.config["config"]["onlyChargeMultiCarsAtHome"]


### PR DESCRIPTION
The changes on this look bigger than they are, because lots of code moved out one indent level.  I suggest using the [whitespace-ignored](https://github.com/ngardiner/TWCManager/pull/345/files?w=1) view for simplicity.

The previous version of this, in #270, was fairly simple, but suffered from a major drawback -- when a car wasn't actually charging, TWCManager doesn't attempt to stop it, so it didn't see that as an occasion where TWCManager didn't want to offer power.  Conversely, when all the cars have been told to charge or are complete, it didn't see that as an occasion where TWCManager wanted to offer power.

This change moves equivalent logic inside the TWCSlave module instead.  In the process, it consolidates a few other chunks of code attempting to impose minimum lengths of time between changes.  I've been running it on my system for about a week, and it performs well in the face of clothes dryers, ovens, and other large appliances that make TWCManager whiplash between offering 25A and 0A.