### PR TITLE
Mark PW2 token as invalid if API call fails

### DIFF
--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -216,6 +216,7 @@ class TeslaPowerwall2:
             except Exception as e:
                 if hasattr(e, "response") and e.response.status_code == 403:
                     logger.info("Authentication required to access local Powerwall API")
+                    self.tokenTimeout = 0
                 else:
                     logger.log(
                         logging.INFO4,


### PR DESCRIPTION
Recent FW updates to the PW2 appear to leave the auth tokens valid for shorter periods of time.  We already catch and log auth failures, but don't do anything about them; this makes us discard the token.

This design means we return stale data for one policy period, but in case the password is wrong, we're not hammering the PW2 with reattempts.  Seems like a worthwhile tradeoff.