### PR TITLE
Further refinement to dampenChanges

### DIFF
--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -699,7 +699,12 @@ class TWCSlave:
         ):
             desiredAmpsOffered = minAmpsToOffer
 
-        dampenChanges = (now - self.timeLastAmpsDesiredFlipped) < self.startStopDelay
+        dampenChanges = False
+        if self.master.getModuleByName("Policy").policyIsGreen():
+            if (now - self.timeLastAmpsDesiredFlipped) < self.startStopDelay:
+                dampenChanges = True
+        else:
+            self.timeLastAmpsDesiredFlipped = 0
 
         if desiredAmpsOffered < minAmpsToOffer:
             logger.debug(

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -447,7 +447,7 @@ class TWCSlave:
 
                 if (
                     now - self.timeLastAmpsOfferedChanged < 60
-                    or now - self.timeReportedAmpsActualChangedSignificantly < 60
+                    or now - self.timeReportedAmpsActualChangedSignificantly < self.startStopDelay
                     or self.reportedAmpsActual < 4.0
                 ):
                     # We want to tell the car to stop charging. However, it's

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -699,16 +699,7 @@ class TWCSlave:
         ):
             desiredAmpsOffered = minAmpsToOffer
 
-        dampenChanges = (
-            True
-            if now
-            - max(
-                self.timeLastAmpsDesiredFlipped,
-                self.timeReportedAmpsActualChangedSignificantly,
-            )
-            < self.startStopDelay
-            else False
-        )
+        dampenChanges = (now - self.timeLastAmpsDesiredFlipped) < self.startStopDelay
 
         if desiredAmpsOffered < minAmpsToOffer:
             logger.debug(
@@ -944,16 +935,10 @@ class TWCSlave:
             self.timeLastAmpsDesiredFlipped = now
             logger.debug("lastAmpsDesired flipped - now " + str(desiredAmpsOffered))
 
-        # Keep charger on or off if dampening changes. See reasoning above where
+        # Keep charger on if dampening changes. See reasoning above where
         # I don't turn the charger off till it's been on for a bit.
-        if self.reportedAmpsActual > 0 and desiredAmpsOffered == 0 and dampenChanges:
-            logger.debug("Don't stop TWC " + self.master.hex_str(self.TWCID) + " yet.")
-            desiredAmpsOffered = self.minAmpsTWCSupports
-        elif self.lastAmpsOffered == 0 and desiredAmpsOffered > 0 and dampenChanges:
-            logger.debug(
-                "Don't start charging TWC " + self.master.hex_str(self.TWCID) + " yet."
-            )
-            desiredAmpsOffered = 0
+        if dampenChanges and self.reportedAmpsActual > 0:
+            desiredAmpsOffered = max(self.minAmpsTWCSupports, desiredAmpsOffered)
 
         # set_last_amps_offered does some final checks to see if the new
         # desiredAmpsOffered is safe. It should be called after we've picked a


### PR DESCRIPTION
This simplifies #345/#364 further and scopes it to green policies only; it does mean that it will always choose to keep charging while waiting for stability rather than continuing not to change, but that seems like an acceptable trade-off for the simplification and the fact that it's more resilient to failed attempts to start charging.

Possible candidate for 1.2.4 (#366).