### PR TITLE
Round current MaxAmps to integer when calculating difference

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -634,7 +634,7 @@ class TWCMaster:
         # consumption.
 
         currentOffer = max(
-            self.getMaxAmpsToDivideAmongSlaves(),
+            int(self.getMaxAmpsToDivideAmongSlaves()),
             self.num_cars_charging_now() * self.config["config"]["minAmpsPerTWC"],
         )
         newOffer = currentOffer + self.convertWattsToAmps(generationW - consumptionW)


### PR DESCRIPTION
This sometimes causes the value selected to be off-by-one from what would logically make sense.  For example, the last round decided to offer 9.8A; what's actually offered is 9A; the algorithm wants to reduce the offer by at least 500W.  The right answer is 8.5A, not 9.3A.