### PR TITLE
Add support for Open Energy Monitor EMS sources

### DIFF
--- a/docs/modules/EMS_EmonCMS.md
+++ b/docs/modules/EMS_EmonCMS.md
@@ -1,0 +1,43 @@
+# Open Energy Monitor EMS Module
+
+## Introduction
+
+The Open Energy Monitor (EmonCMS) EMS module allows fetching of solar generation and consumption values from Open Energy Monitor. This is useful as it allows a general interface to data which may be combined within Open Energy Monitor, eg. accumulating generation data from multiple inverters.
+
+### Status
+
+| Detail          | Value                          |
+| --------------- | ------------------------------ |
+| **Module Name** | EmonCMS                        |
+| **Module Type** | Energy Management System (EMS) |
+| **Features**    | Consumption, Generation        |
+| **Status**      | Implemented, Tested            |
+
+## Configuration
+
+The following table shows the available configuration parameters for the HASS EMS module.
+
+| Parameter   | Value         |
+| ----------- | ------------- |
+| apiKey      | *required* API Key. You can find this under "Feed API Help" in your Open Energy Monitor Feeds page. |
+| enabled     | *required* Boolean value, ```true``` or ```false```. Determines whether we will poll HomeAssistant sensors. |
+| consumptionFeed | *optional* The ID of the consumption feed in OpenEnergyMonitor. |
+| generationFeed  | *optional* The ID of the generation feed in OpenEnergyMonitor. |
+| serverIP    | *required* The IP address or hostname of the Open Energy Monitor instance. We will poll the REST HTTP API. |
+| serverPort  | *optional* The port that the webserver for Open Energy Monitor is listening on. Defaults to 80 (HTTP). |
+| serverPath  | *optional* The HTTP path, if Open Energy Monitor is setup in a subdirectory. Defaults to empty, you should add a trailing '/'. |
+| useHttps    | *optional* Boolean value, ```true``` or ```false```. Should it use https instead of http. |
+
+### JSON Configuration Example
+
+```
+"EmonCMS": {
+  "apiKey": "ABC123",
+  "enabled": true,
+  "consumptionFeed": 1,
+  "generationFeed": 2,
+  "serverIP": "power.local",
+  "serverPort": 80
+}
+```
+

--- a/lib/TWCManager/EMS/EmonCMS.py
+++ b/lib/TWCManager/EMS/EmonCMS.py
@@ -1,0 +1,167 @@
+import logging
+
+logger = logging.getLogger(__name__.rsplit(".")[-1])
+
+
+class EmonCMS:
+
+    # OpenEnergyMonitor (EmonCMS) Module
+    # Fetches Consumption and Generation details from Open Energy Monitor
+
+    import requests
+    import time
+
+    apiKey = None
+    cacheTime = 10
+    config = None
+    configConfig = None
+    configEmonCMS = None
+    consumedW = 0
+    generatedW = 0
+    consumptionFeed = None
+    generationFeed = None
+    lastFetch = 0
+    master = None
+    status = False
+    serverIP = None
+    serverPort = 80
+    serverPath = None
+    useHttps = False
+    timeout = 2
+    entities = None
+
+    def __init__(self, master):
+        self.master = master
+        self.config = master.config
+        try:
+            self.configConfig = master.config["config"]
+        except KeyError:
+            self.configConfig = {}
+        try:
+            self.configEmonCMS = master.config["sources"]["EmonCMS"]
+        except KeyError:
+            self.configEmonCMS = {}
+        self.status = self.configEmonCMS.get("enabled", False)
+        self.serverIP = self.configEmonCMS.get("serverIP", None)
+        self.serverPort = self.configEmonCMS.get("serverPort", 80)
+        self.serverPath = self.configEmonCMS.get("serverPath", "")
+        self.useHttps = self.configEmonCMS.get("useHttps", False)
+        self.apiKey = self.configEmonCMS.get("apiKey", None)
+        self.consumptionFeed = self.configEmonCMS.get("consumptionFeed", None)
+        self.generationFeed = self.configEmonCMS.get("generationFeed", None)
+        self.entities = {}
+
+        # Unload if this module is disabled or misconfigured
+        if (not self.status) or (not self.serverIP) or (int(self.serverPort) < 1):
+            self.master.releaseModule("lib.TWCManager.EMS", "EmonCMS")
+            return None
+
+    def getConsumption(self):
+
+        if not self.status:
+            logger.debug("Module Disabled. Skipping getConsumption")
+            return 0
+
+        # Perform updates if necessary
+        self.update()
+
+        # Return consumption value
+        return self.consumedW
+
+    def getGeneration(self):
+
+        if not self.status:
+            logger.debug("Module Disabled. Skipping getGeneration")
+            return 0
+
+        # Perform updates if necessary
+        self.update()
+
+        # Return generation value
+        return self.generatedW
+
+    def getFeeds(self, feeds):
+        if len(feeds) == 0:
+            logger.log(
+                logging.INFO4,
+                "No EmonCMS feeds to fetch",
+            )
+            return False
+
+        http = "http://" if not (self.useHttps) else "https://"
+        url = http + self.serverIP + ":" + self.serverPort + self.serverPath + "/feed/fetch.json?ids=" + ','.join(feeds)
+        headers = {
+            "Authorization": "Bearer " + self.apiKey,
+        }
+
+        try:
+            logger.debug("Fetching EmonCMS feeds " + ','.join(feeds))
+            httpResponse = self.requests.get(url, headers=headers, timeout=self.timeout)
+        except self.requests.exceptions.ConnectionError as e:
+            logger.log(
+                logging.INFO4,
+                "Error connecting to EmonCMS to fetch feed",
+            )
+            logger.debug(str(e))
+            return False
+        except self.requests.exceptions.ReadTimeout as e:
+            logger.log(
+                logging.INFO4,
+                "Read Timeout fetching EmonCMS feed",
+            )
+            logger.debug(str(e))
+            return False
+
+        if httpResponse.status_code != 200:
+            logger.log(
+                logging.INFO4,
+                "Failed to fetch " + url + " HTTP Status: " + str(httpResponse.status_code),
+            )
+            return False
+
+        jsonResponse = (
+            httpResponse.json()
+            if httpResponse and httpResponse.status_code == 200
+            else None
+        )
+
+        if jsonResponse:
+            return jsonResponse
+        else:
+            return None
+
+    def setCacheTime(self, cacheTime):
+        self.cacheTime = cacheTime
+
+    def setTimeout(self, timeout):
+        self.timeout = timeout
+
+    def update(self):
+        # Update function - determine if an update is required
+
+        if (int(self.time.time()) - self.lastFetch) > self.cacheTime:
+            # Cache has expired. Fetch values from EmonCMS
+            feeds = []
+
+            if self.consumptionFeed:
+                feeds.append(self.consumptionFeed)
+
+            if self.consumptionFeed:
+                feeds.append(self.generationFeed)
+
+            vals = self.getFeeds(feeds)
+            if vals:
+                if self.consumptionFeed:
+                    self.consumedW = float(vals.pop())
+                    logger.debug("getConsumption returns " + str(self.consumedW))
+
+                if self.generationFeed:
+                    self.generatedW = float(vals.pop())
+                    logger.debug("getGeneration returns " + str(self.generatedW))
+
+                self.lastFetch = int(self.time.time())
+
+            return True
+        else:
+            # Cache time has not elapsed since last fetch, serve from cache.
+            return False

--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -89,6 +89,7 @@ modules_available = [
     "Control.MQTTControl",
     #    "Control.OCPPControl",
     "EMS.Efergy",
+    "EMS.EmonCMS",
     "EMS.Enphase",
     "EMS.Fronius",
     "EMS.Growatt",


### PR DESCRIPTION
Open Energy Monitor (aka EmonCMS) https://openenergymonitor.org/ is a tool used to log, analyse and visualise energy data.

It can pull data from multiple sources, and provides a REST API to pass data to and extract data from it.

It is particularly useful as it can apply complex logic to the data, and generate new data feeds based on it. For example, I have 4 inverters (2 of which have batteries), and an additional 2 battery chargers. Open Energy Monitor tracks my solar generation and can provide aggregated data across all inverters.

This patch allows TWCManager to obtain it's consumption and generation feeds directly from Open Energy Monitor.

Signed-off-by: Alastair D'Silva <alastair@d-silva.org>