### PR TITLE
Add option to always poll EMS modules

### DIFF
--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -272,6 +272,14 @@
     # - Evaluate any user defined extensions in the after section below
     # - Outside Scheduled Charging, charge at unscheduled charge rate
     "policy":{
+      # By default, EMS modules are polled only when the data is needed
+      # to track green energy. If you would like to always poll EMS for
+      # display purposes, uncomment this.
+      #
+      # This will not work for custom policies which specify their own
+      # background task.
+      #"alwaysPollEMS": true,
+
       "engine":{
         "policyCheckInterval": 30
       },

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -121,6 +121,11 @@ class Policy:
                 for (name, position) in [("after", 3), ("before", 1), ("emergency", 0)]:
                     self.charge_policy[position:position] = config_extend.get(name, [])
 
+            if config_policy.get("alwaysPollEMS", False):
+                for policy in self.charge_policy:
+                    if policy.get("background_task", None) is None:
+                        policy["background_task"] = "checkGreenEnergy"
+
             # Set the Policy Check Interval if specified
             policy_engine = config_policy.get("engine")
             if policy_engine:


### PR DESCRIPTION
For certain reasons, including a nice UI, some people would rather always gather generation and consumption data, even if it's not being used by the current policy.  This PR adds an option in the config file to have (almost) all policies poll the EMS module for data.  It does so by adding the `checkGreenEnergy` background task to any policy which doesn't have a background task; `checkGreenEnergy` itself will not set charge amps unless the policy fails to specify a value.

The default was chosen for people who have load issues on the endpoint they're polling for data, though it might make sense to flip the default in the future if most users are polling local endpoints with ~unlimited capacity.

The "(almost)" is that if a policy already uses a background task which is not `checkGreenEnergy`, this doesn't override it to avoid breaking the policy, and we don't currently support multiple background tasks per policy.  That doesn't affect any in-box policies, but it could affect certain custom policies.