### PR TITLE
docker: set owner of config file after copy

### DIFF
--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -4,6 +4,7 @@
 # We use this to prepare the configuration for the first time
 if [ ! -e "/etc/twcmanager/config.json" ]; then
     cp /usr/src/TWCManager/etc/twcmanager/config.json /etc/twcmanager/config.json
+    chown twcmanager:twcmanager /etc/twcmanager/config.json
 fi
 
 # This will exec the CMD from your Dockerfile

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -4,7 +4,7 @@
 # We use this to prepare the configuration for the first time
 if [ ! -e "/etc/twcmanager/config.json" ]; then
     cp /usr/src/TWCManager/etc/twcmanager/config.json /etc/twcmanager/config.json
-    chown twcmanager:twcmanager /etc/twcmanager/config.json
+    chown twcmanager:twcmanager /etc/twcmanager /etc/twcmanager/config.json
 fi
 
 # This will exec the CMD from your Dockerfile


### PR DESCRIPTION
If a named volume or host directory is mapped into the container at /etc/twcmanager/ (as in the provided example docker-compose-yaml), it will likely be empty on the first startup. (Other than volumes specified in the Dockerfile, these volumes are not filled with pre-existing content at the target.) entrypoint.sh is working around this. But as the script is running as root, the created config file will be owned by root:root. The twcmanager daemon later can't write the file, because it is running as twcmanager user and the webinterface will display an error if the configuration is changed.

I decided not to change the directory owner, as we may be affecting files/directories on the host system as well and it might be better to be least intrusive. Do you need write access to /etc/twcmanager/? Doesn't look like.

I'm not happy with the hardcoded user/group, but it is hardcoded in the Makefile as well and there aren't any other files in the container owned by the same user which could be used as a reference. So the only option would have been to parse the Makefile to retrieve the user/group, which seems exaggerated and error-prone.
