### PR TITLE
add simple logging format to console logger

### DIFF
--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -376,7 +376,7 @@
         "Console": {
             "enabled": true,
             # simple logging format omits timestamp and colorization
-            "simple": false
+            #"simple": true
         },
         "FileLogger": {
           "enabled": false,

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -374,7 +374,9 @@
         # a pi, it may mean considering alternatives such as a remote database
         # to reduce write cycles.
         "Console": {
-            "enabled": true
+            "enabled": true,
+            # simple logging format omits timestamp and colorization
+            "simple": false
         },
         "FileLogger": {
           "enabled": false,

--- a/lib/TWCManager/Logging/ConsoleLogging.py
+++ b/lib/TWCManager/Logging/ConsoleLogging.py
@@ -51,17 +51,24 @@ class ConsoleLogging:
             self.configLogging["mute"] = {}
 
         # Initialize Logger
-        color_formatter = ColorFormatter(
-            colored("%(asctime)s", "yellow")
-            + " "
-            + colored("%(name)-10.10s", "green")
-            + " "
-            + colored("%(levelno)d", "cyan")
-            + " %(message)s",
-            "%H:%M:%S",
-        )
         handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(color_formatter)
+        if self.configLogging.get("simple", False):
+            handler.setFormatter(
+                logging.Formatter(
+                    "%(name)-10.10s %(levelno)02d %(message)s"
+                )
+            )
+        else:
+            color_formatter = ColorFormatter(
+                colored("%(asctime)s", "yellow")
+                + " "
+                + colored("%(name)-10.10s", "green")
+                + " "
+                + colored("%(levelno)d", "cyan")
+                + " %(message)s",
+                "%H:%M:%S",
+            )
+            handler.setFormatter(color_formatter)
         # handler.setLevel(logging.INFO)
         logging.getLogger("").addHandler(handler)
 


### PR DESCRIPTION
Omitting timestamp and colorization codes improves display on small terminals and those which do not support colorized output.

I'm redirecting console output for all my docker containers to syslog. Colorized log messages really don't work well here.
Before:
`Mar 13 17:43:24 charon twcmanager[665]: #033[33m17:43:24#033[0m #033[32m⛽ Manager #033[0m #033[36m20#033[0m Green energy Generates #033[35m0W#033[0m, Consumption #033[35m3710W#033[0m (Charger Load #033[35m0W#033[0m, Other Load #033[35m3710W#033[0m)`
After:
`Mar 13 17:45:42 charon twcmanager[665]: 17:45:42 ⛽ Manager  20 Green energy Generates 0W, Consumption 3800W (Charger Load 0W, Other Load 3800W)`

It's arguable whether we'd want to remove both colorization and the timestamp with one configuration option, but I'd want to keep it simple. One could also argue that multi-byte unicode characters (`⛽`) might also not be suitable for a "simple" log format.