### PR TITLE
EMS: add modbus TCP support for SolarEdge inverters

### DIFF
--- a/etc/twcmanager/.testconfig.json
+++ b/etc/twcmanager/.testconfig.json
@@ -526,12 +526,29 @@
           "serverPort": "1080"
         },
       # SolarEdge API, consumed from the internet-based SolarEdge Potal
+      # or directly from a local inverter with smart meter via modbus TCP
+      # NOTE: inverter needs to have modbus TCP enabled - call or email
+      #       SolarEdge to enable it for you or use SetApp to enable iT
         "SolarEdge": {
           "enabled": false,
       # API Key must be specified in order to monitor a SolarEdge site
           "apiKey": "",
       # Site ID defines which system to monitor
-          "siteID": ""
+          "siteID": "",
+      ## or local inverter, "apiKey" and "siteID" are ignored if you use this
+      # local IP address or hostname of inverter
+          #"inverterHost": "",
+      # default port is 1502, shouldn't need to be changed
+          #"inverterPort": 1502,
+      # you need 1 smart meter to track consumption, up to 3 are supported
+      # NOTE: if a network part is metered by both a consumption and an export
+      #       meter, only add one of them or consumption will be counted twice
+          #"smartMeters": [{
+      # smart meter names currently may be "Meter1", "Meter2", "Meter3"
+          #  "name": "Meter1",
+      # specify what is metered: "consumption" or "export"
+          #  "type": "export"
+          #}]
         },
       # SolarLog Inverters
         "SolarLog": {

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -578,12 +578,29 @@
           "serverPort": "1080"
         },
       # SolarEdge API, consumed from the internet-based SolarEdge Potal
+      # or directly from a local inverter with smart meter via modbus TCP
+      # NOTE: inverter needs to have modbus TCP enabled - call or email
+      #       SolarEdge to enable it for you or use SetApp to enable it
         "SolarEdge": {
           "enabled": false,
       # API Key must be specified in order to monitor a SolarEdge site
           "apiKey": "",
       # Site ID defines which system to monitor
-          "siteID": ""
+          "siteID": "",
+      ## or local inverter, "apiKey" and "siteID" are ignored if you use this
+      # local IP address or hostname of inverter
+          #"inverterHost": "",
+      # default port is 1502, shouldn't need to be changed
+          #"inverterPort": "1502",
+      # you need 1 smart meter to track consumption, up to 3 are supported
+      # NOTE: if a network part is metered by both a consumption and an export
+      #       meter, only add one of them or consumption will be counted twice
+          #"smartMeters": [{
+      # smart meter names currently may be "Meter1", "Meter2", "Meter3"
+          #  "name": "Meter1",
+      # specify what is metered: "consumption" or "export"
+          #  "type": "export"
+          #}]
         },
       # SolarLog Inverters
         "SolarLog": {

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -591,7 +591,7 @@
       # local IP address or hostname of inverter
           #"inverterHost": "",
       # default port is 1502, shouldn't need to be changed
-          #"inverterPort": "1502",
+          #"inverterPort": 1502,
       # you need 1 smart meter to track consumption, up to 3 are supported
       # NOTE: if a network part is metered by both a consumption and an export
       #       meter, only add one of them or consumption will be counted twice

--- a/etc/twcmanager/demo.json
+++ b/etc/twcmanager/demo.json
@@ -566,12 +566,29 @@
           "serverPort": "1080"
         },
       # SolarEdge API, consumed from the internet-based SolarEdge Potal
+      # or directly from a local inverter with smart meter via modbus TCP
+      # NOTE: inverter needs to have modbus TCP enabled - call or email
+      #       SolarEdge to enable it for you or use SetApp to enable it
         "SolarEdge": {
           "enabled": false,
       # API Key must be specified in order to monitor a SolarEdge site
           "apiKey": "",
       # Site ID defines which system to monitor
-          "siteID": ""
+          "siteID": "",
+      ## or local inverter, "apiKey" and "siteID" are ignored if you use this
+      # local IP address or hostname of inverter
+          #"inverterHost": "",
+      # default port is 1502, shouldn't need to be changed
+          #"inverterPort": 1502,
+      # you need 1 smart meter to track consumption, up to 3 are supported
+      # NOTE: if a network part is metered by both a consumption and an export
+      #       meter, only add one of them or consumption will be counted twice
+          #"smartMeters": [{
+      # smart meter names currently may be "Meter1", "Meter2", "Meter3"
+          #  "name": "Meter1",
+      # specify what is metered: "consumption" or "export"
+          #  "type": "export"
+          #}]
         },
       # SolarLog Inverters
         "SolarLog": {

--- a/lib/TWCManager/EMS/SolarEdge.py
+++ b/lib/TWCManager/EMS/SolarEdge.py
@@ -55,19 +55,18 @@ class SolarEdge:
         self.status = self.configSolarEdge.get("enabled", self.status)
         self.siteID = self.configSolarEdge.get("siteID", None)
         self.inverterHost = self.configSolarEdge.get("inverterHost", self.inverterHost)
-        self.inverterPort = self.configSolarEdge.get("inverterPort", self.inverterPort)
+        self.inverterPort = int(self.configSolarEdge.get("inverterPort", self.inverterPort))
         self.smartMeters = self.configSolarEdge.get("smartMeters", self.smartMeters)
 
         # Unload if this module is disabled or misconfigured
         if (not self.status) or (
             ((not self.siteID) or (not self.apiKey))
-            and ((not self.inverterHost) or (not self.inverterPort)
-                 or (not self.smartMeters))
+            and ((not self.inverterHost) or (not self.inverterPort))
         ):
             self.master.releaseModule("lib.TWCManager.EMS", "SolarEdge")
             return None
 
-        if self.inverterHost and self.inverterPort and self.smartMeters:
+        if self.inverterHost and self.inverterPort:
             # basic syntax check for nested parameters
             for smartMeter in self.smartMeters:
                 if not "name" in smartMeter:

--- a/lib/TWCManager/EMS/SolarEdge.py
+++ b/lib/TWCManager/EMS/SolarEdge.py
@@ -351,6 +351,7 @@ class SolarEdge:
 
         # if we reach this point, everything should have gone well
         self.fetchFailed = False
+        inverter.disconnect()
 
     def update(self):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pyserial>=3.4
 PyYAML
 requests>=2.23.0
 sentry_sdk>=0.11.2
+solaredge_modbus>=0.7.0
 sysv_ipc
 termcolor>=1.1.0
 websockets<=9.1; python_version == '3.6'

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "pyyaml",
         "requests>=2.23.0",
         "sentry_sdk>=0.11.2",
+        "solaredge_modbus>=0.7.0",
         "sysv_ipc",
         "termcolor>=1.1.0",
         "websockets<=9.1; python_version == '3.6'",


### PR DESCRIPTION
Enables TWCManager to query local SolarEdge inverters via modbus TCP, avoiding the SolarEdge Cloud Service.

This requires the solaredge_modbus Python module, which has been added to `requirements.txt` and `setup.py`.

Please note I'm note a Python coder, so please double check if I'm doing very stupid things. :)