### PR TITLE
bugfix: detection of single/multi-phase TWC mix

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -705,17 +705,17 @@ class TWCMaster:
             if slave.voltsPhaseC:
                 localPhases += 1
 
-        if phases:
-            if localPhases != phases:
-                logger.info(
-                    "FATAL:  Mix of multi-phase TWC configurations not currently supported."
-                )
-                return (
-                    self.config["config"].get("defaultVoltage", 240),
-                    self.config["config"].get("numberOfPhases", 1),
-                )
-        else:
-            phases = localPhases
+            if phases:
+                if localPhases != phases:
+                    logger.info(
+                        "FATAL:  Mix of multi-phase TWC configurations not currently supported."
+                    )
+                    return (
+                        self.config["config"].get("defaultVoltage", 240),
+                        self.config["config"].get("numberOfPhases", 1),
+                    )
+            else:
+                phases = localPhases
 
         total = sum(
             [


### PR DESCRIPTION
Bug introduced by wrong indentation of `if` block in commit [af780b8](https://github.com/ngardiner/TWCManager/commit/af780b8cbd52f40783cdf19f551bf3efd4faa77a) 14 days ago

The `if` block belongs into the for loop, or it has no effect. Just stumbled across this by coincidence, while checking why the calculation of `getChargerLoad` and `convertWattsToAmps` respectively does not represent actual power usage of the TWC.

This might overload the power line if the **last** slave in the list has less phases than others in the list and `subtractChargerLoad` in `config.json` is set!

Btw. the concept of `convertAmpsToWatts`and `convertWattsToAmps` is actually broken in general and should better be replaced by something like `getAmpereMeasurement` and `getWattMeasurement`. Possible reasons why this is currently working at all are because it is highly unlikely to have very different Voltage levels in an interconnected setup of multiple TWCs, or maybe because electric current is always distributed equally across all slaves by TWCManager (didn't dig into allocation policies yet, as I don't have a second charger yet).