### PR TITLE
fix logging of charge limit

### DIFF
--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -453,7 +453,11 @@ def update_statuses():
             logger.debug(
                 f"Offering {maxampsDisplay} instead of {nominalOfferDisplay} to compensate for inexact current draw"
             )
-            conwatts = genwatts - master.convertAmpsToWatts(maxamps)
+            conwatts = genwatts - master.convertAmpsToWatts(maxamps) \
+                + ( chgwatts
+                    if (config["config"]["subtractChargerLoad"] and conwatts >= 0)
+                    else 0
+                )
         generation = f"{master.convertWattsToAmps(genwatts):.2f}A"
         consumption = f"{master.convertWattsToAmps(conwatts):.2f}A"
         utilization = f"{master.convertWattsToAmps(chgwatts):.2f}A"

--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -456,13 +456,19 @@ def update_statuses():
             conwatts = genwatts - master.convertAmpsToWatts(maxamps)
         generation = f"{master.convertWattsToAmps(genwatts):.2f}A"
         consumption = f"{master.convertWattsToAmps(conwatts):.2f}A"
-        logger.info(
-            "Limiting charging to %s - %s = %s.",
-            generation,
-            consumption,
-            maxampsDisplay,
-            extra={"colored": "magenta"},
-        )
+        utilization = f"{master.convertWattsToAmps(chgwatts):.2f}A"
+        if (config["config"]["subtractChargerLoad"]):
+            logger.info(
+                "Limiting charging to %s - (%s - %s) = %s.",
+                generation, consumption, utilization, maxampsDisplay,
+                extra={"colored": "magenta"},
+            )
+        else:
+            logger.info(
+                "Limiting charging to %s - %s = %s.",
+                generation, consumption, maxampsDisplay,
+                extra={"colored": "magenta"},
+            )
 
     else:
         # For all other modes, simply show the Amps to charge at

--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -432,20 +432,14 @@ def update_statuses():
                 extra=logExtra,
             )
 
+        # NOTE: conwatts currently can not be < 0, but as this might
+        # change in the future, e.g. for certain EMS scenarios, let's
+        # keep the check below, just in case
         nominalOffer = master.convertWattsToAmps(
-            genwatts
-            + (
-                chgwatts
-                if (config["config"]["subtractChargerLoad"] and conwatts == 0)
+            genwatts - conwatts
+            + ( chgwatts
+                if (config["config"]["subtractChargerLoad"] and conwatts >= 0)
                 else 0
-            )
-            - (
-                conwatts
-                - (
-                    chgwatts
-                    if (config["config"]["subtractChargerLoad"] and conwatts > 0)
-                    else 0
-                )
             )
         )
         if abs(maxamps - nominalOffer) > 0.005:


### PR DESCRIPTION
There are a few improvements to the log output of `update_statuses()` in `TWCManager.py`.

You may reject the simplification of the calculation if you prefer to keep it the way you implemented it. I found it easier to read if it is simplified the way I did.

Logging looked strange the way it was while charging was ongoing, when `subtractChargerLoad` was set. Log line was e.g. like:
` ⛽ Manager  20 Limiting charging to 6.88A - 6.61A = 6.77A.`
Or when nominal offer differed from actual:
`⛽ Manager  20 Limiting charging to 7.04A - -0.00A = 7.04A.`

When `subtractChargerLoad` is set, it now always has the following format:
`⛽ Manager  20 Limiting charging to 7.02A - (6.59A - 6.50A) = max 6.93A.`