### PR TITLE
bugfix: limit number of VIN requests

### DIFF
--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -1230,7 +1230,7 @@ while True:
                         potentialVIN = "".join(slaveTWC.VINData)
 
                         # Ensure we have a valid VIN
-                        if len(potentialVIN) == 17:
+                        if len(potentialVIN) == 17 or len(potentialVIN) == 0:
                             # Record Vehicle VIN
                             slaveTWC.currentVIN = potentialVIN
 


### PR DESCRIPTION
If a car does not report a propper VIN, TWCManager got into an endless getVehicleVIN / error loop, which we break by sending the getVehicleVIN request only two times in addition to the original request.

Connected a BMW 530e to my TWC today, and noticed TWCManager being stuck in an endless loop requesting the vehicles VIN:

> Mar 21 15:59:07 charon twc-test[665]: ⛽ Manager  15 Slave TWC 7218 reported VIN data: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00.
Mar 21 15:59:07 charon twc-test[665]: ⛽ Manager  15 Current VIN string is: ['', '', ''] at part 1.
Mar 21 15:59:08 charon twc-test[665]: ⛽ Manager  15 Slave TWC 7218 reported VIN data: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00.
Mar 21 15:59:08 charon twc-test[665]: ⛽ Manager  15 Current VIN string is: ['', '', ''] at part 2.
Mar 21 15:59:09 charon twc-test[665]: ⛽ Manager  15 Slave TWC 7218 reported VIN data: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00.
Mar 21 15:59:09 charon twc-test[665]: ⛽ Manager  15 Current VIN string is: ['', '', ''] at part 2.
Mar 21 15:59:10 charon twc-test[665]: ⛽ Manager  15 Slave TWC 7218 reported VIN data: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00.
Mar 21 15:59:10 charon twc-test[665]: ⛽ Manager  15 Current VIN string is: ['', '', ''] at part 1.
Mar 21 15:59:10 charon twc-test[665]: ⛽ Manager  15 Slave TWC 7218 reported VIN data: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00.
Mar 21 15:59:10 charon twc-test[665]: ⛽ Manager  15 Current VIN string is: ['', '', ''] at part 2.
Mar 21 15:59:11 charon twc-test[665]: ⛽ Manager  15 Slave TWC 7218 reported VIN data: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00.
Mar 21 15:59:11 charon twc-test[665]: ⛽ Manager  15 Current VIN string is: ['', '', ''] at part 2.
Mar 21 15:59:12 charon twc-test[665]: ⛽ Manager  15 Slave TWC 7218 reported VIN data: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00.
Mar 21 15:59:12 charon twc-test[665]: ⛽ Manager  15 Current VIN string is: ['', '', ''] at part 1.
Mar 21 15:59:13 charon twc-test[665]: ⛽ Manager  15 Slave TWC 7218 reported VIN data: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00.
Mar 21 15:59:13 charon twc-test[665]: ⛽ Manager  15 Current VIN string is: ['', '', ''] at part 2.
Mar 21 15:59:13 charon twc-test[665]: ⛽ Manager  15 Slave TWC 7218 reported VIN data: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00.
Mar 21 15:59:13 charon twc-test[665]: ⛽ Manager  15 Current VIN string is: ['', '', ''] at part 2.

I'm not sure if it does make sense to rerequest the VIN at all, as it's unlikely IMO that we get a different result, and it seems the VIN is requested regularly anyway. But it doesn't hurt to try as well.