### PR TITLE
handle "disconnected" error from Tesla API

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -705,7 +705,7 @@ class TeslaAPI:
                             self.resetCarApiLastErrorTime(vehicle)
                         elif charge:
                             reason = apiResponseDict["response"]["reason"]
-                            if reason == "complete" or reason == "charging" or reason == "disconnected":
+                            if reason in ["complete", "charging", "is_charging", "disconnected"]:
                                 # We asked the car to charge, but it responded that
                                 # it can't, either because it's reached target
                                 # charge state (reason == 'complete'), or it's

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -705,11 +705,12 @@ class TeslaAPI:
                             self.resetCarApiLastErrorTime(vehicle)
                         elif charge:
                             reason = apiResponseDict["response"]["reason"]
-                            if reason == "complete" or reason == "charging":
+                            if reason == "complete" or reason == "charging" or reason == "disconnected":
                                 # We asked the car to charge, but it responded that
                                 # it can't, either because it's reached target
                                 # charge state (reason == 'complete'), or it's
-                                # already trying to charge (reason == 'charging').
+                                # already trying to charge (reason == 'charging') or
+                                # it's not connected to a charger (reason == 'charging').
                                 # In these cases, it won't help to keep asking it to
                                 # charge, so set vehicle.stopAskingToStartCharging =
                                 # True.
@@ -719,7 +720,8 @@ class TeslaAPI:
                                 # which car in the list is connected to our TWC.
                                 logger.info(
                                     vehicle.name
-                                    + " is done charging or already trying to charge.  Stop asking to start charging."
+                                    + " is done charging or already trying to charge or not connected to a charger."
+                                    + "  Stop asking to start charging."
                                 )
                                 vehicle.stopAskingToStartCharging = True
                                 self.resetCarApiLastErrorTime(vehicle)


### PR DESCRIPTION
When a car is not connected to a charger and we ask it to start charging, we get an error saying "disconnected". This is now treated the same as "complete" or "charging".

Related to #428. Did not want to put this into the other pull request that closes the issue, as the two changes are completely independent.

I actually wonder why this was not reported already. It seems to me all cars that are not connected to a charger would return this error. Maybe it was introduced recently in an API change?