### PR TITLE
some EMS may report consumption as positive, and generation as negative

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -1275,6 +1275,8 @@ class TWCMaster:
         self.consumptionValues[source] = value
 
     def setGeneration(self, source, value):
+        if value < 0:
+            value = -value
         self.generationValues[source] = value
 
     def setHomeLat(self, lat):


### PR DESCRIPTION
so automatically negate a negative generation value