### PR TITLE
web: display active charging policy

### DIFF
--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -340,6 +340,18 @@ def CreateHTTPHandlerClass(master):
                 except BrokenPipeError:
                     self.debugLogAPI("Connection Error: Broken Pipe")
 
+            elif self.url.path == "/api/getActivePolicyAction":
+                data = master.getModuleByName("Policy").getActivePolicyAction()
+                self.send_response(200)
+                self.send_header("Content-type", "application/json")
+                self.end_headers()
+
+                json_data = json.dumps(data)
+                try:
+                    self.wfile.write(json_data.encode("utf-8"))
+                except BrokenPipeError:
+                    self.debugLogAPI("Connection Error: Broken Pipe")
+
             elif self.url.path == "/api/getHistory":
                 output = []
                 now = datetime.now().replace(second=0, microsecond=0).astimezone()

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -754,6 +754,19 @@ def CreateHTTPHandlerClass(master):
                 ).car_api_available()
                 self.scheduledAmpsMax = master.getScheduledAmpsMax()
 
+                policy = master.getModuleByName("Policy").active_policy
+                if policy == "Charge Now":
+                    self.activeAction = 1
+                elif policy == "Scheduled Charging":
+                    self.activeAction = 1
+                elif policy == "Track Green Energy":
+                    self.activeAction = 3
+                elif policy == "Non Scheduled Charging":
+                    self.activeAction = master.settings.get("nonScheduledAction", 1)
+                else:
+                    logger.error(f"non-standard policy {policy!r}, cannot display charge action in webinterface")
+
+
                 # Send the html message
                 page = self.template.render(vars(self))
 

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -767,14 +767,7 @@ def CreateHTTPHandlerClass(master):
                 ).car_api_available()
                 self.scheduledAmpsMax = master.getScheduledAmpsMax()
 
-                if master.getModuleByName("Policy").policyIsGreen():
-                    self.activeAction = 3
-                else:
-                    policy = master.getModuleByName("Policy").getPolicyByName(str(master.getModuleByName("Policy").active_policy))
-                    if int(master.getModuleByName("Policy").policyValue(policy.get("charge_amps", 0))) > 0:
-                        self.activeAction = 1
-                    else:
-                        self.activeAction = 2
+                self.activeAction = master.getModuleByName("Policy").getActivePolicyAction()
 
                 # Send the html message
                 page = self.template.render(vars(self))

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -755,7 +755,7 @@ def CreateHTTPHandlerClass(master):
                 ).car_api_available()
                 self.scheduledAmpsMax = master.getScheduledAmpsMax()
 
-                policy = master.getModuleByName("Policy").active_policy
+                policy = str(master.getModuleByName("Policy").active_policy)
                 if policy == "Charge Now":
                     self.activeAction = 1
                 elif policy == "Scheduled Charging":

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -755,18 +755,14 @@ def CreateHTTPHandlerClass(master):
                 ).car_api_available()
                 self.scheduledAmpsMax = master.getScheduledAmpsMax()
 
-                policy = str(master.getModuleByName("Policy").active_policy)
-                if policy == "Charge Now":
-                    self.activeAction = 1
-                elif policy == "Scheduled Charging":
-                    self.activeAction = 1
-                elif policy == "Track Green Energy":
+                if master.getModuleByName("Policy").policyIsGreen():
                     self.activeAction = 3
-                elif policy == "Non Scheduled Charging":
-                    self.activeAction = master.settings.get("nonScheduledAction", 1)
                 else:
-                    logger.error(f"non-standard policy {policy!r}, cannot display charge action in webinterface")
-
+                    policy = master.getModuleByName("Policy").getPolicyByName(str(master.getModuleByName("Policy").active_policy))
+                    if int(master.getModuleByName("Policy").policyValue(policy.get("charge_amps", 0))) > 0:
+                        self.activeAction = 1
+                    else:
+                        self.activeAction = 2
 
                 # Send the html message
                 page = self.template.render(vars(self))

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -84,7 +84,8 @@ def CreateHTTPHandlerClass(master):
             if not len(self.ampsList):
                 self.ampsList.append([0, "Disabled"])
                 for amp in range(
-                    5, (master.config["config"].get("wiringMaxAmpsPerTWC", 5)) + 1
+                    master.config["config"].get("minAmpsPerTWC", 5),
+                    (master.config["config"].get("wiringMaxAmpsPerTWC", master.config["config"].get("minAmpsPerTWC", 5))) + 1
                 ):
                     self.ampsList.append([amp, str(amp) + "A"])
 

--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -61,6 +61,64 @@
                             $("#cancel_chargenow").addClass("disabled");
                         }
                     }
+
+                    // change the state of the Charge Policy display buttons based on Charge Policy
+                    if (json["currentPolicy"] == "Track Green Energy" ||
+                        ( json["currentPolicy"] == "Non Scheduled Charging" &&
+                          $("#nonScheduledAction").val() == 3
+                       )) {
+                        $("#policy_solar").removeClass("btn-outline-primary");
+                        $("#policy_solar").addClass("btn-primary");
+                        $("#policy_fixed").removeClass("btn-primary");
+                        $("#policy_fixed").addClass("btn-outline-primary");
+                        $("#policy_dont").removeClass("btn-primary");
+                        $("#policy_dont").addClass("btn-outline-primary");
+                        $("#helpTextSolar").show();
+                        $("#helpTextFixed").hide();
+                        $("#helpTextDont").hide();
+                        $("#helpTextUnknown").hide();
+                    } else if (( json["currentPolicy"] == "Charge Now" ||
+                                 json["currentPolicy"] == "Scheduled Charging"
+                               ) || (
+                                 json["currentPolicy"] == "Non Scheduled Charging" &&
+                                 $("#nonScheduledAction").val() == 1
+                              )) {
+                        $("#policy_solar").removeClass("btn-primary");
+                        $("#policy_solar").addClass("btn-outline-primary");
+                        $("#policy_fixed").removeClass("btn-outline-primary");
+                        $("#policy_fixed").addClass("btn-primary");
+                        $("#policy_dont").removeClass("btn-primary");
+                        $("#policy_dont").addClass("btn-outline-primary");
+                        $("#helpTextSolar").hide();
+                        $("#helpTextFixed").show();
+                        $("#helpTextDont").hide();
+                        $("#helpTextUnknown").hide();
+                    } else if (json["currentPolicy"] == "Non Scheduled Charging" &&
+                               $("#nonScheduledAction").val() == 2
+                              ) {
+                        $("#policy_solar").removeClass("btn-primary");
+                        $("#policy_solar").addClass("btn-outline-primary");
+                        $("#policy_fixed").removeClass("btn-primary");
+                        $("#policy_fixed").addClass("btn-outline-primary");
+                        $("#policy_dont").removeClass("btn-outline-primary");
+                        $("#policy_dont").addClass("btn-primary");
+                        $("#helpTextSolar").hide();
+                        $("#helpTextFixed").hide();
+                        $("#helpTextDont").show();
+                        $("#helpTextUnknown").hide();
+                    } else {
+                        // unknown policy, remove highlights
+                        $("#policy_solar").removeClass("btn-primary");
+                        $("#policy_solar").addClass("btn-outline-primary");
+                        $("#policy_fixed").removeClass("btn-primary");
+                        $("#policy_fixed").addClass("btn-outline-primary");
+                        $("#policy_dont").removeClass("btn-primary");
+                        $("#policy_dont").addClass("btn-outline-primary");
+                        $("#helpTextSolar").hide();
+                        $("#helpTextFixed").hide();
+                        $("#helpTextDont").hide();
+                        $("#helpTextUnknown").show();
+                    }
                 }
             });
             setTimeout(requestStatus, 3000);

--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -63,10 +63,7 @@
                     }
 
                     // change the state of the Charge Policy display buttons based on Charge Policy
-                    if (json["currentPolicy"] == "Track Green Energy" ||
-                        ( json["currentPolicy"] == "Non Scheduled Charging" &&
-                          $("#nonScheduledAction").val() == 3
-                       )) {
+                    if (json["isGreenPolicy"] == "Yes") {
                         $("#policy_solar").removeClass("btn-outline-primary");
                         $("#policy_solar").addClass("btn-primary");
                         $("#policy_fixed").removeClass("btn-primary");
@@ -76,13 +73,9 @@
                         $("#helpTextSolar").show();
                         $("#helpTextFixed").hide();
                         $("#helpTextDont").hide();
-                        $("#helpTextUnknown").hide();
-                    } else if (( json["currentPolicy"] == "Charge Now" ||
-                                 json["currentPolicy"] == "Scheduled Charging"
-                               ) || (
-                                 json["currentPolicy"] == "Non Scheduled Charging" &&
-                                 $("#nonScheduledAction").val() == 1
-                              )) {
+                    } else if ($('#chargerAvailAmps').html() == "0") {
+                        // chargerAvailAmps not yet updated, do nothing
+                    } else if ($('#chargerAvailAmps').html() != "0.00") {
                         $("#policy_solar").removeClass("btn-primary");
                         $("#policy_solar").addClass("btn-outline-primary");
                         $("#policy_fixed").removeClass("btn-outline-primary");
@@ -92,10 +85,7 @@
                         $("#helpTextSolar").hide();
                         $("#helpTextFixed").show();
                         $("#helpTextDont").hide();
-                        $("#helpTextUnknown").hide();
-                    } else if (json["currentPolicy"] == "Non Scheduled Charging" &&
-                               $("#nonScheduledAction").val() == 2
-                              ) {
+                    } else {
                         $("#policy_solar").removeClass("btn-primary");
                         $("#policy_solar").addClass("btn-outline-primary");
                         $("#policy_fixed").removeClass("btn-primary");
@@ -105,19 +95,6 @@
                         $("#helpTextSolar").hide();
                         $("#helpTextFixed").hide();
                         $("#helpTextDont").show();
-                        $("#helpTextUnknown").hide();
-                    } else {
-                        // unknown policy, remove highlights
-                        $("#policy_solar").removeClass("btn-primary");
-                        $("#policy_solar").addClass("btn-outline-primary");
-                        $("#policy_fixed").removeClass("btn-primary");
-                        $("#policy_fixed").addClass("btn-outline-primary");
-                        $("#policy_dont").removeClass("btn-primary");
-                        $("#policy_dont").addClass("btn-outline-primary");
-                        $("#helpTextSolar").hide();
-                        $("#helpTextFixed").hide();
-                        $("#helpTextDont").hide();
-                        $("#helpTextUnknown").show();
                     }
                 }
             });

--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -61,9 +61,24 @@
                             $("#cancel_chargenow").addClass("disabled");
                         }
                     }
+                }
+            });
+            setTimeout(requestStatus, 3000);
+        }
+        requestStatus();
+    });
 
-                    // change the state of the Charge Policy display buttons based on Charge Policy
-                    if (json["isGreenPolicy"] == "Yes") {
+    // AJAX refresh to retrieve active policy action and update UI
+    $(document).ready(function() {
+        function updateAction() {
+            $.ajax({
+                url: "/api/getActivePolicyAction",
+                dataType: "text",
+                cache: false,
+                success: function(data) {
+                    var json = $.parseJSON(data);
+                    // change the state of the Charge Policy display buttons based on Charge Policy Action
+                    if (json == 3) {
                         $("#policy_solar").removeClass("btn-outline-primary");
                         $("#policy_solar").addClass("btn-primary");
                         $("#policy_fixed").removeClass("btn-primary");
@@ -73,9 +88,7 @@
                         $("#helpTextSolar").show();
                         $("#helpTextFixed").hide();
                         $("#helpTextDont").hide();
-                    } else if ($('#chargerAvailAmps').html() == "0") {
-                        // chargerAvailAmps not yet updated, do nothing
-                    } else if ($('#chargerAvailAmps').html() != "0.00") {
+                    } else if (json == 1) {
                         $("#policy_solar").removeClass("btn-primary");
                         $("#policy_solar").addClass("btn-outline-primary");
                         $("#policy_fixed").removeClass("btn-outline-primary");
@@ -85,7 +98,7 @@
                         $("#helpTextSolar").hide();
                         $("#helpTextFixed").show();
                         $("#helpTextDont").hide();
-                    } else {
+                    } else if (json == 2) {
                         $("#policy_solar").removeClass("btn-primary");
                         $("#policy_solar").addClass("btn-outline-primary");
                         $("#policy_fixed").removeClass("btn-primary");
@@ -95,12 +108,15 @@
                         $("#helpTextSolar").hide();
                         $("#helpTextFixed").hide();
                         $("#helpTextDont").show();
+                    } else {
+                        // TWCmanager (re)started and policy not yet initialized?
+                        console.log('unknown policy action "' + json + '"');
                     }
                 }
             });
-            setTimeout(requestStatus, 3000);
+            setTimeout(updateAction, 3000);
         }
-        requestStatus();
+        updateAction();
     });
 
     // AJAJ refresh for getSlaveTWCs API call

--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -137,8 +137,6 @@ wcmanager/settings.json and try saving your settings again.</b>
             <div class="col-sm-11 col-md-10 col-lg-8">
                 <div class="jumbotron px-5 py-4 rounded-xl" style="background-color: #f0f0f0; pointer-events:none;">
                     <div class="form-group row" style="margin-bottom: -1em!important;">
-                        <!-- note down non scheduled charging action setting for AJAX refresh -->
-                        <input id="nonScheduledAction" type="range" min="1" max="3" step="1" value="{{ master.settings.get("nonScheduledAction", 1) }}" style="display: none;" />
                         <label for="colBtns" class="col-lg-2 col-sm-12 col-form-label display-6">Charge Policy</label>
                         <div class="col-lg-10 col-sm-12 btn-group" id="colBtns" role="group" style="flex-wrap: wrap;">
                             <button id="policy_solar" type="button" class="btn btn-{% if activeAction != 3 %}outline-{% endif %}primary" role="button" aria-describedby="helpTextSolar">Solar Surplus</button>
@@ -154,9 +152,6 @@ wcmanager/settings.json and try saving your settings again.</b>
                             </small>
                             <small id="helpTextSolar" class="form-text text-muted" {% if activeAction != 3 %}style="display: none;"{% endif %}>
                                 Charges a vehicle if Solar production is at least {{ master.config["config"].get("minAmpsPerTWC", 5) }} Amps higher than the current consumption
-                            </small>
-                            <small id="helpTextUnknown" class="form-text text-muted" {% if activeAction %}style="display: none;"{% endif %}>
-                                Currently active policy is unknown, so I can't tell you what it does
                             </small>
                         </div>
                     </div>

--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -153,7 +153,7 @@ wcmanager/settings.json and try saving your settings again.</b>
                                 Doesn't charge a vehicle when plugged in unless manually started (e.g. in the Tesla App)
                             </small>
                             <small id="helpTextSolar" class="form-text text-muted" {% if activeAction != 3 %}style="display: none;"{% endif %}>
-                                Charges a vehicle if Solar production is {{ master.settings.get("minAmpsPerTWC", 5) }} Amps or more than the current consumption
+                                Charges a vehicle if Solar production is at least {{ master.config["config"].get("minAmpsPerTWC", 5) }} Amps higher than the current consumption
                             </small>
                             <small id="helpTextUnknown" class="form-text text-muted" {% if activeAction %}style="display: none;"{% endif %}>
                                 Currently active policy is unknown, so I can't tell you what it does

--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -137,22 +137,26 @@ wcmanager/settings.json and try saving your settings again.</b>
             <div class="col-sm-11 col-md-10 col-lg-8">
                 <div class="jumbotron px-5 py-4 rounded-xl" style="background-color: #f0f0f0; pointer-events:none;">
                     <div class="form-group row" style="margin-bottom: -1em!important;">
-                        {% set active = master.settings.get("nonScheduledAction", 1) %}
+                        <!-- note down non scheduled charging action setting for AJAX refresh -->
+                        <input id="nonScheduledAction" type="range" min="1" max="3" step="1" value="{{ master.settings.get("nonScheduledAction", 1) }}" style="display: none;" />
                         <label for="colBtns" class="col-lg-2 col-sm-12 col-form-label display-6">Charge Policy</label>
                         <div class="col-lg-10 col-sm-12 btn-group" id="colBtns" role="group" style="flex-wrap: wrap;">
-                            <button type="button" class="btn btn-{% if active != 3 %}outline-{% endif %}primary" role="button" aria-describedby="helpText">Solar Surplus</button>
-                            <button type="button" class="btn btn-{% if active != 1 %}outline-{% endif %}primary" role="button" aria-describedby="helpText">Fixed Rate/Amps</button>
-                            <button type="button" class="btn btn-{% if active != 2 %}outline-{% endif %}primary" role="button" aria-describedby="helpText">Don't charge</button>
+                            <button id="policy_solar" type="button" class="btn btn-{% if activeAction != 3 %}outline-{% endif %}primary" role="button" aria-describedby="helpTextSolar">Solar Surplus</button>
+                            <button id="policy_fixed" type="button" class="btn btn-{% if activeAction != 1 %}outline-{% endif %}primary" role="button" aria-describedby="helpTextFixed">Fixed Rate/Amps</button>
+                            <button id="policy_dont" type="button" class="btn btn-{% if activeAction != 2 %}outline-{% endif %}primary" role="button" aria-describedby="helpTextDont">Don't charge</button>
                         </div>
                         <div class="col-lg-10 col-sm-12 offset-lg-2 offset-sm-0">
-                            <small id="helpText" class="form-text text-muted">
-                                {% if active == 1 %}
-                                    Charges a vehicle at a fixed rate of x Amps whenever it is plugged in
-                                {% elif active == 2 %}
-                                    Doesn't charge a vehicle when plugged in unless manually started (e.g. in the Tesla App)
-                                {% elif active == 3 %}
-                                    Charges a vehicle if Solar production is {{ master.settings.get("minAmpsPerTWC", 5) }} Amps or more than the current consumption
-                                {% endif %}
+                            <small id="helpTextFixed" class="form-text text-muted" {% if activeAction != 1 %}style="display: none;"{% endif %}>
+                                Charges a vehicle at a fixed rate of x Amps whenever it is plugged in
+                            </small>
+                            <small id="helpTextDont" class="form-text text-muted" {% if activeAction != 2 %}style="display: none;"{% endif %}>
+                                Doesn't charge a vehicle when plugged in unless manually started (e.g. in the Tesla App)
+                            </small>
+                            <small id="helpTextSolar" class="form-text text-muted" {% if activeAction != 3 %}style="display: none;"{% endif %}>
+                                Charges a vehicle if Solar production is {{ master.settings.get("minAmpsPerTWC", 5) }} Amps or more than the current consumption
+                            </small>
+                            <small id="helpTextUnknown" class="form-text text-muted" {% if activeAction %}style="display: none;"{% endif %}>
+                                Currently active policy is unknown, so I can't tell you what it does
                             </small>
                         </div>
                     </div>

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -246,6 +246,25 @@ class Policy:
                 return policy
         return None
 
+    def getActivePolicyAction(self):
+        # getActivePolicyAction returns an integer value depending on what 
+        # charging action the currently active policy is following. Values
+        # correspond to nonScheduledAction values in settings.json:
+        # 1 ... fixed rate charging
+        # 2 ... do not charge
+        # 3 ... track green energy charging
+        # <None> will be returned if self.active_policy is not (yet) set
+        if self.active_policy == None:
+            return None
+        if self.policyIsGreen():
+            return 3
+        else:
+            policy = self.getPolicyByName(self.active_policy)
+            if int(self.policyValue(policy.get("charge_amps", 0))) > 0:
+                return 1
+            else:
+                return 2
+
     def policyValue(self, value):
         # policyValue is a macro to allow charging policy to refer to things
         # such as EMS module values or settings. This allows us to control

--- a/tests/API/test_getActivePolicyAction.py
+++ b/tests/API/test_getActivePolicyAction.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import json
+import requests
+
+# Configuration
+skipFailure = 1
+
+# Disable environment import to avoid proxying requests
+session = requests.Session()
+session.trust_env = False
+
+getAttempts = 0
+response = None
+
+try:
+    response = session.get("http://127.0.0.1:8088/api/getActivePolicyAction", timeout=30)
+except requests.Timeout:
+    print("Error: Connection Timed Out")
+    exit(255)
+except requests.ConnectionError:
+    print("Error: Connection Error")
+    exit(255)
+
+jsonResp = None
+
+if response.status_code == 200:
+    while (not jsonResp and getAttempts < 3):
+        getAttempts += 1
+        try:
+            jsonResp = response.json()
+        except json.decoder.JSONDecodeError as e:
+            print("Error: Unable to parse JSON output from getActivePolicyAction()")
+
+            # Log the incomplete JSON that we did get - I would like to know
+            # why this would happen
+            f = open("/tmp/twcmanager-tests/getActivePolicyAction-json-"+str(getAttempts)+".txt", "w")
+            f.write("Exception: " + str(e))
+            f.write("API Response: " + str(response.text))
+
+        if (getAttempts == 2):
+            # Too many failures
+            # Fail tests
+            exit(255)
+else:
+    print("Error: Response code " + str(response.status_code))
+    exit(255)
+
+success = 1
+if jsonResp:
+    # Content tests go here
+    if jsonResp == 1 or jsonResp == 2 or jsonResp == 3:
+        success = 1
+    else:
+        print(f"got unknown policy action: {jsonResp!r}")
+else:
+    print("No JSON response from API for getActivePolicyAction()")
+    exit(255)
+
+if success:
+    print("All tests successful")
+    exit(0)
+else:
+    print("At least one test failed. Please review logs")
+    if skipFailure:
+        print("Due to skipFailure being set, we will not fail the test suite pipeline on this test.")
+        exit(0)
+    else:
+        exit(255)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -79,6 +79,8 @@ api:
 	@cd API && ./test_sendStopCommand.py
 	@echo "${bold}${red}(A10/${api})${reset} ${yellow}Test API consumption offsets"
 	@cd API && ./test_consumptionOffsets.py
+	@echo "${bold}${red}(A11/${api})${reset} ${yellow}Test API getActivePolicyAction"
+	@cd API && ./test_getActivePolicyAction.py
 
 ems:
 	@echo "${bold}${red}(E1/${ems})${reset} ${yellow}Starting EMS Test Web Server"


### PR DESCRIPTION
Fixes #385

I'm passing a numeric charging action (consistent with the `nonScheduledAction` setting) based on our currently active charging policy to the template `Modern/main.html.j2`, which is then highlighting the corresponding action. Highlights are updated via `jsrefresh.html.j2` as it may change when user starts `Charge Now`, or when a policy change is initiated by one of its criteria (e.g. time based).

As far as I can see, a similar change is **not** required for the default theme, as the logic is different there.

Please note this includes a commit [baeed42](https://github.com/ngardiner/TWCManager/commit/baeed42f7a96bc308cf1c2e95382d89a55a5fb53) which fixes a bug in the minimum amps display for Solar charging. The template was trying to use a configuration setting in `settings.json`, which actually resides in `config.json`. You may want to cherry pick this, if you don't want to merge the whole branch.
