### PR TITLE
Catch/prevent null values in chargeLimits

### DIFF
--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -654,6 +654,10 @@ class TWCMaster:
             result = self.settings["chargeLimits"][str(ID)]
             if type(result) is int:
                 result = (result, 0)
+            if result[0] is None:
+                result[0] = 0
+            if result[1] is None:
+                result[1] = 0
             return (True, result[0], result[1])
         return (False, None, None)
 

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -875,6 +875,10 @@ class TeslaAPI:
                 # risk changing the charge limit yet.
                 continue
 
+            if not wasAtHome and not vehicle.atHome:
+                # If the vehicle was away and is still away, nothing to do.
+                continue
+
             if not wasAtHome and vehicle.atHome:
                 logger.log(logging.INFO2, vehicle.name + " has arrived")
                 outside = vehicle.chargeLimit

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -866,23 +866,23 @@ class TeslaAPI:
             if vehicle.stopTryingToApplyLimit or not vehicle.ready():
                 continue
 
-            located = vehicle.update_location()
             (wasAtHome, outside, lastApplied) = self.master.getNormalChargeLimit(
                 vehicle.ID
             )
             forgetVehicle = False
-            if not vehicle.update_charge():
-                # We failed to read the "normal" limit; don't risk changing it.
+            if not vehicle.update_charge() or not vehicle.update_location():
+                # We failed to read the "normal" limit or locate the car; don't
+                # risk changing the charge limit yet.
                 continue
 
-            if not wasAtHome and located and vehicle.atHome:
+            if not wasAtHome and vehicle.atHome:
                 logger.log(logging.INFO2, vehicle.name + " has arrived")
                 outside = vehicle.chargeLimit
-            elif wasAtHome and located and not vehicle.atHome:
+            elif wasAtHome and not vehicle.atHome:
                 logger.log(logging.INFO2, vehicle.name + " has departed")
                 forgetVehicle = True
 
-            if limit == -1 or (located and not vehicle.atHome):
+            if limit == -1 or not vehicle.atHome:
                 # We're removing any applied limit, provided it hasn't been manually changed
                 #
                 # If lastApplied == -1, the manual-change path is always selected.


### PR DESCRIPTION
In debugging #451, it appears there's a way for the outside limit to be saved as `null`.  The first commit should prevent any exceptions being thrown when that process encounters one that's already stored.

The second heads off the path that looks like it could store a `null`/`None` in a particular corner case:  Vehicle reports ready, but updating location fails.  Rather than storing the result and checking whether location was successful at multiple places, it just bails if the location couldn't be updated.  It will run again shortly anyway.

There's also a surprisingly long path through the logic for a car that was and remains absent, and I'm not sure it doesn't update the data stored in settings.  I added a short-circuit for that case, just to be safe.