### PR TITLE
Change GH Actions to current versions of checkout and setup_python

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -22,12 +22,12 @@ jobs:
 #    runs-on: [ "self-hosted", "build_host" ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: ./black
           ref: ${{ github.event.push.head.sha }}
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Install Black

--- a/.github/workflows/docker+pypi.yml
+++ b/.github/workflows/docker+pypi.yml
@@ -51,12 +51,12 @@ jobs:
 
     steps:
     - name: Check out Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ./pypi-dev
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
 
@@ -105,12 +105,12 @@ jobs:
 
     steps:
     - name: Check out Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ./pypi
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
 
@@ -152,7 +152,7 @@ jobs:
 
     steps:
     - name: Check out Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ./docker-latest
 
@@ -193,7 +193,7 @@ jobs:
 
     steps:
     - name: Check out Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -226,7 +226,7 @@ jobs:
     steps:
 
     - name: Check out Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -260,7 +260,7 @@ jobs:
     steps:
 
     - name: Check out Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ./docker-release
 
@@ -310,7 +310,7 @@ jobs:
     steps:
 
     - name: Check out Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -11,7 +11,7 @@ jobs:
       options: --user root
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Upgrade setuptools"
         run: pip3 install --upgrade setuptools
@@ -40,7 +40,7 @@ jobs:
       options: --user root
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Upgrade setuptools"
         run: pip3 install --upgrade setuptools
@@ -69,7 +69,7 @@ jobs:
       options: --user root
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Build Project"
         run: CI=1 make webbuild
@@ -95,7 +95,7 @@ jobs:
       options: --user root
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Build Project"
         run: CI=1 make webbuild
@@ -121,7 +121,7 @@ jobs:
       options: --user root
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Upgrade setuptools"
         run: pip3 install --upgrade setuptools
@@ -150,7 +150,7 @@ jobs:
       options: --user root
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Upgrade setuptools"
         run: pip3 install --upgrade setuptools


### PR DESCRIPTION
It would appear that the deprecation of Node 12 has broken many of the GitHub Actions that were running automatically in this repo.  This change points to current versions, which should hopefully restart the code formatting, Docker creation, etc.