### PR TITLE
Add DSMRreader EMS module

### DIFF
--- a/docs/modules/EMS_DSMRreader.md
+++ b/docs/modules/EMS_DSMRreader.md
@@ -1,0 +1,66 @@
+# DSMR-reader EMS Module
+
+## Introduction
+
+The [DSMR-reader](https://github.com/dsmrreader/dsmr-reader) EMS module allows fetching of Consumption and Production values from the DSMR-reader JSON MQTT messages.
+
+## How it works
+
+TWCManager will subscribe to the JSON Telegram MQTT topic of DSMR-reader (`dsmr/json` by default, configure this at `/admin/dsmr_mqtt/jsontelegrammqttsettings/` of your DSMR-reader).
+
+Comsumption is taken from the `electricity_currently_delivered` DSMR-reader value.
+
+Production is taken from the `electricity_currently_returned` DSMR-reader value.
+
+### Dependencies
+
+DSMR-reader needs to publish the JSON Telegram messages to an MQTT broker.
+
+### Note
+
+Given that DSMR-reader measures the total household consumption, this includes the TWC. As a result, the TWC's load will be included in the  Consumption via the P1 output of the smart power meter. Please ensure the following configuration setting is enabled in your `config.json` file:
+
+```
+{
+    "config": {
+        "subtractChargerLoad": true
+    }
+}
+```
+
+### Status
+
+| Detail          | Value                          |
+| --------------- | ------------------------------ |
+| **Module Name** | DSMRreader                     |
+| **Module Type** | Energy Management System (EMS) |
+| **Features**    | Consumption, Production        |
+| **Status**      | In Development                 |
+
+## Configuration
+
+The following table shows the available configuration parameters for the P1 Monitor EMS module.
+
+| Parameter   | Value         |
+| ----------- | ------------- |
+| brokerIP    | *required* The IP address of the MQTT broker. |
+| brokerPort  | *optional* The port of the MQTT broker. |
+| username    | *optional* The username for the MQTT broker. |
+| password    | *optional* The password for the MQTT broker. |
+| topic       | *optional* The MQTT topic where the JSON messages will be published. |
+
+### JSON Configuration Example
+
+```
+{
+    "sources":{
+        "DSMRreader": {
+            "brokerIP": "192.168.1.2",
+            "brokerPort": 1883,
+            "username": "mqttuser",
+            "password": "mqttpass",
+            "topic": "dsmr/json",
+        }
+    }
+}
+```

--- a/docs/modules/EMS_DSMRreader.md
+++ b/docs/modules/EMS_DSMRreader.md
@@ -18,12 +18,13 @@ DSMR-reader needs to publish the JSON Telegram messages to an MQTT broker.
 
 ### Note
 
-Given that DSMR-reader measures the total household consumption, this includes the TWC. As a result, the TWC's load will be included in the  Consumption via the P1 output of the smart power meter. Please ensure the following configuration setting is enabled in your `config.json` file:
+Given that DSMR-reader measures the total household consumption, this includes the TWC. As a result, the TWC's load will be included in the  Consumption via the P1 output of the smart power meter. The smart meter does not know the total PV power delivery, just how much power is being delivered back to the grid. Please ensure the following configuration settings are enabled in your `config.json` file:
 
 ```
 {
     "config": {
-        "subtractChargerLoad": true
+        "subtractChargerLoad": true,
+        "treatGenerationAsGridDelivery": true,
     }
 }
 ```

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -118,6 +118,11 @@
         # time interval, due to the available amps being set below minimum charge.
         "subtractChargerLoad": false,
 
+        # If your EMS does not return total PV generation but only the power
+        # delivered back to the grid, set treatGenerationAsGridDelivery to
+        # true.
+        "treatGenerationAsGridDelivery": false,
+
         # The minChargeLevel parameter determines the minimum acceptable SOC
         # state for any monitored vehicle. If the SOC is below this value,
         # the car will not be stopped from charging (even if we are not

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -459,6 +459,14 @@
         # configured simultaneously, currently we will only add together the values recieved from each. This might be
         # useful if you have one interface that provides generation detail and another that provides consumption
         # detail, but if both systems provided both values, it would be duplicated.
+      # The DSMRreader EMS module subscribes to the below MQTT topic to read Consumption/Generation values
+        "DSMRreader": {
+          "enabled": false,
+          "brokerIP": "192.168.1.2",
+          "username": "mqttuser",
+          "password": "mqttpass",
+          "topic": "dsmr/json",
+        },
       # The Efergy server allows fetching of consumption from https://engage.efergy.com/ token is needed
         "Efergy": {
             "enabled": false,

--- a/lib/TWCManager/EMS/DSMRreader.py
+++ b/lib/TWCManager/EMS/DSMRreader.py
@@ -16,6 +16,7 @@ class DSMRreader:
     __configDSMRreader = None
     __connectionState = 0
     consumedW = 0
+    consumedA = 0
     generatedW = 0
     master = None
     status = False
@@ -117,6 +118,14 @@ class DSMRreader:
 
         # Return consumption value
         return self.consumedW
+
+    def getConsumptionAmps(self):
+        if not self.status:
+            logger.debug("Module Disabled. Skipping getConsumptionAmps")
+            return 0
+
+        # Return consumption value
+        return self.consumedA
 
     def getGeneration(self):
         if not self.status:

--- a/lib/TWCManager/EMS/DSMRreader.py
+++ b/lib/TWCManager/EMS/DSMRreader.py
@@ -1,0 +1,127 @@
+import logging
+import json
+
+logger = logging.getLogger(__name__.rsplit(".")[-1])
+
+
+class DSMRreader:
+    # DSMR-reader MQTT EMS Module
+    # Subscribes to Consumption and Generation details from DSMR-reader MQTT Publisher
+
+    import paho.mqtt.client as mqtt
+    import time
+
+    __config = None
+    __configConfig = None
+    __configDSMRreader = None
+    __connectionState = 0
+    consumedW = 0
+    generatedW = 0
+    master = None
+    status = False
+
+    def __init__(self, master):
+        self.master = master
+        self.__config = master.config
+        try:
+            self.__configConfig = master.config["config"]
+        except KeyError:
+            self.__configConfig = {}
+        try:
+            self.__configDSMRreader = master.config["sources"]["DSMRreader"]
+        except KeyError:
+            self.__configDSMRreader = {}
+
+        self.status = self.__configDSMRreader.get("enabled", False)
+        self.brokerIP = self.__configDSMRreader.get("brokerIP", None)
+        self.brokerPort = self.__configDSMRreader.get("brokerPort", 1883)
+        self.username = self.__configDSMRreader.get("username", None)
+        self.password = self.__configDSMRreader.get("password", None)
+
+        # Unload if this module is disabled or misconfigured
+        if (not self.status) or (not self.brokerIP):
+            self.master.releaseModule("lib.TWCManager.EMS", "MQTT")
+            return None
+
+        self.__topic = self.__configDSMRreader.get("topic", "dsmr/json")
+
+        logger.debug("Attempting to Connect to DSMR-reader MQTT Broker")
+        if self.brokerIP:
+            self.__client = self.mqtt.Client("DSMRreader.EMS")
+            if self.username and self.password:
+                self.__client.username_pw_set(self.username, self.password)
+            self.__client.on_connect = self.mqttConnect
+            self.__client.on_message = self.mqttMessage
+            self.__client.on_subscribe = self.mqttSubscribe
+            try:
+                self.__client.connect_async(
+                    self.brokerIP, port=self.brokerPort, keepalive=30
+                )
+            except ConnectionRefusedError as e:
+                logger.error("Error connecting to DSMR-reader MQTT Broker")
+                logger.debug(str(e))
+                return False
+            except OSError as e:
+                logger.error("Error connecting to DSMR-reader MQTT Broker")
+                logger.debug(str(e))
+                return False
+
+            self.__connectionState = 1
+            self.__client.loop_start()
+
+        else:
+            logger.log(logging.INFO4, "Module enabled but no brokerIP specified.")
+
+    def mqttConnect(self, client, userdata, flags, rc):
+        logger.log(logging.INFO5, "DSMRreader MQTT Connected.")
+
+        if self.__topic:
+            logger.log(logging.INFO5, "Subscribe to " + self.__topic)
+            res = self.__client.subscribe(self.__topic, qos=0)
+            logger.log(logging.INFO5, "Res: " + str(res))
+
+    def mqttMessage(self, client, userdata, message):
+        # Takes an DSMR-reader JSON MQTT message, and update the associated Generation/Consumption value
+        decoded_message = str(message.payload.decode("utf-8","ignore"))
+        logger.debug(f"Decoded message {decoded_message}")
+        try:
+            payload = json.loads(decoded_message)
+            logger.log(logging.INFO5, "Loaded JSON from message")
+        except Exception as e:
+            payload = {}
+            logger.warning(f"Loading JSON from message failed: {str(e)}")
+
+        if message.topic == self.__topic:
+            self.consumedW = float(payload.get("electricity_currently_delivered", 0)) * 1000.0
+            logger.log(logging.INFO3, f"Consumption Value updated to {round(self.consumedW)}W")
+
+            self.generatedW = float(payload.get("electricity_currently_returned", 0)) * 1000.0
+            logger.log(logging.INFO3, f"Generation Value updated to {round(self.generatedW)}W")
+
+            ampsL1 = payload.get("phase_power_current_l1", 0)
+            ampsL2 = payload.get("phase_power_current_l2", 0)
+            ampsL3 = payload.get("phase_power_current_l3", 0)
+            if self.consumedW > self.generatedW:
+                self.consumedA = max(ampsL1, ampsL2, ampsL3)
+            else:
+                self.consumedA = 0
+            logger.log(logging.INFO3, f"Consumption Amps Value updated to {self.consumedA}A")
+
+    def mqttSubscribe(self, client, userdata, mid, granted_qos):
+        logger.info("Subscribe operation completed with mid " + str(mid))
+
+    def getConsumption(self):
+        if not self.status:
+            logger.debug("Module Disabled. Skipping getConsumption")
+            return 0
+
+        # Return consumption value
+        return self.consumedW
+
+    def getGeneration(self):
+        if not self.status:
+            logger.debug("Module Disabled. Skipping getGeneration")
+            return 0
+
+        # Return generation value
+        return self.generatedW

--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -365,6 +365,8 @@ def update_statuses():
     # generation and consumption figures
     maxamps = master.getMaxAmpsToDivideAmongSlaves()
     maxampsDisplay = f"{maxamps:.2f}A"
+    subtractChargerLoad = config["config"].get("subtractChargerLoad", False)
+    treatGenerationAsGridDelivery = config["config"].get("treatGenerationAsGridDelivery", False)
     if master.getModuleByName("Policy").policyIsGreen():
         genwatts = master.getGeneration()
         conwatts = master.getConsumption()
@@ -372,12 +374,16 @@ def update_statuses():
         chgwatts = master.getChargerLoad()
         othwatts = 0
 
-        if config["config"]["subtractChargerLoad"]:
+        if subtractChargerLoad:
             if conwatts > 0:
                 othwatts = conwatts - chgwatts
 
             if conoffset > 0:
                 othwatts -= conoffset
+
+        if treatGenerationAsGridDelivery:
+            # Calculate total generation when it is already consumed by TWC
+            genwatts = max(0, genwatts + chgwatts - conwatts)
 
         # Extra parameters to send with logs
         logExtra = {
@@ -433,14 +439,14 @@ def update_statuses():
             genwatts
             + (
                 chgwatts
-                if (config["config"]["subtractChargerLoad"] and conwatts == 0)
+                if (subtractChargerLoad and conwatts == 0)
                 else 0
             )
             - (
                 conwatts
                 - (
                     chgwatts
-                    if (config["config"]["subtractChargerLoad"] and conwatts > 0)
+                    if (subtractChargerLoad and conwatts > 0)
                     else 0
                 )
             )

--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -86,6 +86,7 @@ modules_available = [
     "Control.HTTPControl",
     "Control.MQTTControl",
     #    "Control.OCPPControl",
+    "EMS.DSMRreader",
     "EMS.Efergy",
     "EMS.EmonCMS",
     "EMS.Enphase",


### PR DESCRIPTION
TWCManager already supports the DSMR P1 port protocol but this means the P1 port needs to be free. When the port is already used by the [DSMR-reader](https://github.com/dsmrreader/dsmr-reader) TWCManager can still use the data by subscribing to the MQTT messages that DSMR-reader produces.