### PR TITLE
Move all runners to ubuntu-latest

### DIFF
--- a/.github/workflows/docker+pypi.yml
+++ b/.github/workflows/docker+pypi.yml
@@ -43,7 +43,8 @@ on:
 jobs:
   pypi-dev:
     name: Build a PyPi Package if this is a commit to the ci_dev branch
-    runs-on: [ "self-hosted", "build_host" ]
+    # runs-on: [ "self-hosted", "build_host" ]
+    runs-on: ubuntu-latest
 
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/ci_dev')) ||
@@ -97,7 +98,8 @@ jobs:
 
   pypi:
     name: Build a PyPi Package if this is a tagged release commit
-    runs-on: [ "self-hosted", "build_host" ]
+    # runs-on: [ "self-hosted", "build_host" ]
+    runs-on: ubuntu-latest
 
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) ||
@@ -144,7 +146,8 @@ jobs:
 
   docker-latest:
     name: Create docker-latest Docker Image from current head
-    runs-on: [ "self-hosted", "build_host" ]
+    # runs-on: [ "self-hosted", "build_host" ]
+    runs-on: ubuntu-latest
 
     if: |
       github.event_name == 'push' ||
@@ -251,7 +254,8 @@ jobs:
 
   docker-release:
     name: Create docker-release Docker Image for release version
-    runs-on: [ "self-hosted", "build_host" ]
+    # runs-on: [ "self-hosted", "build_host" ]
+    runs-on: ubuntu-latest
 
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) ||

--- a/.github/workflows/docker+pypi.yml
+++ b/.github/workflows/docker+pypi.yml
@@ -165,10 +165,10 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
       id: buildx
-      with:
-        driver-opts: |
-          env.http_proxy=http://192.0.2.1:3128
-          env.https_proxy=http://192.0.2.1:3128
+      # with:
+      #   driver-opts: |
+      #     env.http_proxy=http://192.0.2.1:3128
+      #     env.https_proxy=http://192.0.2.1:3128
 
     - name: Login to DockerHub
       uses: docker/login-action@v1
@@ -183,9 +183,9 @@ jobs:
         platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
         push: true
         tags: twcmanager/twcmanager:latest
-        build-args: |
-          http_proxy=http://192.0.2.1:3128
-          https_proxy=http://192.0.2.1:3128
+        # build-args: |
+        #   http_proxy=http://192.0.2.1:3128
+        #   https_proxy=http://192.0.2.1:3128
 
   docker-latest-cloud:
     name: Create docker-latest Docker Image from current head (Cloud)
@@ -282,10 +282,10 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
       id: buildx
-      with:
-        driver-opts: |
-          env.http_proxy=http://192.0.2.1:3128
-          env.https_proxy=http://192.0.2.1:3128
+      # with:
+      #   driver-opts: |
+      #     env.http_proxy=http://192.0.2.1:3128
+      #     env.https_proxy=http://192.0.2.1:3128
 
     - name: Login to DockerHub
       uses: docker/login-action@v1
@@ -300,9 +300,9 @@ jobs:
         platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
         push: true
         tags: twcmanager/twcmanager:${{ steps.branch_name.outputs.SOURCE_TAG }}
-        build-args: |
-          http_proxy=http://192.0.2.1:3128
-          https_proxy=http://192.0.2.1:3128
+        # build-args: |
+        #   http_proxy=http://192.0.2.1:3128
+        #   https_proxy=http://192.0.2.1:3128
 
   docker-testing-cloud:
     name: Create docker-testing Docker Image (Cloud)

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -5,7 +5,9 @@ on:
 jobs:
   twcmanager-python3_6_direct:
     name: Python 3.6 - Run Direct
-    runs-on: [ "self-hosted", "build_host" ]
+    # runs-on: [ "self-hosted", "build_host" ]
+    runs-on: ubuntu-latest
+
     container:
       image: twcmanager/twcmanager-testsuite:py3.6.13
       options: --user root
@@ -34,7 +36,9 @@ jobs:
 
   twcmanager-python3_6_service:
     name: Python 3.6 - Run as a Service
-    runs-on: [ "self-hosted", "build_host" ]
+    # runs-on: [ "self-hosted", "build_host" ]
+    runs-on: ubuntu-latest
+
     container:
       image: twcmanager/twcmanager-testsuite:py3.6.13
       options: --user root
@@ -63,7 +67,8 @@ jobs:
 
   twcmanager-python3_7_direct:
     name: Python 3.7 - Run Direct
-    runs-on: [ "self-hosted", "build_host" ]
+    # runs-on: [ "self-hosted", "build_host" ]
+    runs-on: ubuntu-latest
     container:
       image: twcmanager/twcmanager-testsuite:py3.7.10
       options: --user root
@@ -89,7 +94,8 @@ jobs:
 
   twcmanager-python3_7_service:
     name: Python 3.7 - Run as a Service
-    runs-on: [ "self-hosted", "build_host" ]
+    # runs-on: [ "self-hosted", "build_host" ]
+    runs-on: ubuntu-latest
     container:
       image: twcmanager/twcmanager-testsuite:py3.7.10
       options: --user root
@@ -115,7 +121,8 @@ jobs:
 
   twcmanager-python3_8_direct:
     name: Python 3.8 - Run Direct
-    runs-on: [ "self-hosted", "build_host" ]
+    # runs-on: [ "self-hosted", "build_host" ]
+    runs-on: ubuntu-latest
     container:
       image: twcmanager/twcmanager-testsuite:py3.8.12
       options: --user root
@@ -144,7 +151,8 @@ jobs:
 
   twcmanager-python3_9_direct:
     name: Python 3.9 - Run Direct
-    runs-on: [ "self-hosted", "build_host" ]
+    # runs-on: [ "self-hosted", "build_host" ]
+    runs-on: ubuntu-latest
     container:
       image: twcmanager/twcmanager-testsuite:py3.9.10
       options: --user root


### PR DESCRIPTION
The self-hosted runner infrastructure appears not to be working, so let's not rely on it for the moment.  This will hopefully unblock Docker images.