### PR TITLE
Set chargeNowDuration step to 1, fixes #503

### DIFF
--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -297,7 +297,7 @@ wcmanager/settings.json and try saving your settings again.</b>
     <div class="row">
         <div class="col-12 col-md-6 col-lg-4">
             <label for="chargeNowDuration" class="form-label text-muted">Charge duration <span class="text-dark font-weight-bold" id="{{ twcid }}_durationVal">1</span> hour</label>
-            <input type="range" class="form-range" id="chargeNowDuration" name="chargeNowDuration" min="1" max="24" step="5" value="1" onInput="$('#{{ twcid }}_durationVal').html($(this).val())">
+            <input type="range" class="form-range" id="chargeNowDuration" name="chargeNowDuration" min="1" max="24" step="1" value="1" onInput="$('#{{ twcid }}_durationVal').html($(this).val())">
         </div>
         <hr class="d-block d-md-none my-md-0 my-4">
         <div class="col-12 col-md-6 col-lg-4">


### PR DESCRIPTION
chargeNowDuration has a step 5 so it can only be set to 1,6,11,16, etc using the UI which is pretty weird.

Fixes #503 