### PR TITLE
Remove config.json from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 __pycache__
 build/
-config.json
 .vscode/
 dist/
 TWCManager.egg-info/


### PR DESCRIPTION
This patch remove contains `etc/twcmanager/config.json` which is installed as the default config. So `config.json` should not be in `.gitignore`. 

This prevents (ripgrep)[https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md] from searching this file, for example.