### PR TITLE
Allow charging with < 6A for 3 phase TWC

### DIFF
--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -56,7 +56,8 @@
         # 6A * 230V * 3 = 4140W for three-phase power. Consult an electrician if this
         # doesn't make sense.
         #
-        # https://forums.tesla.com/forum/forums/charging-lowest-amperage-purposely
+        # https://web.archive.org/web/20180807013639/https://forums.tesla.com/forum/forums/charging-lowest-amperage-purposely
+        # and https://teslamotorsclub.com/tmc/threads/low-amp-charging.197800/
         # says another reason to charge at higher power is to preserve battery life.
         # The best charge rate is the capacity of the battery pack / 2.  Home chargers
         # can't reach that rate, so charging as fast as your wiring supports is best

--- a/lib/TWCManager/Control/themes/Default/settings.html.j2
+++ b/lib/TWCManager/Control/themes/Default/settings.html.j2
@@ -116,6 +116,7 @@
               [
                 [1, "Use TWC Exclusively to control Charge Rate"],
                 [2, "Use Tesla API Exclusively to control Charge Rate"],
+                [3, "Use TWC >= 6A + Tesla API < 6A to control Charge Rate"],
               ],
               {
                 "name": "chargeRateControl",

--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -1169,6 +1169,19 @@ while True:
                         },
                     )
 
+                    # Set minAmpsTWCSupports to 1A for 3 phase chargers
+                    if (
+                        voltsPhaseA >= 200
+                        and voltsPhaseB >= 200
+                        and voltsPhaseC >= 200
+                    ):
+                        slaveTWC.minAmpsTWCSupports = 1
+                        logger.debug(
+                            "Slave TWC %02X%02X: Set minAmpsTWCSupports to 1A",
+                            senderID[0],
+                            senderID[1]
+                        )
+
                     # Update the timestamp of the last reciept of this message
                     master.lastkWhMessage = time.time()
 


### PR DESCRIPTION
See the discussion in #510 

I was not able to get my TWC gen2 to actually offer < 6A to the car. The API can though. So I introduced a new option: `Use TWC >= 6A + Tesla API < 6A to control Charge Rate`. 

This code works quite well for me.