### PR TITLE
Add options for rounding vs. truncating, smaller granularity than whole amps

### DIFF
--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -64,6 +64,12 @@
         # rates really does.
         "minAmpsPerTWC": 12,
 
+        # By default TWCManager will limit charging to whole Amps only and never more
+        # than the PV surplus. This strategy can be changed by setting roundingAmps
+        # to "half" or "quart". Or to allow rounding to the nearest number (that
+        # might be more than the PV surplus) use "round", "roundHalf" or "roundQuart".
+        "roundingAmps": "int",
+
         # If the system rapidly changes its mind about whether to start or stop charging,
         # this parameter keeps charging / not charging until the decision remains stable
         # for this many seconds.

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -82,6 +82,7 @@ class TWCSlave:
             "useFlexAmpsToStartCharge", False
         )
         self.startStopDelay = self.configConfig.get("startStopDelay", 60)
+        self.roundingAmps = self.configConfig.get("roundingAmps", "int")
 
     def print_status(self, heartbeatData):
         try:
@@ -806,7 +807,7 @@ class TWCSlave:
             # Call the Tesla API to set the charge rate for vehicle connected to this TWC
             # TODO: Identify vehicle
             if (
-                int(desiredAmpsOffered) == self.__lastAPIAmpsValue
+                self.rounding(desiredAmpsOffered) == self.__lastAPIAmpsValue
                 and (
                     self.__lastAPIAmpsRepeat > 50 or self.__lastAPIAmpsRepeat % 10 != 0
                 )
@@ -819,7 +820,7 @@ class TWCSlave:
             else:
                 self.__lastAPIAmpsRequest = time.time()
                 self.__lastAPIAmpsRepeat = 0
-                self.__lastAPIAmpsValue = int(desiredAmpsOffered)
+                self.__lastAPIAmpsValue = self.rounding(desiredAmpsOffered)
 
                 # Determine vehicle to control
                 targetVehicle = (
@@ -827,7 +828,7 @@ class TWCSlave:
                 )
 
                 self.master.getModuleByName("TeslaAPI").setChargeRate(
-                    int(desiredAmpsOffered), targetVehicle
+                    int(self.rounding(desiredAmpsOffered)), targetVehicle
                 )
 
             desiredAmpsOffered = int(self.configConfig.get("wiringMaxAmpsPerTWC", 6))
@@ -840,7 +841,7 @@ class TWCSlave:
             # one second and 12.0A the next second, the car reduces its power
             # use to ~5.14-5.23A and refuses to go higher. So it seems best to
             # stick with whole amps.
-            desiredAmpsOffered = int(desiredAmpsOffered)
+            desiredAmpsOffered = self.rounding(desiredAmpsOffered)
 
             # Mid Oct 2017, Tesla pushed a firmware update to their cars
             # that seems to create the following bug:
@@ -1018,7 +1019,7 @@ class TWCSlave:
         # look like this:
         #   S 032e 0.25/0.00A: 03 0000 0019 0000 M: 05 0000 0000 0000
         if self.reportedAmpsMax != desiredAmpsOffered or desiredAmpsOffered == 0:
-            desiredHundredthsOfAmps = int(desiredAmpsOffered * 100)
+            desiredHundredthsOfAmps = int(self.rounding(desiredAmpsOffered) * 100)
             self.masterHeartbeatData = bytearray(
                 [
                     (0x09 if self.protocolVersion == 2 else 0x05),
@@ -1165,3 +1166,16 @@ class TWCSlave:
         if lastVehicle != None:
             return lastVehicle
         return None
+
+    def rounding(self, value):
+        if self.roundingAmps == 'half':
+            return int(value * 2) / 2
+        if self.roundingAmps == 'quart':
+            return int(value * 4) / 4
+        if self.roundingAmps == 'round':
+            return round(value)
+        if self.roundingAmps == 'roundHalf':
+            return round(value * 2) / 2
+        if self.roundingAmps == 'roundQuart':
+            return round(value * 4) / 4
+        return int(value)


### PR DESCRIPTION
I found that using round() works much better for PV tracking. With round() I stay within 0.5A of the target. With 3-phases 240V that is a maximum inaccuracy of 360W instead of 720W when using int(). With single phase 120V it is 60W vs 120W so it doesn't matter as much.