### PR TITLE
More accurate getConsumptionAmps()

### DIFF
--- a/lib/TWCManager/EMS/DSMRreader.py
+++ b/lib/TWCManager/EMS/DSMRreader.py
@@ -107,13 +107,14 @@ class DSMRreader:
                 logging.INFO3, f"Generation Value updated to {round(self.generatedW)}W"
             )
 
-            ampsL1 = payload.get("phase_power_current_l1", 0)
-            ampsL2 = payload.get("phase_power_current_l2", 0)
-            ampsL3 = payload.get("phase_power_current_l3", 0)
-            if self.consumedW > self.generatedW:
-                self.consumedA = max(ampsL1, ampsL2, ampsL3)
-            else:
-                self.consumedA = 0
+            # Determine the most consumed Amps among all phases
+            self.consumedA = 0
+            if payload.get("phase_currently_delivered_l1", 0) > payload.get("phase_currently_returned_l1", 0):
+                self.consumedA = max(self.consumedA, payload.get("phase_power_current_l1", 0))
+            if payload.get("phase_currently_delivered_l2", 0) > payload.get("phase_currently_returned_l2", 0):
+                self.consumedA = max(self.consumedA, payload.get("phase_power_current_l2", 0))
+            if payload.get("phase_currently_delivered_l3", 0) > payload.get("phase_currently_returned_l3", 0):
+                self.consumedA = max(self.consumedA, payload.get("phase_power_current_l3", 0))
             logger.log(
                 logging.INFO3, f"Consumption Amps Value updated to {self.consumedA}A"
             )


### PR DESCRIPTION
Especially for highly unbalanced 3-phase circuits. If you return 16A on phase 1 and draw 10A on phase 2, getConsumptionAmps() should report 10A, not 16A like it did before this patch. 