### PR TITLE
Fix vehicle_data for api_version 67

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1400,6 +1400,7 @@ class CarApiVehicle:
     def update_vehicle_data(self, cacheTime=60):
         url = "https://owner-api.teslamotors.com/api/1/vehicles/"
         url = url + str(self.ID) + "/vehicle_data"
+        url = url + "?endpoints=location_data%3Bcharge_state%3Bclimate_state%3Bvehicle_state%3Bgui_settings%3Bvehicle_config"
 
         now = time.time()
 


### PR DESCRIPTION
Firmware version 2023.38+ [requires](https://developer.tesla.com/docs/tesla-fleet-api#2023-10-24-vehicle-data-update-on-firmware-versions-2023-38) to send the `endpoints` parameter to retrieve `vehicle_data`. Otherwise you will see errors like this:
```
2023-11-12 00:29:32,384 - 🚗 TeslaAPI 13 Car API cmd https://owner-api.teslamotors.com/api/1/vehicles/1234567890/vehicle_data <Response [200]>
2023-11-12 00:29:32,394 - ⛽ Manager  20 BackgroundError: Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/TWCManager/TWCManager.py", line 266, in background_tasks_thread
    carapi.applyChargeLimit(limit=task["limit"])
  File "/usr/local/lib/python3.9/dist-packages/TWCManager/Vehicle/TeslaAPI.py", line 840, in applyChargeLimit
    or (vehicle.update_location(cacheTime=3600) and not vehicle.atHome)
  File "/usr/local/lib/python3.9/dist-packages/TWCManager/Vehicle/TeslaAPI.py", line 1391, in update_location
    return self.update_vehicle_data(cacheTime)
  File "/usr/local/lib/python3.9/dist-packages/TWCManager/Vehicle/TeslaAPI.py", line 1417, in update_vehicle_data
    self.lat = drive["latitude"]
KeyError: 'latitude'
, occurred when processing background task
``` 