### PR TITLE
Fix SQL statements to work with MariaDB Server 10.5

### DIFF
--- a/lib/TWCManager/Logging/MySQLLogging.py
+++ b/lib/TWCManager/Logging/MySQLLogging.py
@@ -28,7 +28,7 @@ class MySQLHandler(logging.Handler):
 
                 query = """
                     INSERT INTO charge_sessions (chargeid, startTime, startkWh, slaveTWC)
-                    VALUES (%s,now(),%s,'%s')
+                    VALUES (%s,now(),%s,%s)
                 """
 
                 # Ensure database connection is alive, or reconnect if not
@@ -69,8 +69,8 @@ class MySQLHandler(logging.Handler):
                 chgid = self.slaveSession.get(twcid, 0)
                 if getattr(record, "vehicleVIN", None):
                     query = """
-                        UPDATE charge_sessions SET vehicleVIN = '%s'
-                        WHERE chargeid = %s AND slaveTWC = '%s'
+                        UPDATE charge_sessions SET vehicleVIN = %s
+                        WHERE chargeid = %s AND slaveTWC = %s
                     """
 
                     # Ensure database connection is alive, or reconnect if not
@@ -84,7 +84,7 @@ class MySQLHandler(logging.Handler):
                     rows = 0
                     try:
                         rows = cur.execute(
-                            query % (getattr(record, "vehicleVIN", ""), chgid, twcid)
+                            query, (getattr(record, "vehicleVIN", ""), chgid, twcid)
                         )
                     except Exception as e:
                         logger.error("Error updating MySQL database: %s", e)
@@ -104,7 +104,7 @@ class MySQLHandler(logging.Handler):
                 chgid = self.slaveSession.get(twcid, 0)
                 query = """
                     UPDATE charge_sessions SET endTime = now(), endkWh = %s
-                    WHERE chargeid = %s AND slaveTWC = '%s'
+                    WHERE chargeid = %s AND slaveTWC = %s
                 """
 
                 # Ensure database connection is alive, or reconnect if not


### PR DESCRIPTION
I just started to use the MySQLLogging module but it did not work. The logfile said:
```
2023-12-16 20:23:47,136 - MySQLLoggi 40 Error updating MySQL database: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '2666''' at line 2")
```
`2666` is my `slaveTWC`. I checked the SQL statements and found #333 -> #334 and https://github.com/ngardiner/TWCManager/commit/5d62d7eda2ffdcd5d4bf132000fd109e2d7c8cca have introduced quotes in the prepared statements. All (even string) values in the SQL statements used by `cur.execute` should be referred to by using `%s` without quotes. Using Python format strings to insert the values into the SQL statement might lead to SQL injection. It is safer to let Python MySQL handle the paramaters.

This PR fixes the SQL statements for me. I'm using MariaDB Server 10.5 at the moment but I believe the current code is broken for older databases as well.