### PR TITLE
Support for vehicle command proxy / FleetAPI

### DIFF
--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -155,6 +155,9 @@
         #
         # Only set "httpProxyCert" when setting "teslaApiUrl" to a local proxy.
         #"httpProxyCert": "/path/to/public_key.pem",
+        #
+        # Only set "teslaApiClientID" when setting "teslaApiUrl" to a local proxy.
+        #"teslaApiClientID": "client-id-of-proxy",
 
         # The cloudUpdateInterval determines how often to poll certain
         # data retrieved from the Tesla API to evaluate policy.

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -142,6 +142,11 @@
         # FleetAPI http proxy:    https://localhost:4443/api/1/vehicles
         "teslaApiUrl": "https://fleet-api.prd.na.vn.cloud.tesla.com/api/1/vehicles",
 
+        # The client_id of the app registered with Tesla. Registration is
+        # required to use the FleetAPI and Vehicle Command protocol.
+        # See https://developer.tesla.com/docs/fleet-api#authentication
+        #"teslaApiClientID": "client-id-of-registered-app",
+
         # Since 2024 the Tesla Vehicle Command protocol is required for all
         # vehicles manufacturered after 2021. The Tesla Vehicle Command proxy
         # will automatically fall back to the FleetAPI for older vehicles.
@@ -155,9 +160,6 @@
         #
         # Only set "httpProxyCert" when setting "teslaApiUrl" to a local proxy.
         #"httpProxyCert": "/path/to/public_key.pem",
-        #
-        # Only set "teslaApiClientID" when setting "teslaApiUrl" to a local proxy.
-        #"teslaApiClientID": "client-id-of-proxy",
 
         # The cloudUpdateInterval determines how often to poll certain
         # data retrieved from the Tesla API to evaluate policy.

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -135,20 +135,20 @@
         # include the "/api/1/vehicles" path.
         # Known values are:
         #
-        # owner-api (legacy):      https://owner-api.teslamotors.com/api/1/vehicles
-        # fleet-api North America: https://fleet-api.prd.na.vn.cloud.tesla.com/api/1/vehicles
-        # fleet-api Europe:        https://fleet-api.prd.eu.vn.cloud.tesla.com/api/1/vehicles
-        # fleet-api China:         https://fleet-api.prd.cn.vn.cloud.tesla.cn/api/1/vehicles
-        # fleet-api http proxy:    https://localhost:4443/api/1/vehicles
+        # OwnerAPI (legacy):      https://owner-api.teslamotors.com/api/1/vehicles
+        # FleetAPI North America: https://fleet-api.prd.na.vn.cloud.tesla.com/api/1/vehicles
+        # FleetAPI Europe:        https://fleet-api.prd.eu.vn.cloud.tesla.com/api/1/vehicles
+        # FleetAPI China:         https://fleet-api.prd.cn.vn.cloud.tesla.cn/api/1/vehicles
+        # FleetAPI http proxy:    https://localhost:4443/api/1/vehicles
         "teslaApiUrl": "https://fleet-api.prd.na.vn.cloud.tesla.com/api/1/vehicles",
 
         # Since 2024 the Tesla Vehicle Command protocol is required for all
         # vehicles manufacturered after 2021. The Tesla Vehicle Command proxy
-        # will automatically fall back to the fleet-api for older vehicles.
+        # will automatically fall back to the FleetAPI for older vehicles.
         #
         # TWCManager does not implement the Tesla Vehicle Command protocol.
         # Instead it relies on the Tesla Vehicle Command proxy which translates
-        # the fleet-api REST calls if the destination vehicle supports the
+        # the FleetAPI REST calls if the destination vehicle supports the
         # new protocol. This requires the URL of the proxy to be set as
         # "teslaApiUrl" above and the proxy certificate for validation here.
         # See https://github.com/teslamotors/vehicle-command

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -131,6 +131,29 @@
         # you will need to un-comment it to have it take effect.
         #"minChargeLevel": 10,
 
+        # The Tesla API URL is base URL for all REST API calls. This should
+        # include the "/api/1/vehicles" path.
+        # Known values are:
+        #
+        # owner-api (legacy):      https://owner-api.teslamotors.com/api/1/vehicles
+        # fleet-api North America: https://fleet-api.prd.na.vn.cloud.tesla.com/api/1/vehicles
+        # fleet-api Europe:        https://fleet-api.prd.eu.vn.cloud.tesla.com/api/1/vehicles
+        # fleet-api China:         https://fleet-api.prd.cn.vn.cloud.tesla.cn/api/1/vehicles
+        # fleet-api http proxy:    https://localhost:4443/api/1/vehicles
+        "teslaApiUrl": "https://fleet-api.prd.na.vn.cloud.tesla.com/api/1/vehicles",
+
+        # Since 2024 the Tesla Vehicle Command protocol is required for all
+        # vehicles manufacturered after 2021. The Tesla Vehicle Command proxy
+        # will automatically fall back to the fleet-api for older vehicles.
+        #
+        # TWCManager does not implement the Tesla Vehicle Command protocol.
+        # Instead it relies on the Tesla Vehicle Command proxy which translates
+        # the fleet-api REST calls if the destination vehicle supports the
+        # new protocol. This requires the URL of the proxy to be set as
+        # "teslaApiUrl" above and the proxy certificate for validation here.
+        # See https://github.com/teslamotors/vehicle-command
+        "httpProxyCert": "/path/to/public_key.pem",
+
         # The cloudUpdateInterval determines how often to poll certain
         # data retrieved from the Tesla API to evaluate policy.
         "cloudUpdateInterval": 1800,

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -152,7 +152,9 @@
         # new protocol. This requires the URL of the proxy to be set as
         # "teslaApiUrl" above and the proxy certificate for validation here.
         # See https://github.com/teslamotors/vehicle-command
-        "httpProxyCert": "/path/to/public_key.pem",
+        #
+        # Only set "httpProxyCert" when setting "teslaApiUrl" to a local proxy.
+        #"httpProxyCert": "/path/to/public_key.pem",
 
         # The cloudUpdateInterval determines how often to poll certain
         # data retrieved from the Tesla API to evaluate policy.

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -18,6 +18,8 @@ class TeslaAPI:
     __apiState = None
     __authURL = "https://auth.tesla.com/oauth2/v3/token"
     __callbackURL = "https://auth.tesla.com/void/callback"
+    baseURL = "https://owner-api.teslamotors.com/api/1/vehicles"
+    proxyCert = None
     carApiLastErrorTime = 0
     carApiBearerToken = ""
     carApiRefreshToken = ""
@@ -1212,6 +1214,8 @@ class CarApiVehicle:
     carapi = None
     __config = None
     debuglevel = 0
+    baseURL = "https://owner-api.teslamotors.com/api/1/vehicles"
+    proxyCert = None
     ID = None
     name = ""
     syncSource = "TeslaAPI"
@@ -1245,6 +1249,8 @@ class CarApiVehicle:
     def __init__(self, json, carapi, config):
         self.carapi = carapi
         self.__config = config
+        self.baseURL = config["config"].get("teslaApiUrl", "https://owner-api.teslamotors.com/api/1/vehicles")
+        self.proxyCert = config["config"].get("httpProxyCert", None)
         self.ID = json["id"]
         self.VIN = json["vin"]
         self.name = json["display_name"]

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -19,6 +19,7 @@ class TeslaAPI:
     __authURL = "https://auth.tesla.com/oauth2/v3/token"
     __callbackURL = "https://auth.tesla.com/void/callback"
     baseURL = "https://owner-api.teslamotors.com/api/1/vehicles"
+    refreshClientID = "ownerapi"
     proxyCert = None
     carApiLastErrorTime = 0
     carApiBearerToken = ""
@@ -64,6 +65,7 @@ class TeslaAPI:
         try:
             self.config = master.config
             self.baseURL = self.config["config"].get("teslaApiUrl", "https://owner-api.teslamotors.com/api/1/vehicles")
+            self.refreshClientID = self.config["config"].get("teslaApiClientID", "ownerapi")
             self.proxyCert = self.config["config"].get("httpProxyCert", None)
             self.minChargeLevel = self.config["config"].get("minChargeLevel", -1)
             self.chargeUpdateInterval = self.config["config"].get(
@@ -108,10 +110,9 @@ class TeslaAPI:
         # days when first issued, so we'll get a new token every 15 days.
         headers = {"accept": "application/json", "Content-Type": "application/json"}
         data = {
-            "client_id": "ownerapi",
+            "client_id": self.refreshClientID,
             "grant_type": "refresh_token",
             "refresh_token": self.getCarApiRefreshToken(),
-            "scope": "openid email offline_access",
         }
         req = None
         now = time.time()

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -66,7 +66,7 @@ class TeslaAPI:
             self.config = master.config
             self.baseURL = self.config["config"].get("teslaApiUrl", "https://owner-api.teslamotors.com/api/1/vehicles")
             self.refreshClientID = self.config["config"].get("teslaApiClientID", "ownerapi")
-            self.proxyCert = self.config["config"].get("httpProxyCert", None)
+            self.proxyCert = self.config["config"].get("httpProxyCert", True)
             self.minChargeLevel = self.config["config"].get("minChargeLevel", -1)
             self.chargeUpdateInterval = self.config["config"].get(
                 "cloudUpdateInterval", 1800

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -644,7 +644,7 @@ class TeslaAPI:
                 self.applyChargeLimit(self.lastChargeLimitApplied, checkArrival=True)
 
             url = self.baseURL + "/"
-            url = url + str(vehicle.ID) + "/command/charge_" + startOrStop
+            url = url + str(vehicle.VIN) + "/command/charge_" + startOrStop
             headers = {
                 "accept": "application/json",
                 "Authorization": "Bearer " + self.getCarApiBearerToken(),
@@ -1118,7 +1118,7 @@ class TeslaAPI:
         vehicle.lastAPIAccessTime = time.time()
 
         url = self.baseURL + "/"
-        url = url + str(vehicle.ID) + "/command/set_charging_amps"
+        url = url + str(vehicle.VIN) + "/command/set_charging_amps"
 
         headers = {
             "accept": "application/json",
@@ -1179,7 +1179,7 @@ class TeslaAPI:
         vehicle.lastAPIAccessTime = time.time()
 
         url = self.baseURL + "/"
-        url = url + str(vehicle.ID) + "/wake_up"
+        url = url + str(vehicle.VIN) + "/wake_up"
 
         headers = {
             "accept": "application/json",
@@ -1320,7 +1320,7 @@ class CarApiVehicle:
     # Permits opportunistic API requests
     def is_awake(self):
         if self.syncSource == "TeslaAPI":
-            url = self.baseURL + "/" + str(self.ID)
+            url = self.baseURL + "/" + str(self.VIN)
             (result, response) = self.get_car_api(
                 url, checkReady=False, provesOnline=False
             )
@@ -1407,7 +1407,7 @@ class CarApiVehicle:
 
     def update_vehicle_data(self, cacheTime=60):
         url = self.baseURL + "/"
-        url = url + str(self.ID) + "/vehicle_data"
+        url = url + str(self.VIN) + "/vehicle_data"
         url = (
             url
             + "?endpoints=location_data%3Bcharge_state%3Bclimate_state%3Bvehicle_state%3Bgui_settings%3Bvehicle_config"
@@ -1464,7 +1464,7 @@ class CarApiVehicle:
         self.lastLimitAttemptTime = now
 
         url = self.baseURL + "/"
-        url = url + str(self.ID) + "/command/set_charge_limit"
+        url = url + str(self.VIN) + "/command/set_charge_limit"
 
         headers = {
             "accept": "application/json",


### PR DESCRIPTION
The legacy OwnerAPI will soon be dropped by Tesla. Newer cars will support only signed commands using the Vehicle Command protocol. Pre-2021 Model X/Y will move to the FleetAPI. This PR supports both. For the Vehicle Command protocol it uses the proxy [supplied](https://github.com/teslamotors/vehicle-command) by Tesla.

This PR adds 3 new configuration settings:

1. `teslaApiUrl` with as default the FleetAPI URL for North America. If this setting is missing in the config, the old OwnerAPI URL is used. This ensures that TWCManager keep working as-is with existing configurations.
1. `teslaApiClientID` is the `client_id` of the app registered with Tesla. This is needed to refresh the tokens.
1. `httpProxyCert` should point to the certificate of the proxy if `teslaApiUrl` is set to a proxy URL.

Fixes #545