### PR TITLE
Get list of vehicles using products endpoint

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -229,6 +229,8 @@ class TeslaAPI:
         if self.getCarApiBearerToken() != "":
             if self.getVehicleCount() < 1:
                 url = self.baseURL
+                if 'owner-api' in url:
+                    url = url.replace('vehicles', 'products')
                 headers = {
                     "accept": "application/json",
                     "Authorization": "Bearer " + self.getCarApiBearerToken(),


### PR DESCRIPTION
Fix borrowed from [TeslaMate](https://github.com/teslamate-org/teslamate/issues/3629). Untested but needed for TWCManager to keep working after a restart.