### PR TITLE
Add comma in new config.json line

### DIFF
--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -149,7 +149,7 @@
         # See https://github.com/teslamotors/vehicle-command
         #
         # The URL of the Tesla HTTP Proxy running locally
-        # "teslaProxy": "https://localhost:4443"
+        # "teslaProxy": "https://localhost:4443",
         #
         # Only set "teslaProxyCert" when "teslaProxy" is set.
         #"teslaProxyCert": "/path/to/public_key.pem",


### PR DESCRIPTION
I missed this in #548. Without the comma the JSON will be invalid the line is uncommented.