### PR TITLE
Only add vehicles to carApiVehicles

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -89,8 +89,8 @@ class TeslaAPI:
         self.generateChallenge()
 
     def addVehicle(self, json):
-        self.carApiVehicles.append(CarApiVehicle(json, self, self.config))
-        return True
+        if "vin" in json:
+            self.carApiVehicles.append(CarApiVehicle(json, self, self.config))
 
     def apiDebugInterface(self, command, vehicleID, parameters):
         # Provides an interface from the Web UI to allow commands to be run interactively


### PR DESCRIPTION
Because of 4b1767f7360313654784d4004764e32e6c25ce40 the list of [products](https://developer.tesla.com/docs/#products) might also include Tesla home batteries, Tesla chargers, etc. So we need to only select the cars from the list.

Also, the return value of `addVehicle()` is not used. So instead of returning `False` when no vehicle is added, I removed the return altogether.