### PR TITLE
Use python3 / pip3 in the manual

### DIFF
--- a/docs/Software_Manual.md
+++ b/docs/Software_Manual.md
@@ -104,7 +104,7 @@ The following documents provide detail on specific areas of configuration:
 Once the above steps are complete, start the TWCManager script with the following command:
 
 ```
-sudo -u twcmanager python -m TWCManager
+sudo -u twcmanager python3 -m TWCManager
 ```
 
 ### Monitoring the script operation
@@ -158,7 +158,7 @@ From version v1.2.4 of TWCManager and beyond, you can use pip to upgrade TWCMana
 To upgrade TWCManager to the latest version:
 
 ```
-sudo pip install --upgrade twcmanager
+sudo pip3 install --upgrade twcmanager
 ```
 
 ### Development Version


### PR DESCRIPTION
Modern Linux does not come with `python` as an alias for `python3` anymore..