### PR TITLE
Reduce scope, add drive_state

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1437,12 +1437,13 @@ class CarApiVehicle:
             return True
 
     def update_vehicle_data(self, cacheTime=60):
-        url = self.carapi.getCarApiBaseURL() + "/"
-        url = url + str(self.VIN) + "/vehicle_data"
-        url = (
-            url
-            + "?endpoints=location_data%3Bcharge_state%3Bclimate_state%3Bvehicle_state%3Bgui_settings%3Bvehicle_config"
-        )
+        url = "/".join([
+            self.carapi.getCarApiBaseURL(),
+            str(self.VIN),
+            "vehicle_data"
+        ]) + "?endpoints=" + "%3B".join([
+            "location_data","charge_state","drive_state"
+        ])
 
         now = time.time()
 


### PR DESCRIPTION
Following the discussion in #564 with @r3ptile1860, this makes two key changes:

- Adds `drive_state` to the list of requested data, since that no longer seems to be implicit (at least for older vehicles?)
- Drops several of the endpoints we don't actually use

I think when the requirement to specify endpoints was added, we just requested everything to fix the issue and didn't revisit that later. It appears that we only actually touch drive and charge states in this function, plus location as an add-on to drive.