### PR TITLE
Specify scope in API token refresh

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -124,6 +124,7 @@ class TeslaAPI:
             "client_id": self.refreshClientID,
             "grant_type": "refresh_token",
             "refresh_token": self.getCarApiRefreshToken(),
+            "scope": "offline_access",
         }
         req = None
         now = time.time()


### PR DESCRIPTION
Tesla API requires to specify access scope to return certain data for quite some time now. Without "offline_access", it won't return a new refresh token.

Fixes issue #564.