### PR TITLE
Don't attempt to start or stop charging a disconnected car

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -634,6 +634,16 @@ class TeslaAPI:
             # more than once per minute.
             self.updateLastStartOrStopChargeTime()
 
+            # Don't attempt to start or stop charging a disconnected car.
+            if vehicle.chargingState == "Disconnected":
+                logger.info(
+                    vehicle.name
+                    + " is disconnected.  Do not "
+                    + startOrStop
+                    + " charge."
+                )
+                continue
+
             # only start/stop charging cars parked at home.
 
             if vehicle.update_location() is False:
@@ -727,16 +737,14 @@ class TeslaAPI:
                                 "complete",
                                 "charging",
                                 "is_charging",
-                                "disconnected",
                                 "requested",
                             ]:
                                 # We asked the car to charge, but it responded
                                 # that it can't, either because it's reached
                                 # target charge state (reason == 'complete'), or
                                 # it's already trying to charge (reason ==
-                                # 'charging' or 'requested') or it's not
-                                # connected to a charger (reason ==
-                                # 'disconnected'). In these cases, it won't help
+                                # 'charging' or 'requested').
+                                # In these cases, it won't help
                                 # to keep asking it to charge, so set
                                 # vehicle.stopAskingToStartCharging = True.
                                 #
@@ -1277,6 +1285,7 @@ class CarApiVehicle:
     lon = 10000
     atHome = False
     timeToFullCharge = 0.0
+    chargingState = ""
 
     # Sync values are updated by an external module such as TeslaMate
     syncTimestamp = 0
@@ -1471,6 +1480,7 @@ class CarApiVehicle:
             self.chargeLimit = charge["charge_limit_soc"]
             self.batteryLevel = charge["battery_level"]
             self.timeToFullCharge = charge["time_to_full_charge"]
+            self.chargingState = charge.get("charging_state", "")
 
             self.lastVehicleStatusTime = now
 


### PR DESCRIPTION
This works quite well. I turned on my car Kriek but did not plug it in for a while.

```
2024-04-26 08:27:26,379 - 🚗 TeslaAPI 13 Kriek not ready because it wasn't woken in the last 2 minutes.
2024-04-26 08:27:26,380 - 🚗 TeslaAPI 13 car_api_charge return because car_api_available() == False
2024-04-26 08:27:27,260 - 🚗 TeslaAPI 13 Entering car_api_available - next step is to query Tesla API
2024-04-26 08:27:27,414 - 🚗 TeslaAPI 13 Car API cmd https://127.0.0.1:4443/api/1/vehicles/<Kriek VIN> <Response [200]>
2024-04-26 08:27:27,415 - 🚗 TeslaAPI 13 car_api_available returning True
2024-04-26 08:27:27,416 - 🚗 TeslaAPI 13 startOrStop is set to start
2024-04-26 08:27:27,416 - 🚗 TeslaAPI 13 Don't charge Big Red because vehicle.stopAskingToStartCharging == True
2024-04-26 08:27:36,599 - 🚗 TeslaAPI 13 Car API cmd https://127.0.0.1:4443/api/1/vehicles/<Kriek VIN>/vehicle_data?endpoints=location_data%3Bcharge_state%3Bdrive_state <Response [408]>
2024-04-26 08:27:36,600 - 🚗 TeslaAPI 20 ERROR: Can't access vehicle status for Kriek.  Will try again later.
2024-04-26 08:27:36,601 - 🚗 TeslaAPI 13 updateCarApiLastErrorTime() called due to Tesla API Error. Updating timestamp from 0 to 1714112856.6009448
2024-04-26 08:27:36,601 - 🚗 TeslaAPI 20 Kriek is disconnected.  Do not start charge.
2024-04-26 08:28:36,332 - 🚗 TeslaAPI 13 Car API cmd wake_up<Response [200]>
2024-04-26 08:28:36,333 - 🚗 TeslaAPI 13 car_api_available returning True
2024-04-26 08:28:41,338 - 🚗 TeslaAPI 13 startOrStop is set to start
2024-04-26 08:28:41,339 - 🚗 TeslaAPI 13 Don't charge Big Red because vehicle.stopAskingToStartCharging == True
2024-04-26 08:28:41,339 - 🚗 TeslaAPI 13 Kriek not ready because of recent lastErrorTime 1714112856.6009448
...
2024-04-26 08:44:40,276 - 🚗 TeslaAPI 13 Entering car_api_available - next step is to query Tesla API
2024-04-26 08:44:40,277 - 🚗 TeslaAPI 13 car_api_available returning True
2024-04-26 08:44:40,278 - 🚗 TeslaAPI 13 startOrStop is set to start
2024-04-26 08:44:40,278 - 🚗 TeslaAPI 13 Don't charge Big Red because vehicle.stopAskingToStartCharging == True
2024-04-26 08:44:40,279 - 🚗 TeslaAPI 20 Kriek is disconnected.  Do not start charge.
...
2024-04-26 08:45:05,727 - ⛽ Master   20 Charge Session Started for Slave TWC 2119
2024-04-26 08:45:05,737 - ⛽ Slave    20 SHB 2119: 09 02.29/06.00A 0000 0000  M: 00 00.00/00.00A 0000 0000
2024-04-26 08:45:05,738 - ⛽ Slave    20 Slave power for TWCID 2119, status: 9
2024-04-26 08:45:07,431 - 🚗 TeslaAPI 13 Entering car_api_available - next step is to query Tesla API
2024-04-26 08:45:07,431 - 🚗 TeslaAPI 13 car_api_available returning True
2024-04-26 08:45:07,829 - 🚗 TeslaAPI 13 Car API cmd https://127.0.0.1:4443/api/1/vehicles/<Big Red VIN> <Response [200]>
2024-04-26 08:45:08,664 - 🚗 TeslaAPI 13 Car API cmd https://127.0.0.1:4443/api/1/vehicles/<Big Red VIN>/vehicle_data?endpoints=location_data%3Bcharge_state%3Bdrive_state <Response [200]>
2024-04-26 08:45:08,909 - 🚗 TeslaAPI 13 Car API cmd https://127.0.0.1:4443/api/1/vehicles/<Kriek VIN>/vehicle_data?endpoints=location_data%3Bcharge_state%3Bdrive_state <Response [200]>
2024-04-26 08:45:08,922 - ⛽ Manager  20 Vehicle <Kriek VIN> on TWC 2119 is permitted to charge.
2024-04-26 08:45:09,653 - ⛽ Slave    20 SHB 2119: 01 05.70/06.00A 0000 0000  M: 00 00.00/00.00A 0000 0000
2024-04-26 08:45:09,654 - ⛽ Slave    20 Slave power for TWCID 2119, status: 1
2024-04-26 08:45:11,698 - 📊 MQTT     13 Publishing MQTT Topic TWC/2119/ampsInUse (value is 6.23)
2024-04-26 08:45:11,699 - 📊 MQTT     13 Publishing MQTT Topic TWC/2119/state (value is 1)
2024-04-26 08:45:11,700 - 📊 MQTT     13 Publishing MQTT Topic TWC/2119/carsCharging (value is 1)
```

Fixes #576