### PR TITLE
Better token expiration handling

### DIFF
--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -1265,11 +1265,8 @@ def CreateHTTPHandlerClass(master):
                     carapi = master.getModuleByName("TeslaAPI")
                     if key == "carApiBearerToken":
                         carapi.setCarApiBearerToken(self.getFieldValue(key))
-                        # New tokens expire after 8 hours
-                        carapi.setCarApiTokenExpireTime(time.time() + 8 * 60 * 60)
                     elif key == "carApiRefreshToken":
                         carapi.setCarApiRefreshToken(self.getFieldValue(key))
-                        carapi.setCarApiTokenExpireTime(time.time() + 45 * 24 * 60 * 60)
 
                 else:
                     # Write setting to dictionary

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1145,6 +1145,11 @@ class TeslaAPI:
 
     def setCarApiRefreshToken(self, token):
         self.carApiRefreshToken = token
+        if not self.master.tokenSyncEnabled() and (
+            self.getCarApiBearerToken() == ""
+            or self.getCarApiTokenExpireTime() - time.time() < 60 * 60
+        ):
+            self.apiRefresh()
         return True
 
     def setCarApiTokenExpireTime(self, value):

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1115,30 +1115,30 @@ class TeslaAPI:
                 return False
             else:
                 self.carApiBearerToken = token
-                if not self.baseURL:
-                    try:
-                        decoded = jwt.decode(
-                            token,
-                            options={
-                                "verify_signature": False,
-                                "verify_aud": False,
-                                "verify_exp": False,
-                            },
-                        )
+                try:
+                    decoded = jwt.decode(
+                        token,
+                        options={
+                            "verify_signature": False,
+                            "verify_aud": False,
+                            "verify_exp": False,
+                        },
+                    )
+                    if not self.baseURL:
                         if "owner-api" in "".join(decoded.get("aud", "")):
                             self.baseURL = self.regionURL["OwnerAPI"]
                         elif decoded.get("ou_code", "") in self.regionURL:
                             self.baseURL = self.regionURL[decoded["ou_code"]]
-                        
-                        if "exp" in decoded:
-                            self.setCarApiTokenExpireTime(int(decoded["exp"]))
-                        else:
-                            self.setCarApiTokenExpireTime(time.time() + 8 * 60 * 60)
-
-                    except jwt.exceptions.DecodeError:
-                        # Fallback to owner-api if we get an exception decoding jwt token
-                        self.baseURL = self.regionURL["OwnerAPI"]
+                    
+                    if "exp" in decoded:
+                        self.setCarApiTokenExpireTime(int(decoded["exp"]))
+                    else:
                         self.setCarApiTokenExpireTime(time.time() + 8 * 60 * 60)
+
+                except jwt.exceptions.DecodeError:
+                    # Fallback to owner-api if we get an exception decoding jwt token
+                    self.baseURL = self.regionURL["OwnerAPI"]
+                    self.setCarApiTokenExpireTime(time.time() + 8 * 60 * 60)
                 return True
         else:
             return False

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -131,18 +131,31 @@ class TeslaAPI:
         try:
             req = requests.post(self.refreshURL, headers=headers, json=data)
             logger.log(logging.INFO2, "Car API request" + str(req))
+            req.raise_for_status()
             apiResponseDict = json.loads(req.text)
         except requests.exceptions.RequestException:
-            logger.log(
-                logging.INFO2, "Request Exception parsing API Token Refresh Response"
-            )
-            pass
-        except ValueError:
-            pass
+            if req.status_code == 401:
+                logger.log(
+                    logging.INFO2,
+                    "TeslaAPI",
+                    "ERROR: Can't access Tesla car via API.  Please supply fresh tokens.",
+                )
+                self.setCarApiBearerToken("")
+                self.setCarApiRefreshToken("")
+            self.updateCarApiLastErrorTime()
+            # Instead of just setting carApiLastErrorTime, erase tokens to
+            # prevent further authorization attempts until user enters password
+            # on web interface. I feel this is safer than trying to log in every
+            # ten minutes with a bad token because Tesla might decide to block
+            # remote access to your car after too many authorization errors.
+            self.master.queue_background_task({"cmd": "saveSettings"})                
+            return False
         except json.decoder.JSONDecodeError:
             logger.log(
                 logging.INFO2, "JSON Decode Error parsing API Token Refresh Response"
             )
+            pass
+        except ValueError:
             pass
 
         try:
@@ -151,24 +164,12 @@ class TeslaAPI:
             self.setCarApiRefreshToken(apiResponseDict["refresh_token"])
             self.setCarApiTokenExpireTime(now + apiResponseDict["expires_in"])
             self.master.queue_background_task({"cmd": "saveSettings"})
+            return True
 
-        except KeyError:
-            logger.log(
-                logging.INFO2,
-                "TeslaAPI",
-                "ERROR: Can't access Tesla car via API.  Please log in again via web interface.",
-            )
-            self.updateCarApiLastErrorTime()
-            # Instead of just setting carApiLastErrorTime, erase tokens to
-            # prevent further authorization attempts until user enters password
-            # on web interface. I feel this is safer than trying to log in every
-            # ten minutes with a bad token because Tesla might decide to block
-            # remote access to your car after too many authorization errors.
-            self.setCarApiBearerToken("")
-            self.setCarApiRefreshToken("")
-            self.master.queue_background_task({"cmd": "saveSettings"})
-        except UnboundLocalError:
+        except:
             pass
+
+        return False
 
     def car_api_available(
         self, email=None, password=None, charge=None, applyLimit=None
@@ -1149,7 +1150,7 @@ class TeslaAPI:
             self.getCarApiBearerToken() == ""
             or self.getCarApiTokenExpireTime() - time.time() < 60 * 60
         ):
-            self.apiRefresh()
+            return self.apiRefresh()
         return True
 
     def setCarApiTokenExpireTime(self, value):
@@ -1244,8 +1245,11 @@ class TeslaAPI:
         except requests.exceptions.RequestException:
             if req.status_code == 401 and "expired" in req.text:
                 # If the token is expired, refresh it and try again
-                self.apiRefresh()
-                return self.wakeVehicle(vehicle)
+                if self.apiRefresh():
+                    return self.wakeVehicle(vehicle)
+            elif req.status_code == 429:
+                # We're explicitly being told to back off
+                self.errorCount = max(30, self.errorCount)
             return False
         except json.decoder.JSONDecodeError:
             return False
@@ -1411,10 +1415,12 @@ class CarApiVehicle:
             except requests.exceptions.RequestException:
                 if req.status_code == 401 and "expired" in req.text:
                     # If the token is expired, refresh it and try again
-                    self.apiRefresh()
-                    continue
-                else:
-                    pass
+                    if self.apiRefresh():
+                        continue
+                elif req.status_code == 429:
+                    # We're explicitly being told to back off
+                    self.errorCount = max(30, self.errorCount)
+                return False, None
             except json.decoder.JSONDecodeError:
                 pass
 

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1145,7 +1145,7 @@ class TeslaAPI:
 
     def setCarApiRefreshToken(self, token):
         self.carApiRefreshToken = token
-        if not self.master.tokenSyncEnabled() and (
+        if token and not self.master.tokenSyncEnabled() and (
             self.getCarApiBearerToken() == ""
             or self.getCarApiTokenExpireTime() - time.time() < 60 * 60
         ):


### PR DESCRIPTION
Now that we have the code to parse the JWTs, we don't have to assume the length of a token's duration -- we can read it. We can also respond to 401 errors by refreshing the token instead of continuing to fail until what we thought was the expriation time.