### PR TITLE
No display name?

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1326,6 +1326,8 @@ class CarApiVehicle:
         self.ID = json["id"]
         self.VIN = json["vin"]
         self.name = json["display_name"]
+        if not self.name:
+            self.name = self.VIN
 
         # Launch sync monitoring thread
         Thread(target=self.checkSyncNotStale).start()


### PR DESCRIPTION
API appears to not be returning the car's display name, which breaks all kinds of things that assume it's a string. Don't know if that's a permanent change or a new scope we need to request, but this is a quick fix-up. Note that this also breaks MQTT, since we currently match on the display name.

This change causes the VIN to be used as the display name if none is returned.