### PR TITLE
Get vehicle_name from vehicle_state or set to VIN or ID when not available

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1328,9 +1328,7 @@ class CarApiVehicle:
         self.verifyCert = config["config"].get("teslaProxyCert", True)
         self.ID = json["id"]
         self.VIN = json["vin"]
-        self.name = json["display_name"]
-        if not self.name:
-            self.name = self.VIN
+        self.name = json["display_name"] or self.VIN or str(self.ID) or "unknown"
 
         # Launch sync monitoring thread
         Thread(target=self.checkSyncNotStale).start()
@@ -1494,7 +1492,9 @@ class CarApiVehicle:
         url = (
             "/".join([self.carapi.getCarApiBaseURL(), str(self.VIN), "vehicle_data"])
             + "?endpoints="
-            + "%3B".join(["location_data", "charge_state", "drive_state"])
+            + "%3B".join(
+                ["location_data", "charge_state", "drive_state", "vehicle_state"]
+            )
         )
 
         now = time.time()
@@ -1518,6 +1518,8 @@ class CarApiVehicle:
             self.chargeLimit = charge["charge_limit_soc"]
             self.batteryLevel = charge["battery_level"]
             self.timeToFullCharge = charge["time_to_full_charge"]
+
+            self.name = response["vehicle_state"]["vehicle_name"] or self.name
 
             self.lastVehicleStatusTime = now
 


### PR DESCRIPTION
I restarted TWCManager this morging and noticed these errors:
```
2024-12-27 22:24:57,318 - ⛽ Manager  20 BackgroundError: Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/TWCManager/Vehicle/TeslaAPI.py", line 1507, in update_vehicle_data
    (result, response) = self.get_car_api(url)
  File "/usr/local/lib/python3.9/dist-packages/TWCManager/Vehicle/TeslaAPI.py", line 1415, in get_car_api
    if checkReady and not self.ready():
  File "/usr/local/lib/python3.9/dist-packages/TWCManager/Vehicle/TeslaAPI.py", line 1394, in ready
    self.name + " not ready because it wasn't woken in the last 2 minutes.",
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

It seems in the Fleet API response for /api/1/vehicles `display_name` is now [defined](https://developer.tesla.com/docs/fleet-api/endpoints/vehicle-endpoints#list) as `null`.

I made the code more robust so that `self.name` always is a string and it updates to the `vehicle_name` from `vehicle_state` when present.