### PR TITLE
Dampen some useless commands

### DIFF
--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -621,6 +621,15 @@ class TWCSlave:
             self.master.queue_background_task({"cmd": "checkDeparture"}, 20 * 60)
             self.master.queue_background_task({"cmd": "checkDeparture"}, 45 * 60)
 
+            # If the drop-off was an expected completion, don't restart
+            lastVehicle = self.getLastVehicle()
+            if lastVehicle is not None and (
+                lastVehicle.chargingState in ["Complete", "Disconnected"] or
+                lastVehicle.timeToFullCharge * 60 <= 5
+            ):
+                lastVehicle.stopAskingToStartCharging = True
+
+
         # Keep track of the amps the slave is actually using and the last time it
         # changed by more than 0.8A.
         # Also update self.reportedAmpsActualSignificantChangeMonitor if it's

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -664,6 +664,31 @@ class TeslaAPI:
                 logger.info(message)
                 continue
 
+            if vehicle.update_charge() is False:
+                result = "error"
+                continue
+
+            if vehicle.chargeState in ["Disconnected", "Complete"]:
+                # Sending a command to a disconnected or complete vehicle is
+                # useless.
+                logger.info(
+                    vehicle.name
+                    + " is not able to charge.  Do not "
+                    + startOrStop
+                    + " charge."
+                )
+                vehicle.stopAskingToStartCharging = True
+                continue
+
+            if vehicle.chargeState == "Charging" and charge:
+                # Don't start charging if car is already charging.
+                logger.info(
+                    vehicle.name
+                    + " is already charging.  Do not start charge."
+                )
+                vehicle.stopAskingToStartCharging = True
+                continue
+
             # If you send charge_start/stop less than 1 second after calling
             # update_location(), the charge command usually returns:
             #   {'response': {'result': False, 'reason': 'could_not_wake_buses'}}


### PR DESCRIPTION
This targets the two useless commands I identified in #591; if others are noted, I can add them.  It's based on #571, since it needs some of the additional state that was picked up there; I'll retarget to main once that's merged.

- When charging stops (as reported by the TWC), `stopAskingToStartCharging` is set on the last-connected vehicle if one of the following is true:
  - That vehicle now reports that it is disconnected or complete
  - That vehicle last reported an estimated time-to-completion of less than five minutes
- Before sending a start-charge command, the vehicle's last-reported charge status is checked. No start/stop command is sent if the vehicle reported being disconnected or done charging, and no charge command is sent if the vehicle reported that it was already charging.