### PR TITLE
Bump Python version to un-break tasks

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -26,10 +26,11 @@ jobs:
         with:
           path: ./black
           ref: ${{ github.event.push.head.sha }}
-      - name: Set up Python 3.7
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.12
+          cache: 'pip'
       - name: Install Black
         run: pip install black
       - name: Check if formatting is required for any file

--- a/.github/workflows/docker+pypi.yml
+++ b/.github/workflows/docker+pypi.yml
@@ -57,10 +57,10 @@ jobs:
       with:
         path: ./pypi-dev
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.12
 
     - name: Install pypa/build
       run: >-
@@ -109,10 +109,10 @@ jobs:
     - name: Check out Repository
       uses: actions/checkout@v3
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.12
 
     - name: Install pypa/build
       run: >-
@@ -158,10 +158,10 @@ jobs:
       with:
         path: ./pypi
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.12
 
     - name: Install pypa/build
       run: >-
@@ -195,10 +195,10 @@ jobs:
     - name: Check out Repository
       uses: actions/checkout@v3
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.12
 
     - name: Install pypa/build and build a binary wheel and a source tarball
       run: |


### PR DESCRIPTION
I notice the autoblack and pypi tasks are failing because Python 3.7 isn't supported on the latest Ubuntu. This bumps to the default Python version on that build, which is 3.12. It does not attempt to update any of the tests in the other task, because I don't control those images. They're probably at least stable, since the image build will insure the expected version is present.