### PR TITLE
Change logging name for HASSStatus module

### DIFF
--- a/lib/TWCManager/Status/HASSStatus.py
+++ b/lib/TWCManager/Status/HASSStatus.py
@@ -5,7 +5,7 @@ import logging
 import time
 
 
-logger = logging.getLogger("\U0001F4CA HASS")
+logger = logging.getLogger("\U0001F4CA HASSStatus")
 
 
 class HASSStatus:


### PR DESCRIPTION
Rename to avoid confusion with:
https://github.com/ngardiner/TWCManager/blob/83825193104272b6d544f03397b7f68b21bb2c5b/lib/TWCManager/EMS/HASS.py#L3