### PR TITLE
Max amps to divide from grid global

### DIFF
--- a/etc/twcmanager/.testconfig.json
+++ b/etc/twcmanager/.testconfig.json
@@ -344,8 +344,6 @@
       #   "match": [ "tm_hour", "tm_hour", "settings.hourResumeTrackGreenEnergy" ],
       #   "condition": [ "gte", "lt", "lte" ],
       #   "value": [ 6, 20, "tm_hour" ],
-      #   "charge_amps": "getMaxAmpsToDivideGreenEnergy()",
-      #   "background_task": "checkGreenEnergy",
       #   "charge_limit": "config.greenEnergyLimit" },
 
       # { "name": "Non Scheduled Charging",

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -32,30 +32,11 @@
         # wiringMaxAmpsPerTWC = 50 * 0.8 = 40 and wiringMaxAmpsAllTWCs = 40 + 40 = 80.
         "wiringMaxAmpsPerTWC": 6,
 
-
-        # If you what to limit the power drawn from the Grid you need to set this
-        # maxAmpsAllowedFromGrid and extend the policy you what it to apply, i.e.:
-        # { "name": "Charge Now with Grid power limit",
-        #   "match": [
-        #       "settings.chargeNowAmps",
-        #       "settings.chargeNowTimeEnd",
-        #       "settings.chargeNowTimeEnd",
-        #   ],
-        #   "condition": ["gt", "gt", "gt"],
-        #   "value": [0, 0, "now"],
-        #   "background_task": "checkMaxPowerFromGrid",
-        #   "charge_amps": "settings.chargeNowAmps",
-        #   "charge_limit": "config.chargeNowLimit"},
-
-        # { "name": "Scheduled Charging with Grid power limit",
-        #   "match": [ "checkScheduledCharging()" ],
-        #   "condition": [ "eq" ],
-        #   "value": [ 1 ],
-        #   "background_task": "checkMaxPowerFromGrid",
-        #   "charge_amps": "settings.scheduledAmpsMax",
-        #   "charge_limit": "config.scheduledLimit"},
-
-        "maxAmpsAllowedFromGrid": 16,
+        # If you would like to limit the overall grid draw (chargers and house combined),
+        # set maxAmpsAllowedFromGrid to the maximum number of amps you want to draw from
+        # the grid.  This is useful if you have a limited power connection to your house
+        # and you want to make sure you don't exceed it.
+        #"maxAmpsAllowedFromGrid": 6,
 
 
         # https://teslamotorsclub.com/tmc/threads/model-s-gen2-charger-efficiency-testing.78740/#post-1844789
@@ -333,9 +314,6 @@
       # By default, EMS modules are polled only when the data is needed
       # to track green energy. If you would like to always poll EMS for
       # display purposes, uncomment this.
-      #
-      # This will not work for custom policies which specify their own
-      # background task.
       #"alwaysPollEMS": true,
 
       "engine":{
@@ -349,25 +327,6 @@
         #
         # They should primarily be used to abort charging when necessary.
         "emergency":[
-         { "name": "Charge Now with Grid power limit",
-           "match": [
-               "settings.chargeNowAmps",
-               "settings.chargeNowTimeEnd",
-               "settings.chargeNowTimeEnd",
-           ],
-           "condition": ["gt", "gt", "gt"],
-           "value": [0, 0, "now"],
-           "background_task": "checkMaxPowerFromGrid",
-           "charge_amps": "settings.chargeNowAmps",
-           "charge_limit": "config.chargeNowLimit"},
-
-         { "name": "Scheduled Charging with Grid power limit",
-           "match": [ "checkScheduledCharging()" ],
-           "condition": [ "eq" ],
-           "value": [ 1 ],
-           "background_task": "checkMaxPowerFromGrid",
-           "charge_amps": "settings.scheduledAmpsMax",
-           "charge_limit": "config.scheduledLimit"},
         ],
         # Rules in the before section here are evaluated after the Charge Now rule
         "before":[
@@ -431,8 +390,6 @@
       #   "match": [ "tm_hour", "tm_hour", "settings.hourResumeTrackGreenEnergy" ],
       #   "condition": [ "gte", "lt", "lte" ],
       #   "value": [ 6, 20, "tm_hour" ],
-      #   "charge_amps": "getMaxAmpsToDivideGreenEnergy()",
-      #   "background_task": "checkGreenEnergy",
       #   "charge_limit": "config.greenEnergyLimit" },
 
       # { "name": "Non Scheduled Charging",

--- a/etc/twcmanager/demo.json
+++ b/etc/twcmanager/demo.json
@@ -343,8 +343,6 @@
       #   "match": [ "tm_hour", "tm_hour", "settings.hourResumeTrackGreenEnergy" ],
       #   "condition": [ "gte", "lt", "lte" ],
       #   "value": [ 6, 20, "tm_hour" ],
-      #   "charge_amps": "getMaxAmpsToDivideGreenEnergy()",
-      #   "background_task": "checkGreenEnergy",
       #   "charge_limit": "config.greenEnergyLimit" },
 
       # { "name": "Non Scheduled Charging",

--- a/lib/TWCManager/Control/themes/Default/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Default/jsrefresh.html.j2
@@ -20,7 +20,7 @@ $(document).ready(function() {
                 }
 
                 // Change the state of the Charge Now button based on Charge Policy
-                if (json["currentPolicy"] == "Charge Now" || json["currentPolicy"] == "Charge Now with Grid power limit") {
+                if (json["currentPolicy"] == "Charge Now") {
                   document.getElementById("start_chargenow").value = "Update Charge Now";
                   document.getElementById("cancel_chargenow").disabled = false;
                 } else {

--- a/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/jsrefresh.html.j2
@@ -48,7 +48,7 @@
                     $('#surplusAmps').html(surplusAmps.toFixed(2));
 
                     // Change the state of the Charge Now button based on Charge Policy
-                    if (json["currentPolicy"] == "Charge Now" || json["currentPolicy"] == "Charge Now with Grid power limit") {
+                    if (json["currentPolicy"] == "Charge Now") {
                         if ($("#start_chargenow").length) {
                             $("#start_chargenow").html("Update Charge Now");
                             $("#cancel_chargenow").prop("disabled", false);

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -118,11 +118,6 @@ class Policy:
                 for name, position in [("after", 3), ("before", 1), ("emergency", 0)]:
                     self.charge_policy[position:position] = config_extend.get(name, [])
 
-            if config_policy.get("alwaysPollEMS", False):
-                for policy in self.charge_policy:
-                    if policy.get("background_task", None) is None:
-                        policy["background_task"] = "checkGreenEnergy"
-
             # Set the Policy Check Interval if specified
             policy_engine = config_policy.get("engine")
             if policy_engine:
@@ -220,6 +215,14 @@ class Policy:
         bgt = policy.get("background_task", None)
         if bgt:
             self.master.queue_background_task({"cmd": bgt})
+
+        # If we are not checking green energy already but we need to, queue that
+        # as well.
+        if bgt is not "checkGreenEnergy":
+            alwaysPoll = self.config.get("policy",{}).get("alwaysPollEMS", False)
+            maxAmps = self.config.get("config",{}).get("maxAmpsAllowedFromGrid", None)
+            if alwaysPoll or maxAmps or self.policyIsGreen():
+                self.master.queue_background_task({"cmd": "checkGreenEnergy"})
 
         # If a charge limit is defined for this policy, apply it
         limit = limit = self.policyValue(policy.get("charge_limit", -1))
@@ -324,10 +327,7 @@ class Policy:
     def policyIsGreen(self):
         current = self.getPolicyByName(self.active_policy)
         if current:
-            return (
-                current.get("background_task", "") == "checkGreenEnergy"
-                and current.get("charge_amps", None) == None
-            )
+            return current.get("charge_amps", None) is None
         return False
 
     def doesConditionMatch(self, match, condition, value, exitOn):

--- a/lib/TWCManager/Policy/Policy.py
+++ b/lib/TWCManager/Policy/Policy.py
@@ -301,8 +301,8 @@ class Policy:
         #
         # If value refers to a function, execute the function and capture the
         # output
-        if value == "getMaxAmpsToDivideGreenEnergy()":
-            return self.master.getMaxAmpsToDivideGreenEnergy()
+        if value in ["getMaxAmpsToDivideGreenEnergy()", "getMaxAmpsForTargetGridUsage()"]:
+            return self.master.getMaxAmpsForTargetGridUsage()
         elif value == "checkScheduledCharging()":
             return self.master.checkScheduledCharging()
 

--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -374,7 +374,7 @@ def check_green_energy():
     elif config.get("config",{}).get("maxAmpsAllowedFromGrid", None):
         master.setLimitAmpsToDivideAmongSlaves(
             master.getMaxAmpsForTargetGridUsage(
-                master.convertAmpsToWatts(config["config"]["maxAmpsAllowedFromGrid"])
+                config["config"]["maxAmpsAllowedFromGrid"]
             )
         )
 

--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -367,11 +367,11 @@ def check_green_energy():
 
     # Set max amps iff charge_amps isn't specified on the policy.
     if master.getModuleByName("Policy").policyIsGreen():
-        master.setMaxAmpsToDivideAmongSlaves(master.getMaxAmpsToDivideGreenEnergy())
+        master.setMaxAmpsToDivideAmongSlaves(master.getMaxAmpsForTargetGridUsage())
 
     if config.get("config",{}).get("maxAmpsAllowedFromGrid", None):
         master.setLimitAmpsToDivideAmongSlaves(
-            master.getMaxAmpsToDivideGreenEnergy(
+            master.getMaxAmpsForTargetGridUsage(
                 master.convertAmpsToWatts(config["config"]["maxAmpsAllowedFromGrid"])
             )
         )

--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -368,8 +368,10 @@ def check_green_energy():
     # Set max amps iff charge_amps isn't specified on the policy.
     if master.getModuleByName("Policy").policyIsGreen():
         master.setMaxAmpsToDivideAmongSlaves(master.getMaxAmpsForTargetGridUsage())
-
-    if config.get("config",{}).get("maxAmpsAllowedFromGrid", None):
+        master.setLimitAmpsToDivideAmongSlaves(
+            config["config"]["wiringMaxAmpsAllTWCs"]
+        )
+    elif config.get("config",{}).get("maxAmpsAllowedFromGrid", None):
         master.setLimitAmpsToDivideAmongSlaves(
             master.getMaxAmpsForTargetGridUsage(
                 master.convertAmpsToWatts(config["config"]["maxAmpsAllowedFromGrid"])

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -674,6 +674,23 @@ class TWCMaster:
         availableW = float(generationW + targetW - generationOffset)
         availableAmps = self.convertWattsToAmps(availableW)
 
+        # Get consumption Amps for highest phase, if the EMS source supports it
+        consumptionA = float(self.getConsumptionAmps())
+
+        # Check if we need to limit the Amps
+        maxAmpsAllowedFromGrid = self.config["config"].get("maxAmpsAllowedFromGrid")
+
+        # Limit based on highest phase Amps, if possible
+        if (
+            consumptionA
+            and maxAmpsAllowedFromGrid
+            and consumptionA > maxAmpsAllowedFromGrid
+        ):
+            newOffer = maxAmpsAllowedFromGrid - consumptionA + currentOffer
+            logger.info(
+                f"getMaxAmpsForTargetGridUsage limited Amps to {newOffer:.1f}A: consumption {consumptionA:.1f}A > {maxAmpsAllowedFromGrid}A"
+            )
+
         # Offer the smaller of the two, but not less than zero.
         amps = max(
             min(newOffer, availableAmps / self.getRealPowerFactor(availableAmps)), 0

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -649,7 +649,7 @@ class TWCMaster:
     def getMasterHeartbeatOverride(self):
         return self.overrideMasterHeartbeatData
 
-    def getMaxAmpsToDivideGreenEnergy(self, targetW=0):
+    def getMaxAmpsForTargetGridUsage(self, targetW=0):
         # Calculate our current generation and consumption in watts
         generationW = float(self.getGeneration())
         consumptionW = float(self.getConsumption())

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -653,7 +653,10 @@ class TWCMaster:
         # Calculate our current generation and consumption in amps
         generationA = float(self.convertWattsToAmps(self.getGeneration()))
         consumptionA = float(self.getConsumptionAmps())
-        if not consumptionA:
+
+        # Use consumption on all phases when the target is 0 or consumptionA
+        # is not available
+        if targetA == 0 or not consumptionA:
             consumptionA = float(self.convertWattsToAmps(self.getConsumption()))
         availableA = generationA + targetA - consumptionA
 
@@ -674,9 +677,7 @@ class TWCMaster:
         availableA = float(generationA + targetA - generationOffsetA)
 
         # Offer the smaller of the two, but not less than zero.
-        amps = max(
-            min(newOffer, availableA / self.getRealPowerFactor(availableA)), 0
-        )
+        amps = max(min(newOffer, availableA / self.getRealPowerFactor(availableA)), 0)
         return round(amps, 2)
 
     def getNormalChargeLimit(self, ID):


### PR DESCRIPTION
Per #607, rewrite of #384/#202 to make the option global and not reliant on particular policy names.  Note that this has some internal behavior changes:

- check_green_energy is no longer an explicit background task on green-energy policies
- alwaysPollEMS no longer adds check_green_energy to the in-memory copy of all policies
- policyIsGreen() no longer looks for check_green_energy to determine if a policy is green

Instead:

- policyIsGreen() is true if a policy does not specify charge_amps
- check_green_energy is automatically queued if the policy is green _or_ alwaysPollEMS is set _or_ maxAmpsAllowedFromGrid is set (e.g. maxAmpsAllowedFromGrid implies alwaysPollEMS)
- check_green_energy now includes a step to set a new property, limitAmpsToDivideAmongSlaves, which controls a variable upper-bound on the power offered to the TWCs in parallel with the (constant) wiringMaxAmpsAllTwcs

The key insight here is that the logic for determining green energy is really trying to achieve a particular draw from the grid (zero), so by generalizing it to allow a specified target, the logic can be reused to determine how much can be offered for any desired grid use.

Also dropped some comments from config files that were out-of-date and related to this logic.