### PR TITLE
Add FleetTelemetryMQTT vehicle module

### DIFF
--- a/docs/modules/Vehicle_FleetTelemetryMQTT.md
+++ b/docs/modules/Vehicle_FleetTelemetryMQTT.md
@@ -1,0 +1,181 @@
+# Tesla Fleet Telemetry Vehicle Integration via MQTT
+
+## Introduction
+
+Tesla <a href="https://developer.tesla.com/docs/fleet-api/fleet-telemetry">Fleet Telemetry</a> is the Tesla preferred way of receiving data from vehicles. It replaces polling the `vehicle_data` API endpoint for all Tesla's except pre-2021 Model S and X cars. It is faster and a lot <a href="https://developer.tesla.com">cheaper</a> than using the API.
+
+The purpose of this integration is to allow users of TWCManager to receive real-time status data from their cars without constantly polling the Tesla Fleet API. If the telemetry data stops for more than 1 hour (for example during a long sleep) TWCManager will fall back to polling the `vehicle_data` API endpoint. When the telemetry stream is restored it will take over again. This means the API might still used once per long sleep/wake cycle.
+
+## Requirements
+
+You need to set up a Tesla Fleet Telemetry server with the MQTT data store configured. TWCManager will pick up the data from MQTT server. There are many guides on how to this but simply following the <a href="https://developer.tesla.com/docs/fleet-api/fleet-telemetry">instructions</a> from Tesla should work. These start with setting up a <a href="https://github.com/teslamotors/vehicle-command">vehicle-command</a> HTTP proxy. You need to do this only once. Once the key is paired with you vehicles you can reuse it to configure the fleet-telemetry config as well.
+
+When the vehicle-command HTTP proxy is working, configure the appropriate settings in the TWCManager `config.json`:
+
+```
+        "teslaApiClientID": "client-id-of-registered-app",
+        "teslaProxy": "https://localhost:4443",
+        "teslaProxyCert": "/path/to/public_key.pem",
+```
+
+## Integrations
+
+### Tesla Fleet Telemetry
+
+The Tesla Fleet Telemetry server reference implementation comes with various data stores. Since TWCManager already uses MQTT for various integrations, using the MQTT data store was easy to implement.
+
+#### Docker Configuration
+
+In addition to the `docker-compose.json` method documented by Tesla a simple `docker create` or `docker run` command can be used to run the Tesla Fleet Telemetry server with the docker image from <a href="https://hub.docker.com/r/tesla/fleet-telemetry">tesla/fleet-telemetry</a> :
+
+```
+docker create \
+  --name fleet-telemetry \
+  --restart always \
+  -p 4433:4433 \
+  -v /etc/fleet-telemetry:/etc/fleet-telemetry \
+  tesla/fleet-telemetry
+```
+
+#### Fleet Telemetry Server Configuration
+
+Below is a working example configuration to place in `/etc/fleet-telemetry/config.json`
+
+Some notes:
+
+* Using a self-signed CA works just fine. Check out <a href="https://easy-rsa.readthedocs.io/en/latest/">easy-rsa</a> for a simple way to achieve this. Just make sure the CN of your server certificate matches the `hostname` in the `config.json`.
+* You can run the server on any TCP port you like
+* If your Telsa connects to your local Wifi network at home, it can stream the telemetry data directly to a server in your local network
+* If you want to use the fleet telemetry during drivers, make sure the telemetry server TCP port is reachable from the public internet
+* The MQTT setting `retained` is used so TWCManager can see which vehicles are sending telemetry data even if they are currently asleep 
+* The Tesla Fleet Telemetry server reference implementation is secured with client TLS certificates. This means only Tesla cars can connect to it. Random internet bots probing your server IP and port will not get past this protection.
+
+
+```
+{
+  "host": "0.0.0.0",
+  "hostname": "telemetry.example.com",
+  "port": 4433,
+  "log_level": "info",
+  "json_log_enable": true,
+  "namespace": "tesla_telemetry",
+  "reliable_ack": false,
+  "monitoring": {
+    "prometheus_metrics_port": 9090,
+    "profiler_port": 4269,
+    "profiling_path": "/tmp/trace.out"
+  },
+  "rate_limit": {
+    "enabled": true,
+    "message_interval_time": 30,
+    "message_limit": 1000
+  },
+  "tls": {
+    "server_cert": "/etc/fleet-telemetry/selfsigned-cert.pem",
+    "server_key": "/etc/fleet-telemetry/selfsigned-key.pem"
+  },
+  "mqtt": {
+    "broker": "192.168.1.2:1883",
+    "client_id": "fleet-telemetry",
+    "username": "mqttuser",
+    "password": "mqttuser",
+    "topic_base": "telemetry",
+    "qos": 1,
+    "retained": true,
+    "connect_timeout_ms": 10000,
+    "publish_timeout_ms": 2500,
+    "disconnect_timeout_ms": 250,
+    "connect_retry_interval_ms": 10000,
+    "keep_alive_seconds": 30
+  },
+  "records": {
+    "alerts": [
+      "mqtt",
+      "logger"
+    ],
+    "errors": [
+      "mqtt",
+      "logger"
+    ],
+    "V": [
+      "mqtt",
+      "logger"
+    ],
+    "connectivity": [
+      "mqtt",
+      "logger"
+    ]
+  }
+}
+```
+
+#### Fleet Telemetry Server Registraton
+Once your Telsa Fleet Telemetry Server is running you need to register it with your car(s). You need a working Tesla vehicle-command HTTP proxy for this. 
+
+TWCManager does not require many data points to function. All data is only sent to the telemetry server when it changes but never more often than the configured `interval_seconds`. You can add more <a href="https://developer.tesla.com/docs/fleet-api/fleet-telemetry/available-data">available data</a> from your car if you need it for other purposes.
+
+Save the config below to `fleet-telemetry-config.json`
+
+* Replace `TESLA_VIN1` and `TESLA_VIN2` with the VIN(s) of your car(s)
+* Replace `hostname` with the hostname of your server (should be resolvable in DNS!)
+* Replace `port` with the TCP port where your server is reachable either inside your local network or on the internet (or preferably both)
+* Replace the certificate in `"ca"` with the certificate of the CA you used. Either self-signed or commercial.
+
+```
+{
+    "vins": [
+        "TESLA_VIN1",
+        "TESLA_VIN2"
+    ],
+    "config": {
+        "hostname": "telemetry.example.com",
+        "port": 4433,
+        "ca": "-----BEGIN CERTIFICATE-----\nMIICETCCAZegAwIBAgIUV6uzlujiD32rb9vQO9jMvk6JWiIwCgYIKoZIzj0EAwIw\nHTEbMBkGA1UEAwwSTW91bnQgS25vd2xlZGdlIENBMB4XDTI1MDMwMTE2MzUyMFoX\nDTQ1MDIyNDE2MzUyMFowHTEbMBkGA1UEAwwSTW91bnQgS25vd2xlZGdlIENBMHYw\nEAYHKoZIzj0CAQYFK4EEACIDYgAEEfUrjGY1irTQfhw4pOINzOiBSaKoGZwFGo+M\nLK7qQNj1jp3dbx65tS53CtIqjDVL+Gmt9EqLAoSnzxtUGjiZi7uFgLfeUOzeP3vX\n4DxeIezfDLgU0NH4KJcDhnZM9ln6o4GXMIGUMAwGA1UdEwQFMAMBAf8wHQYDVR0O\nBBYEFBzwtrkUd6cnUaa+QMs1DHyvW1qbMFgGA1UdIwRRME+AFBzwtrkUd6cnUaa+\nQMs1DHyvW1qboSGkHzAdMRswGQYDVQQDDBJNb3VudCBLbm93bGVkZ2UgQ0GCFFer\ns5bo4g99q2/b0DvYzL5OiVoiMAsGA1UdDwQEAwIBBjAKBggqhkjOPQQDAgNoADBl\nAjEAyblL768SxxDqkNpGKHdn6aO+idhV/3j+eYdktJRJ2avqOT3rbwY8zjj5lXuv\nfFN1AjBnvcQBzIiUG5rLd4itSKl4FQkHMbCkOUNbqBlu8aT9YusMeMsfTq63KSc5\ns142lUE=\n-----END CERTIFICATE-----",
+        "fields": {
+            "BatteryLevel": {
+                "interval_seconds": 60
+            },
+            "ChargeLimitSoc": {
+                "interval_seconds": 60
+            },
+            "DetailedChargeState": {
+                "interval_seconds": 60
+            },
+            "Gear": {
+                "interval_seconds": 60
+            },
+            "VehicleName": {
+                "interval_seconds": 60
+            },
+            "Location": {
+                "interval_seconds": 60
+            },
+            "TimeToFullCharge": {
+                "interval_seconds": 60
+            }
+        }
+    }
+}
+```
+
+Send this configration to the VINs inside it using the <a href="https://developer.tesla.com/docs/fleet-api/endpoints/vehicle-endpoints#fleet-telemetry-config-create">fleet_telemetry_config</a> API endpoint.
+
+Example command:
+
+```
+curl -s -o out.json --cacert proxy.crt --header "Authorization: Bearer $TESLA_AUTH_TOKEN" -H 'Content-Type: application/json' --data @fleet-telemetry-config.json https://localhost:4443/api/1/vehicles/fleet_telemetry_config
+```
+
+#### TWCManager Configuration
+
+```
+   "vehicle": {
+        "teslaFleetTelemetryMQTT": {
+          "enabled": true,
+          "syncTelemetry": true,
+          "mqtt_host": "192.168.1.1",
+          "mqtt_user": "mqttuser",
+          "mqtt_pass": "mqttpass",
+          "mqtt_prefix": "telemetry"
+        },
+```

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -735,6 +735,14 @@
         }
     },
     "vehicle": {
+        "teslaFleetTelemetryMQTT": {
+          "enabled": false,
+          "syncTelemetry": false,
+          "mqtt_host": "192.168.1.1",
+          "mqtt_user": "mqttuser",
+          "mqtt_pass": "mqttpass",
+          "mqtt_prefix": "telemetry"
+        },
         "TeslaMate": {
             "enabled": false,
             "syncTokens": false,

--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -83,6 +83,7 @@ modules_available = [
     "Vehicle.TeslaAPI",
     "Vehicle.TeslaBLE",
     "Vehicle.TeslaMateVehicle",
+    "Vehicle.FleetTelemetryMQTT",
     "Control.WebIPCControl",
     "Control.HTTPControl",
     "Control.MQTTControl",

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -1083,17 +1083,24 @@ class TWCMaster:
         # Removes a module from the modules dict
         # This ensures we do not continue to call the module if it is
         # inoperable
+        deleted = False
         self.releasedModules.append(module)
         if self.modules.get(module, None):
             del self.modules[module]
+            deleted = True
 
+        # Remove from python sys.modules as well
         fullname = path + "." + module
         if modules.get(fullname, None):
             del modules[fullname]
+            deleted = True
 
-        logger.log(
-            logging.INFO7, "Released module %s", module, extra={"colored": "red"}
-        )
+        if deleted:
+            logger.log(
+                logging.INFO7, "Released module %s", module, extra={"colored": "red"}
+            )
+        else:
+            logger.warning("Tried to released module %s that was not loaded", module)
 
     def removeNormalChargeLimit(self, ID):
         if "chargeLimits" in self.settings and str(ID) in self.settings["chargeLimits"]:

--- a/lib/TWCManager/Vehicle/FleetTelemetryMQTT.py
+++ b/lib/TWCManager/Vehicle/FleetTelemetryMQTT.py
@@ -52,15 +52,15 @@ class FleetTelemetryMQTT(TelmetryBase):
         if len(topic) > 3 and topic[2] == "v":
             if topic[3] == "Gear":
                 if payload in (
-                    "ShiftStateR",
-                    "ShiftStateN",
-                    "ShiftStateD",
-                    "ShiftStateSNA",
+                    "R",
+                    "N",
+                    "D",
                 ):
                     self.applyDataToVehicle(topic[1], "syncState", "driving")
                 elif syncState == "driving":
                     self.applyDataToVehicle(topic[1], "syncState", "online")
             elif topic[3] == "DetailedChargeState":
+                self.applyDataToVehicle(topic[1], topic[3], payload)
                 if payload == "DetailedChargeStateCharging":
                     self.applyDataToVehicle(topic[1], "syncState", "charging")
                 elif syncState == "charging":

--- a/lib/TWCManager/Vehicle/FleetTelemetryMQTT.py
+++ b/lib/TWCManager/Vehicle/FleetTelemetryMQTT.py
@@ -1,0 +1,83 @@
+import logging
+import psycopg2
+import paho.mqtt.client as mqtt
+import threading
+import time
+import json
+
+from TWCManager.Vehicle.Telemetry import TelmetryBase
+
+logger = logging.getLogger("\U0001f697 FleetTLM")
+
+
+class FleetTelemetryMQTT(TelmetryBase):
+    configName = "teslaFleetTelemetryMQTT"
+    vehicleNameTopic = "VehicleName"
+    events = {
+        "BatteryLevel": ["batteryLevel", lambda a: int(float(a))],
+        "ChargeLimitSoc": ["chargeLimit", lambda a: int(float(a))],
+        "VehicleName": ["name", lambda a: a],
+        "latitude": ["syncLat", lambda a: float(a)],
+        "longitude": ["syncLon", lambda a: float(a)],
+        "syncState": ["syncState", lambda a: a],
+        "TimeToFullCharge": ["timeToFullCharge", lambda a: float(a)],
+        "ChargeCurrentRequest": ["availableCurrent", lambda a: int(a)],
+        "ChargeAmps": ["actualCurrent", lambda a: float(a)],
+        "ChargerPhases": ["phases", lambda a: int(a) if a else 0],
+        "ChargerVoltage": ["voltage", lambda a: float(a)],
+        "DetailedChargeState": ["chargingState", lambda a: a[19:]],
+    }
+
+    def mqttConnect(self, client, userdata, flags, rc, properties=None):
+        logger.log(logging.INFO5, "MQTT Connected.")
+        logger.log(logging.INFO5, "Subscribe to " + self.mqtt_prefix + "/#")
+        res = self.client.subscribe(self.mqtt_prefix + "/#", qos=1)
+        logger.log(logging.INFO5, "Res: " + str(res))
+
+    def mqttMessage(self, client, userdata, message):
+        topic = str(message.topic).split("/")
+        try:
+            payload = json.loads(message.payload.decode("utf-8"))
+        except json.decoder.JSONDecodeError:
+            logger.warning(f"Can't decode payload {payload} in topic {message.topic}")
+            return
+
+        # Topic format is telemetry/VEHICLE-VIN/v/ChargerVoltage
+        if topic[0] != self.mqtt_prefix:
+            return
+
+        syncState = (
+            self.vehicles[topic[1]].syncState if self.vehicles.get(topic[1]) else ""
+        )
+        if len(topic) > 3 and topic[2] == "v":
+            if topic[3] == "Gear":
+                if payload in (
+                    "ShiftStateR",
+                    "ShiftStateN",
+                    "ShiftStateD",
+                    "ShiftStateSNA",
+                ):
+                    self.applyDataToVehicle(topic[1], "syncState", "driving")
+                elif syncState == "driving":
+                    self.applyDataToVehicle(topic[1], "syncState", "online")
+            elif topic[3] == "DetailedChargeState":
+                if payload == "DetailedChargeStateCharging":
+                    self.applyDataToVehicle(topic[1], "syncState", "charging")
+                elif syncState == "charging":
+                    self.applyDataToVehicle(topic[1], "syncState", "online")
+            elif topic[3] == "Location" and isinstance(payload, dict):
+                if payload.get("latitude"):
+                    self.applyDataToVehicle(topic[1], "latitude", payload["latitude"])
+                if payload.get("longitude"):
+                    self.applyDataToVehicle(topic[1], "longitude", payload["longitude"])
+            else:
+                self.applyDataToVehicle(topic[1], topic[3], payload)
+        elif len(topic) > 2 and topic[2] == "connectivity":
+            status = payload.get("Status")
+            if status == "CONNECTED" and syncState not in (
+                "driving",
+                "charging",
+            ):
+                self.applyDataToVehicle(topic[1], "syncState", "online")
+            elif status == "DISCONNECTED":
+                self.applyDataToVehicle(topic[1], "syncState", "offline")

--- a/lib/TWCManager/Vehicle/Telemetry.py
+++ b/lib/TWCManager/Vehicle/Telemetry.py
@@ -1,0 +1,187 @@
+import logging
+import paho.mqtt.client as mqtt
+import threading
+import time
+
+logger = logging.getLogger("\U0001f697 Telemetry")
+
+
+class TelmetryBase:
+    client = None
+    config = None
+    configConfig = None
+    configModule = None
+    configName = "Telemetry"
+    vehicleNameTopic = "display_name"
+    master = None
+    mqtt_host = None
+    mqtt_user = None
+    mqtt_pass = None
+    mqtt_port = 1883
+    mqtt_prefix = None
+    syncTelemetry = False
+    lastSync = 0
+    status = None
+    vehicles = {}
+    unknownVehicles = {}
+
+    # Empty default events
+    events = {
+        # syntax:
+        # "battery_level": ["batteryLevel", lambda a: int(a)],
+    }
+
+    def __init__(self, master):
+        self.master = master
+
+        self.config = master.config
+        try:
+            self.configConfig = self.config["config"]
+        except KeyError:
+            self.configConfig = {}
+        try:
+            self.configModule = self.config["vehicle"][self.configName]
+            self.status = self.config["vehicle"][self.configName]["enabled"]
+        except KeyError:
+            self.configModule = {}
+
+        # Unload if this module is disabled or misconfigured
+        if not self.status or self.__class__.__name__ == "TelmetryBase":
+            self.master.releaseModule("lib.TWCManager.Vehicle", self.__class__.__name__)
+            return None
+
+        # Configure MQTT parameters
+        self.mqtt_host = self.configModule.get("mqtt_host", None)
+        self.mqtt_user = self.configModule.get("mqtt_user", None)
+        self.mqtt_pass = self.configModule.get("mqtt_pass", None)
+        self.mqtt_prefix = self.configModule.get("mqtt_prefix", None)
+
+        self.syncTelemetry = self.configModule.get("syncTelemetry", False)
+
+        if self.syncTelemetry:
+            # We delay collecting telemetry for a short period
+            # This gives the TeslaAPI module time to connect to the Tesla API
+            # and fetch vehicle information, allowing us to then merge our
+            # telemetry and Tesla API information cleanly
+            logger.log(
+                logging.INFO4, "Telemetry information will be fetched in 30 seconds."
+            )
+            timer = threading.Timer(30, self.doMQTT)
+            timer.start()
+
+    def doMQTT(self):
+        client_name = f"TWC{self.__class__.__name__}"
+        if hasattr(mqtt, "CallbackAPIVersion"):
+            self.client = mqtt.Client(
+                mqtt.CallbackAPIVersion.VERSION2, client_name, protocol=mqtt.MQTTv5
+            )
+        else:
+            self.client = mqtt.Client(client_name)
+        if self.mqtt_user and self.mqtt_pass:
+            self.client.username_pw_set(self.mqtt_user, self.mqtt_pass)
+        self.client.on_connect = self.mqttConnect
+        self.client.on_message = self.mqttMessage
+        self.client.on_subscribe = self.mqttSubscribe
+        self.client.on_disconnect = self.mqttDisconnect
+
+        logger.log(logging.INFO4, "Attempting connection to MQTT Broker")
+
+        try:
+            self.client.connect_async(self.mqtt_host, port=self.mqtt_port, keepalive=30)
+        except ConnectionRefusedError as e:
+            logger.log(logging.INFO4, "Error connecting to MQTT Broker")
+            logger.debug(str(e))
+            return False
+        except OSError as e:
+            logger.log(logging.INFO4, "Error connecting to MQTT Broker")
+            logger.debug(str(e))
+            return False
+
+        self.client.loop_start()
+        threading.Timer(24 * 60 * 60, self.resetMQTT).start()
+
+    def resetMQTT(self):
+        self.client.disconnect()
+        self.client.loop_stop()
+        self.doMQTT()
+
+    def mqttConnect(self, client, userdata, flags, rc, properties=None):
+        logger.log(logging.INFO5, "MQTT Connected.")
+        # No default subscriptions, should be handled by child class
+
+    def mqttDisconnect(self, client, userdata, flags, rc, properties=None):
+        if rc != 0:
+            logger.log(
+                logging.INFO5, "MQTT Disconnected. Should reconnect automatically."
+            )
+
+    def mqttMessage(self, client, userdata, message):
+        # No defaults, should be handled by child class
+        pass
+
+    def applyDataToVehicle(self, id, event, payload):
+        logger.log(logging.INFO8, f"applyDataToVehicle event={event} payload={payload}")
+
+        # Do not try to apply unset event payloads
+        if payload is None:
+            return
+
+        events = self.events
+
+        if event == self.vehicleNameTopic:
+            # We can map the car ID in Telemetry data to the vehicle
+            # in the Tesla API module
+            self.updateVehicles(id, payload)
+            if id in self.unknownVehicles:
+                pastEvents = self.unknownVehicles[id]
+                del self.unknownVehicles[id]
+                for pastEvent in pastEvents:
+                    self.applyDataToVehicle(id, pastEvent[0], pastEvent[1])
+
+        elif event in events:
+            vehicle = self.vehicles.get(id, None)
+            if vehicle:
+                property_name = events[event][0]
+                converter = events[event][1]
+
+                setattr(vehicle, property_name, converter(payload))
+                vehicle.syncTimestamp = time.time()
+
+                # If sync timed out and has recovered, log it
+                if vehicle.syncSource != self.__class__.__name__:
+                    vehicle.syncSource = self.__class__.__name__
+                    logger.info(
+                        f"Vehicle {vehicle.name} telemetry has resumed being provided by {self.__class__.__name__}"
+                    )
+            else:
+                # If we don't know this vehicle yet, save the data.
+                if id not in self.unknownVehicles:
+                    self.unknownVehicles[id] = []
+                self.unknownVehicles[id].append([event, payload])
+
+    def mqttSubscribe(self, client, userdata, mid, reason_codes, properties=None):
+        logger.info("Subscribe operation completed with mid " + str(mid))
+
+    def updateVehicles(self, vehicle_id, vehicle_name):
+        # Called by mqttMessage each time we get the display_name topic
+        # We check to see if this aligns with a vehicle we know of from the API
+
+        vehicle = self.vehicles.get(vehicle_id, None)
+        if vehicle:
+            # We already have this vehicle mapped
+            vehicle.name = vehicle_name
+        else:
+            for apiVehicle in self.master.getModuleByName(
+                "TeslaAPI"
+            ).getCarApiVehicles():
+                if apiVehicle.name == vehicle_name:
+                    # Found a match
+                    self.vehicles[vehicle_id] = apiVehicle
+                    self.vehicles[vehicle_id].syncSource = self.__class__.__name__
+
+                    logger.info(
+                        f"Vehicle {vehicle_name} telemetry being provided by {self.__class__.__name__}"
+                    )
+
+    def updateSettings(self):
+        return True

--- a/lib/TWCManager/Vehicle/TeslaMateVehicle.py
+++ b/lib/TWCManager/Vehicle/TeslaMateVehicle.py
@@ -43,7 +43,7 @@ class TeslaMateVehicle(TelmetryBase):
         self.__db_name = self.configModule.get("db_name", None)
         self.__db_pass = self.configModule.get("db_pass", None)
         self.__db_user = self.configModule.get("db_user", None)
-        self.syncTokens = self.configTeslaMate.get("syncTokens", False)
+        self.syncTokens = self.configModule.get("syncTokens", False)
 
         # If we're set to sync the auth tokens from the database, do this at startup
         if self.syncTokens:

--- a/lib/TWCManager/Vehicle/TeslaMateVehicle.py
+++ b/lib/TWCManager/Vehicle/TeslaMateVehicle.py
@@ -1,33 +1,22 @@
 import logging
 import psycopg2
 import paho.mqtt.client as mqtt
-import _thread
 import threading
 import time
+
+from TWCManager.Vehicle.Telemetry import TelmetryBase
 
 logger = logging.getLogger("\U0001f697 TeslaMate")
 
 
-class TeslaMateVehicle:
+class TeslaMateVehicle(TelmetryBase):
     __db_host = None
     __db_name = None
     __db_pass = None
     __db_user = None
-    __client = None
-    __config = None
-    __configConfig = None
-    __configTeslaMate = None
-    __master = None
-    __mqtt_host = None
-    __mqtt_user = None
-    __mqtt_pass = None
-    __mqtt_port = 1883
-    __mqtt_prefix = None
-    lastSync = 0
-    status = None
-    syncTokens = False
-    vehicles = {}
 
+    configName = "TeslaMate"
+    syncTokens = False
     events = {
         "battery_level": ["batteryLevel", lambda a: int(a)],
         "charge_limit_soc": ["chargeLimit", lambda a: int(a)],
@@ -42,41 +31,19 @@ class TeslaMateVehicle:
         "charger_voltage": ["voltage", lambda a: int(a)],
         "charging_state": ["chargingState", lambda a: str(a)],
     }
-    unknownVehicles = {}
 
     def __init__(self, master):
-        self.__master = master
+        super().__init__(master)
 
-        self.__config = master.config
-        try:
-            self.__configConfig = self.__config["config"]
-        except KeyError:
-            self.__configConfig = {}
-        try:
-            self.__configTeslaMate = self.__config["vehicle"]["TeslaMate"]
-            self.status = self.__config["vehicle"]["TeslaMate"]["enabled"]
-        except KeyError:
-            self.__configTeslaMate = {}
-
-        # Unload if this module is disabled or misconfigured
         if not self.status:
-            self.__master.releaseModule("lib.TWCManager.Vehicle", "TeslaMate")
             return None
 
         # Configure database parameters
-        self.__db_host = self.__configTeslaMate.get("db_host", None)
-        self.__db_name = self.__configTeslaMate.get("db_name", None)
-        self.__db_pass = self.__configTeslaMate.get("db_pass", None)
-        self.__db_user = self.__configTeslaMate.get("db_user", None)
-
-        # Configure MQTT parameters
-        self.__mqtt_host = self.__configTeslaMate.get("mqtt_host", None)
-        self.__mqtt_user = self.__configTeslaMate.get("mqtt_user", None)
-        self.__mqtt_pass = self.__configTeslaMate.get("mqtt_pass", None)
-        self.__mqtt_prefix = self.__configTeslaMate.get("mqtt_prefix", None)
-
-        self.syncTelemetry = self.__configTeslaMate.get("syncTelemetry", False)
-        self.syncTokens = self.__configTeslaMate.get("syncTokens", False)
+        self.__db_host = self.configModule.get("db_host", None)
+        self.__db_name = self.configModule.get("db_name", None)
+        self.__db_pass = self.configModule.get("db_pass", None)
+        self.__db_user = self.configModule.get("db_user", None)
+        self.syncTokens = self.configTeslaMate.get("syncTokens", False)
 
         # If we're set to sync the auth tokens from the database, do this at startup
         if self.syncTokens:
@@ -84,54 +51,6 @@ class TeslaMateVehicle:
 
             # After initial sync, set a timer to continue to sync the tokens every hour
             resync = threading.Timer(3600, self.doSyncTokens)
-
-        if self.syncTelemetry:
-            # We delay collecting TeslaMate telemetry for a short period
-            # This gives the TeslaAPI module time to connect to the Tesla API
-            # and fetch vehicle information, allowing us to then merge our
-            # TeslaMate and Tesla API information cleanly
-            logger.log(
-                logging.INFO4, "Telemetry information will be fetched in 30 seconds."
-            )
-            timer = threading.Timer(30, self.doMQTT)
-            timer.start()
-
-    def doMQTT(self):
-        if hasattr(mqtt, "CallbackAPIVersion"):
-            self.__client = mqtt.Client(
-                mqtt.CallbackAPIVersion.VERSION2, "TWCTeslaMate", protocol=mqtt.MQTTv5
-            )
-        else:
-            self.__client = mqtt.Client("TWCTeslaMate")
-        if self.__mqtt_user and self.__mqtt_pass:
-            self.__client.username_pw_set(self.__mqtt_user, self.__mqtt_pass)
-        self.__client.on_connect = self.mqttConnect
-        self.__client.on_message = self.mqttMessage
-        self.__client.on_subscribe = self.mqttSubscribe
-        self.__client.on_disconnect = self.mqttDisconnect
-
-        logger.log(logging.INFO4, "Attempting connection to MQTT Broker")
-
-        try:
-            self.__client.connect_async(
-                self.__mqtt_host, port=self.__mqtt_port, keepalive=30
-            )
-        except ConnectionRefusedError as e:
-            logger.log(logging.INFO4, "Error connecting to MQTT Broker")
-            logger.debug(str(e))
-            return False
-        except OSError as e:
-            logger.log(logging.INFO4, "Error connecting to MQTT Broker")
-            logger.debug(str(e))
-            return False
-
-        self.__client.loop_start()
-        threading.Timer(24 * 60 * 60, self.resetMQTT).start()
-
-    def resetMQTT(self):
-        self.__client.disconnect()
-        self.__client.loop_stop()
-        self.doMQTT()
 
     def doSyncTokens(self, firstrun=False):
         # Connect to TeslaMate database and synchronize API tokens
@@ -169,7 +88,7 @@ class TeslaMateVehicle:
                 result = cur.fetchone()
 
                 # Set Bearer and Refresh Tokens
-                carapi = self.__master.getModuleByName("TeslaAPI")
+                carapi = self.master.getModuleByName("TeslaAPI")
                 # We don't want to refresh the token - let the source handle that.
                 carapi.setCarApiTokenExpireTime(99999 * 99999 * 99999)
                 carapi.setCarApiBearerToken(result[0])
@@ -200,20 +119,14 @@ class TeslaMateVehicle:
     def mqttConnect(self, client, userdata, flags, rc, properties=None):
         logger.log(logging.INFO5, "MQTT Connected.")
         subscription = "teslamate/"
-        if self.__mqtt_prefix:
-            subscription += self.__mqtt_prefix + "/"
+        if self.mqtt_prefix:
+            subscription += self.mqtt_prefix + "/"
         subscription += "cars/+/"
         for topic in self.events.keys():
             topic = subscription + topic
             logger.log(logging.INFO5, "Subscribe to " + topic)
-            res = client.subscribe(topic, qos=0)
+            res = client.subscribe(topic, qos=1)
             logger.log(logging.INFO5, "Res: " + str(res))
-
-    def mqttDisconnect(self, client, userdata, flags, rc, properties=None):
-        if rc != 0:
-            logger.log(
-                logging.INFO5, "MQTT Disconnected. Should reconnect automatically."
-            )
 
     def mqttMessage(self, client, userdata, message):
         topic = str(message.topic).split("/")
@@ -221,77 +134,9 @@ class TeslaMateVehicle:
 
         if len(topic) > 4:
             prefix = topic[1:-3].join("/")
-            if prefix != self.__mqtt_prefix:
+            if prefix != self.mqtt_prefix:
                 return
             topic = [topic[0]] + topic[-3:]
 
         if topic[0] == "teslamate" and topic[1] == "cars":
             self.applyDataToVehicle(topic[2], topic[3], payload)
-
-    def applyDataToVehicle(self, id, event, payload):
-        events = self.events
-
-        if event == "display_name":
-            # We can map the car ID in TeslaMate to the vehicle
-            # in the Tesla API module
-            self.updateVehicles(id, payload)
-            if id in self.unknownVehicles:
-                pastEvents = self.unknownVehicles[id]
-                del self.unknownVehicles[id]
-                for pastEvent in pastEvents:
-                    self.applyDataToVehicle(id, pastEvent[0], pastEvent[1])
-
-        elif event in events:
-            vehicle = self.vehicles.get(id, None)
-            if vehicle:
-                property_name = events[event][0]
-                converter = events[event][1]
-
-                setattr(vehicle, property_name, converter(payload))
-                vehicle.syncTimestamp = time.time()
-
-                # If sync timed out and has recovered, log it
-                if vehicle.syncSource != "TeslaMateVehicle":
-                    vehicle.syncSource = "TeslaMateVehicle"
-                    logger.info(
-                        "Vehicle "
-                        + vehicle.name
-                        + " telemetry has resumed being provided by TeslaMate"
-                    )
-            else:
-                # If we don't know this vehicle yet, save the data.
-                if id not in self.unknownVehicles:
-                    self.unknownVehicles[id] = []
-                self.unknownVehicles[id].append([event, payload])
-
-        else:
-            pass
-
-    def mqttSubscribe(self, client, userdata, mid, reason_codes, properties=None):
-        logger.info("Subscribe operation completed with mid " + str(mid))
-
-    def updateVehicles(self, vehicle_id, vehicle_name):
-        # Called by mqttMessage each time we get the display_name topic
-        # We check to see if this aligns with a vehicle we know of from the API
-
-        vehicle = self.vehicles.get(vehicle_id, None)
-        if vehicle:
-            # We already have this vehicle mapped
-            vehicle.name = vehicle_name
-        else:
-            for apiVehicle in self.__master.getModuleByName(
-                "TeslaAPI"
-            ).getCarApiVehicles():
-                if apiVehicle.name == vehicle_name:
-                    # Found a match
-                    self.vehicles[vehicle_id] = apiVehicle
-                    self.vehicles[vehicle_id].syncSource = "TeslaMateVehicle"
-
-                    logger.info(
-                        "Vehicle "
-                        + vehicle_name
-                        + " telemetry being provided by TeslaMate"
-                    )
-
-    def updateSettings(self):
-        return True


### PR DESCRIPTION
This module allows to receive vehicle data from a Tesla Fleet Telemetry server instead of polling the `vehicle_data` endpoint.