### PR TITLE
Set syncState to online for every received metric

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1434,7 +1434,9 @@ class CarApiVehicle:
 
     # Permits opportunistic API requests
     def is_awake(self):
-        if self.syncSource == "TeslaAPI":
+        if self.syncSource == "TeslaAPI" or self.syncTimestamp < (
+            time.time() - self.syncTimeout / 4
+        ):
             url = self.carapi.getCarApiBaseURL() + "/" + str(self.VIN)
             (result, response) = self.get_car_api(
                 url, checkReady=False, provesOnline=False


### PR DESCRIPTION
The connectivity messages of Fleet Telemetry sometimes leaves the `syncState` set to `offline` while the datasteam is still active. I solved this by setting the `syncState` to `online` every time a message is received. Now the `syncState` is not marked `offline` when it is actually not.

Also, it makes sense for `is_awake()` to fall back to polling the API when the `syncSource` is silent. This allows for the scenario where the local Fleet Telemetry server (or Teslamate) has becomes unavailable while the vehicle is offline. `is_awake()` will now notice the vehicle is online and then the `syncTimeout` will make sure TWCManager falls back to polling the API until the `syncSource` comes back up.