### PR TITLE
Avoid wake up loop during battery health check (soh test)

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -309,7 +309,7 @@ class TeslaAPI:
                         )
                         continue
 
-                    if self.getCarApiRetryRemaining():
+                    if self.getCarApiRetryRemaining(vehicle):
                         # It's been under carApiErrorRetryMins minutes since the car
                         # API generated an error on this vehicle. Don't send it more
                         # commands yet.
@@ -461,14 +461,18 @@ class TeslaAPI:
 
                         if state == "error":
                             logger.info(
-                                "Car API wake car failed with unknown response.  "
+                                "Car API wake "
+                                + vehicle.name
+                                + " failed with unknown response.  "
                                 + "Will try again in "
                                 + str(vehicle.delayNextWakeAttempt)
                                 + " seconds."
                             )
                         else:
                             logger.info(
-                                "Car API wake car failed.  State remains: '"
+                                "Car API wake "
+                                + vehicle.name
+                                + " failed.  State remains: '"
                                 + state
                                 + "'.  Will try again in "
                                 + str(vehicle.delayNextWakeAttempt)
@@ -482,7 +486,9 @@ class TeslaAPI:
                         # It should never take over an hour to wake a car.  If it
                         # does, ask user to report an error.
                         logger.info(
-                            "ERROR: We have failed to wake a car from '"
+                            "ERROR: We have failed to wake "
+                            + vehicle.name
+                            + " from '"
                             + state
                             + "' state for %.1f hours.\n"
                             "Please file an issue at https://github.com/ngardiner/TWCManager/. "
@@ -1209,7 +1215,7 @@ class TeslaAPI:
 
     def setChargeRate(self, charge_rate, vehicle=None, set_again=False):
         # As a fallback to allow initial implementation of the charge rate functionality for single car installs,
-        # If no vehcle is specified, we take the first returned to us.
+        # If no vehicle is specified, we take the first returned to us.
 
         if not vehicle:
             vehicle = self.getCarApiVehicles()[0]


### PR DESCRIPTION
I ran a battery health check yesterday. A requirement is to be connected to a changer with a minimum of 5 kW power. The test starts with discharging the battery. This confuses TWCManager: it tries to start the charge but the start command receives this error as a response:

```
2025-10-31 22:08:51,662 - 🚗 TeslaAPI 20 ERROR "High energy features disabled during soh test" when trying to start car charging via Tesla car API.  Will try again later.
```

This error causes `vehicle.lastErrorTime` to be set and `vehicle.ready()` to return False.

However, TWCManager still tried to wake the car every 5 seconds:

```
2025-10-31 22:11:49,628 - 🚗 TeslaAPI 13 Car API cmd wake_up<Response [200]>
2025-10-31 22:11:55,739 - 🚗 TeslaAPI 13 Car API cmd wake_up<Response [200]>
2025-10-31 22:12:01,851 - 🚗 TeslaAPI 13 Car API cmd wake_up<Response [200]>
2025-10-31 22:12:07,870 - 🚗 TeslaAPI 13 Car API cmd wake_up<Response [200]>
2025-10-31 22:12:14,028 - 🚗 TeslaAPI 13 Car API cmd wake_up<Response [200]>
```

The wake up call is a charged Tesla Fleet API endpoint, so that turned out to be pretty expensive.

I think this can be avoided to call `self.getCarApiRetryRemaining` with the `vehicle` parameter. This will take into account the `vehicle.lastErrorTime` and backoff the wake up calls.