### PR TITLE
Add Tesla FleetAPI OAuth web login flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This document logs the changes per release of TWCManager.
 ## v1.4.0 - Upcoming
 
 * Bugfixes
+    * Fix: Remove cryptography<3.4 upper bound; modern versions ship binary wheels and the Rust build requirement is no longer a concern (closes #647)
     * Fix: RS485 read returns empty bytes after reconnect instead of None, preventing crash on socket disconnect (closes #461)
     * Fix: Stop flooding VIN queries when non-Tesla vehicle or CAN-disabled TWC returns all-zero VIN data (closes #296)
     * Fix: WebIPCControl recovers from ExistentialError when IPC queue is removed at runtime (closes #192)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This document logs the changes per release of TWCManager.
     * Fix: Cast numeric strings from settings in policyValue() so non-scheduled charge rate is applied correctly (closes #370)
 * Features
     * Add MQTT control topics for nonScheduledAmpsMax and nonScheduledAction to allow policy control via MQTT (closes #475)
+    * (@ngardiner) - FleetAPI OAuth web login flow with auto-capture callback and paste-back, replacing the retired Owner API login
 * Architecture
     * Remove retired Tesla Owner API support (owner-api endpoints, ownerapi web login flow); FleetAPI, TeslaMate token sync, manual token entry and BLE remain the supported paths
 * Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ This document logs the changes per release of TWCManager.
     * Fix: Publish charger_load_w status on every heartbeat so Home Assistant entities don't disappear after HA reboot (closes #462)
     * Fix: Log a warning at startup when minAmpsPerTWC exceeds wiringMaxAmpsPerTWC, which would prevent charging from ever starting (closes #24)
     * Fix: Set stopAskingToStartCharging=True when a vehicle departs home, preventing unnecessary wake attempts on absent vehicles (closes #590)
+    * Fix: Trust TeslaMate asleep/offline state in is_awake() to avoid Fleet API status polls when vehicle is confirmed sleeping
+    * Fix: Fleet API wake minimization - 3-minute pre-wake delay (configurable wakeDelayMins), 30-minute retry backoff, no API polls during hold windows
 
 * Architecture
     * (@MikeBishop) TWC abstraction layer - EVSEController/EVSEInstance interface ported from #483 (@MikeBishop). Gen2 TWC slaves, Tesla API vehicles, and future EVSE types are now managed through a unified interface:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This document logs the changes per release of TWCManager.
 
 * Bugfixes
     * Fix: Remove stopAskingToStartCharging heartbeat reset that caused charge_start API commands to fire every 60 seconds while already charging (re-opens #575, closes #651)
+    * Fix: Remove redundant car_api_available() call at applyChargeLimit entry - rate limit check now runs first, halving Fleet API calls on every policy tick
+    * Fix: VehiclePriority now treats TeslaAPI "error" string return as failure, enabling correct fallback to BLE and failure stat tracking
+    * Fix: update_location(minInterval) now honours the cache interval argument, preventing duplicate vehicle_data API calls per charge cycle
     * Fix: Remove cryptography<3.4 upper bound; modern versions ship binary wheels and the Rust build requirement is no longer a concern (closes #647)
     * Fix: RS485 read returns empty bytes after reconnect instead of None, preventing crash on socket disconnect (closes #461)
     * Fix: Stop flooding VIN queries when non-Tesla vehicle or CAN-disabled TWC returns all-zero VIN data (closes #296)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This document logs the changes per release of TWCManager.
     * Fix: Cast numeric strings from settings in policyValue() so non-scheduled charge rate is applied correctly (closes #370)
 * Features
     * Add MQTT control topics for nonScheduledAmpsMax and nonScheduledAction to allow policy control via MQTT (closes #475)
-    * (@ngardiner) - FleetAPI OAuth web login flow with auto-capture callback and paste-back, replacing the retired Owner API login
+    * (@ngardiner) - FleetAPI Authorization Code web login (PKCE by default, optional client-secret flow), with auto-capture callback and paste-back, replacing the retired Owner API login
 * Architecture
     * Remove retired Tesla Owner API support (owner-api endpoints, ownerapi web login flow); FleetAPI, TeslaMate token sync, manual token entry and BLE remain the supported paths
 * Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This document logs the changes per release of TWCManager.
 ## v1.4.0 - Upcoming
 
 * Bugfixes
+    * Fix: Remove stopAskingToStartCharging heartbeat reset that caused charge_start API commands to fire every 60 seconds while already charging (re-opens #575, closes #651)
     * Fix: Remove cryptography<3.4 upper bound; modern versions ship binary wheels and the Rust build requirement is no longer a concern (closes #647)
     * Fix: RS485 read returns empty bytes after reconnect instead of None, preventing crash on socket disconnect (closes #461)
     * Fix: Stop flooding VIN queries when non-Tesla vehicle or CAN-disabled TWC returns all-zero VIN data (closes #296)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@
 ![Screenshot](docs/screenshot.png)
 ![Screenshot](docs/screenshot4.png)
 
+## Tesla API
+
+Tesla is actively deprecating the Owner API in favour of Fleet API, with ongoing changes affecting vehicle control. TWCManager reflects this with two active 1.3.x tracks:
+
+- **Stable (1.3.3):** Owner API based. Works today, but Tesla is phasing this out - new users should plan accordingly.
+- **Fleet API (1.3.4):** Fleet API based. Tesla's supported path going forward.
+
+See [Choosing a version](docs/README.md#choosing-a-version) for guidance on which to use.
+
 ## How it works
 
 * In order to allow multiple Tesla Wall Connector (TWC) units to operate on a single power circuit, Tesla provides a Load-Sharing protocol to interconnect the Tesla Wall Connector units together, and to direct those units to charge at a specific rate based on the number of cars charging simtultaneously.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,18 @@
 # TWCManager Documentation
 
+## Choosing a Version
+
+Tesla is actively deprecating the Owner API in favour of Fleet API, with ongoing changes that affect how vehicle control works. TWCManager has two active 1.3.x tracks:
+
+| Track | Vehicle control |
+| ----- | --------------- |
+| **Stable (1.3.3)** | Owner API - works today, but Tesla is phasing this out |
+| **Fleet API (1.3.4)** | Fleet API (requires a registered app) or TeslaBLE |
+
+- **New users:** the Fleet API track (1.3.4) is the direction of travel. Starting there avoids a forced migration when Tesla eventually removes Owner API access.
+- **Existing stable users:** your installation continues to work. Plan to migrate as Tesla continues to phase out the Owner API.
+- **No Tesla account?** [TeslaBLE](modules/Vehicle_TeslaBLE.md) is available on both tracks and requires no cloud credentials.
+
 ## Having Trouble?
 
 If you're having trouble getting TWCManager working, check out our [Troubleshooting Guide](Troubleshooting.md) to see if any of our tips help you out!

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,7 +92,7 @@ In an upcoming release, this will be offered as a switchable option to replace t
       
       * Use the Tesla API to connect to the car, sending a command to stop/start charging.
 
-This requires a Tesla API token, which is stored locally within a settings file. Tesla retired the legacy Owner API, so cloud control now requires a registered FleetAPI app (see the Vehicle module docs), TeslaMate token sync, or pasting a token into the Settings page. Local BLE control (TeslaBLE) is also available and needs no cloud token.
+This requires a Tesla API token, which is stored locally within a settings file. Tesla retired the legacy Owner API, so cloud control now requires a registered FleetAPI app (see the [Tesla FleetAPI setup guide](modules/Vehicle_TeslaAPI.md)), TeslaMate token sync, or pasting a token into the Settings page. Local BLE control (TeslaBLE) is also available and needs no cloud token.
 
 If you have multiple cars, TWCManager will attempt to identify which cars are home using geofencing. The following page of the TMC forums thread explains it better than I could: https://teslamotorsclub.com/tmc/threads/new-wall-connector-load-sharing-protocol.72830/page-16
 

--- a/docs/modules/Vehicle_TeslaAPI.md
+++ b/docs/modules/Vehicle_TeslaAPI.md
@@ -13,8 +13,9 @@ locally over Bluetooth and needs no Tesla account.
 ## Prerequisites
 
 - A Tesla account that owns the vehicle(s).
-- An application registered at https://developer.tesla.com (provides a client ID and
-  client secret).
+- An application registered at https://developer.tesla.com with the **Authorization
+  Code (Third-Party Tokens)** grant type (provides a client ID; a client secret is also
+  issued but the default PKCE login does not use it).
 - For sending commands to vehicles built after 2021, the Tesla Vehicle Command proxy.
   See [the proxy](https://github.com/teslamotors/vehicle-command) and the `teslaProxy`
   / `teslaProxyCert` options in config.json. Partner account registration and hosting
@@ -23,11 +24,16 @@ locally over Bluetooth and needs no Tesla account.
 ## Registering your application
 
 1. Sign in at https://developer.tesla.com and create an application.
-2. Note the generated **client ID** and **client secret**.
-3. Set the **allowed scopes** to include charging control and vehicle data, e.g.
-   `vehicle_device_data`, `vehicle_cmds`, `vehicle_charging_cmds` (plus `openid` and
-   `offline_access`).
-4. Add an **allowed origin** and one or more **redirect URIs**. Tesla ties the app to
+2. For the **OAuth grant type**, choose **Authorization Code (Third-Party Tokens)**.
+   This is the user-authorization flow TWCManager uses. Do **not** choose **Client
+   Credentials (Partner Tokens)** - that is for partner/machine tokens and does not log
+   a user in.
+3. Note the generated **client ID**. A **client secret** is also generated, but the
+   default login does not use it (see Auth methods below).
+4. Set the **allowed scopes** to include charging control, vehicle data and location,
+   e.g. `vehicle_device_data`, `vehicle_cmds`, `vehicle_charging_cmds`,
+   `vehicle_location` (plus `openid` and `offline_access`).
+5. Add an **allowed origin** and one or more **redirect URIs**. Tesla ties the app to
    a **public HTTPS domain you control** (the allowed origin) - this is the domain
    where Tesla fetches your public key from
    `https://<domain>/.well-known/appspecific/com.tesla.3p.public-key.pem` during the
@@ -50,6 +56,19 @@ locally over Bluetooth and needs no Tesla account.
      Tesla returns the browser to that URL and login completes with no copy/paste.
      This still must not be a TWCManager instance published openly to the internet.
 
+## Auth methods (PKCE vs client secret)
+
+The Authorization Code flow can be completed two ways. TWCManager picks automatically
+based on whether you configure a client secret:
+
+- **PKCE (default, recommended).** No client secret. TWCManager proves the request with
+  a PKCE code challenge and exchanges the code at `auth.tesla.com`. The account region
+  is derived from the returned token, so you don't need to set it. This is what most
+  registered apps use. Just set `teslaApiClientID` and `teslaApiRedirectUri`.
+- **Client secret (optional/advanced).** If you set `teslaApiClientSecret`, TWCManager
+  instead sends the secret plus a regional `audience` and exchanges the code at the
+  regional `fleet-auth` endpoint. This also requires `teslaApiRegion`.
+
 ## Configuration
 
 Set the following in the `config` section of `config.json`:
@@ -57,19 +76,20 @@ Set the following in the `config` section of `config.json`:
 | Key | Required | Description |
 |-----|----------|-------------|
 | `teslaApiClientID` | Yes | Client ID of your registered application |
-| `teslaApiClientSecret` | Yes | Client secret of your registered application |
 | `teslaApiRedirectUri` | Yes | Redirect URI, exactly matching one registered on the app (under your public domain - not TWCManager's address) |
-| `teslaApiRegion` | No | Account region: `NA` (default), `EU` or `CN` |
+| `teslaApiClientSecret` | No | Only to force the client-secret exchange instead of PKCE (advanced) |
+| `teslaApiRegion` | No | Only used with `teslaApiClientSecret`: `NA` (default), `EU` or `CN` |
 | `teslaApiScope` | No | Override the requested OAuth scopes |
 
-Keep `config.json` readable only by the `twcmanager` user, as it holds the client
-secret.
+If you do set `teslaApiClientSecret`, keep `config.json` readable only by the
+`twcmanager` user.
 
 ## Logging in
 
 1. Open the TWCManager web UI. When no token is stored, the home page shows a Tesla
    login section.
-2. Choose your account region and click **Log in to Tesla**.
+2. Click **Log in to Tesla** (with PKCE there is no region to choose; the client-secret
+   method shows a region selector first).
 3. Approve access in the Tesla consent page.
 4. Completion:
    - Paste-back (typical): copy the full URL you were redirected to from your browser's
@@ -89,8 +109,8 @@ rotated on each refresh and persisted to the settings file).
 
 ## Troubleshooting
 
-- "Tesla FleetAPI is not configured": one of `teslaApiClientID`,
-  `teslaApiClientSecret` or `teslaApiRedirectUri` is missing.
+- "Tesla FleetAPI is not configured": `teslaApiClientID` or `teslaApiRedirectUri` is
+  missing (the client secret is optional).
 - "state mismatch": the login was started too long ago or in another browser session.
   Start the login again.
 - A Tesla error code on the result page usually indicates a mismatch between the

--- a/docs/modules/Vehicle_TeslaAPI.md
+++ b/docs/modules/Vehicle_TeslaAPI.md
@@ -27,13 +27,28 @@ locally over Bluetooth and needs no Tesla account.
 3. Set the **allowed scopes** to include charging control and vehicle data, e.g.
    `vehicle_device_data`, `vehicle_cmds`, `vehicle_charging_cmds` (plus `openid` and
    `offline_access`).
-4. Add an **allowed origin** and one or more **redirect URIs**. The redirect URI must
-   match exactly what TWCManager sends. Two options:
-   - Auto-capture: register the callback on your TWCManager instance, e.g.
-     `https://your-twcmanager-host/teslaAccount/callback`. Tesla returns the browser
-     to TWCManager and login completes with no copy/paste.
-   - Paste-back: register any redirect URI you control. After login you copy the URL
-     you were redirected to and paste it into TWCManager.
+4. Add an **allowed origin** and one or more **redirect URIs**. Tesla ties the app to
+   a **public HTTPS domain you control** (the allowed origin) - this is the domain
+   where Tesla fetches your public key from
+   `https://<domain>/.well-known/appspecific/com.tesla.3p.public-key.pem` during the
+   partner/Vehicle Command setup. It **cannot be `localhost` or a LAN IP**, and it is
+   **not** TWCManager's own address. The redirect URI must be HTTPS, registered in
+   advance, and sit under that same domain; TWCManager must send it back exactly.
+
+   > **Do not expose TWCManager directly to the internet.** It controls your charger
+   > and has minimal authentication. The redirect domain is a domain you own; it does
+   > not need to reach TWCManager at all (see paste-back below).
+
+   Two ways to receive the authorization code:
+   - **Paste-back (recommended).** Register any redirect URI under your domain - it can
+     point at a static page or somewhere TWCManager can't see. After approving access
+     you copy the URL from your browser's address bar and paste it into TWCManager.
+     No inbound exposure of TWCManager is required.
+   - **Auto-capture (advanced).** Only if you already run a reverse proxy you control
+     that terminates HTTPS and forwards `/teslaAccount/callback` to TWCManager on your
+     LAN (e.g. `https://twc.yourdomain.com/teslaAccount/callback` -> `192.168.x.y:8080`).
+     Tesla returns the browser to that URL and login completes with no copy/paste.
+     This still must not be a TWCManager instance published openly to the internet.
 
 ## Configuration
 
@@ -43,7 +58,7 @@ Set the following in the `config` section of `config.json`:
 |-----|----------|-------------|
 | `teslaApiClientID` | Yes | Client ID of your registered application |
 | `teslaApiClientSecret` | Yes | Client secret of your registered application |
-| `teslaApiRedirectUri` | Yes | Redirect URI, matching one registered on the app |
+| `teslaApiRedirectUri` | Yes | Redirect URI, exactly matching one registered on the app (under your public domain - not TWCManager's address) |
 | `teslaApiRegion` | No | Account region: `NA` (default), `EU` or `CN` |
 | `teslaApiScope` | No | Override the requested OAuth scopes |
 
@@ -57,10 +72,10 @@ secret.
 2. Choose your account region and click **Log in to Tesla**.
 3. Approve access in the Tesla consent page.
 4. Completion:
-   - Auto-capture: if your redirect URI points at this instance, you are returned
-     automatically and the tokens are stored.
-   - Paste-back: copy the full URL you were redirected to and paste it into the box,
-     then click **Save Token**.
+   - Paste-back (typical): copy the full URL you were redirected to from your browser's
+     address bar and paste it into the box, then click **Save Token**.
+   - Auto-capture: only if your redirect URI is served by a reverse proxy that forwards
+     to TWCManager, you are returned automatically and the tokens are stored.
 
 Once tokens are stored, TWCManager refreshes them automatically (the refresh token is
 rotated on each refresh and persisted to the settings file).

--- a/docs/modules/Vehicle_TeslaAPI.md
+++ b/docs/modules/Vehicle_TeslaAPI.md
@@ -91,6 +91,7 @@ Set the following in the `config` section of `config.json`:
 | `teslaApiClientSecret` | No | Only to force the client-secret exchange instead of PKCE (advanced) |
 | `teslaApiRegion` | No | Only used with `teslaApiClientSecret`: `NA` (default), `EU` or `CN` |
 | `teslaApiScope` | No | Override the requested OAuth scopes |
+| `wakeDelayMins` | No | Minutes to wait before sending a Fleet API wake command (default: 3). During the delay the car may self-start from the TWC power offer. Set to 0 to wake immediately. |
 
 If you do set `teslaApiClientSecret`, keep `config.json` readable only by the
 `twcmanager` user.

--- a/docs/modules/Vehicle_TeslaAPI.md
+++ b/docs/modules/Vehicle_TeslaAPI.md
@@ -2,13 +2,23 @@
 
 ## Introduction
 
-TWCManager uses the Tesla FleetAPI to read vehicle state (state of charge, location)
-and to start, stop and rate-limit charging for Tesla vehicles you own.
+TWCManager exists to **drive charging** - it starts, stops and rate-limits your
+vehicle. The Tesla FleetAPI login covered here provides the cloud connection used to
+read vehicle state (state of charge, location, online status) for policy and home
+geofencing, and to issue charge commands.
 
-Tesla retired the legacy Owner API, so cloud control now requires you to register
+> **Important: FleetAPI login alone cannot drive charging.** Tesla now requires the
+> **Vehicle Command Protocol** for charge commands on essentially all vehicles - the
+> legacy REST charge endpoints return `403 "Tesla Vehicle Command Protocol required"`.
+> So to actually control charging you must **also** run the Tesla Vehicle Command proxy
+> (set `teslaProxy`) **or** use the local [TeslaBLE](Vehicle_TeslaBLE.md) module. The
+> login + tokens give you data and authentication; the proxy or BLE give you control.
+> See [Driving charging](#driving-charging-proxy-or-ble) below.
+
+Tesla retired the legacy Owner API, so cloud access now requires you to register
 your own application with Tesla and complete an OAuth login. If you would rather not
-register an application, the [TeslaBLE](Vehicle_TeslaBLE.md) module controls charging
-locally over Bluetooth and needs no Tesla account.
+register an application at all, TeslaBLE controls charging locally over Bluetooth and
+needs no Tesla account.
 
 ## Prerequisites
 
@@ -16,10 +26,11 @@ locally over Bluetooth and needs no Tesla account.
 - An application registered at https://developer.tesla.com with the **Authorization
   Code (Third-Party Tokens)** grant type (provides a client ID; a client secret is also
   issued but the default PKCE login does not use it).
-- For sending commands to vehicles built after 2021, the Tesla Vehicle Command proxy.
-  See [the proxy](https://github.com/teslamotors/vehicle-command) and the `teslaProxy`
-  / `teslaProxyCert` options in config.json. Partner account registration and hosting
-  your public key are part of that proxy setup and are not handled by TWCManager.
+- **To drive charging (required):** the Tesla Vehicle Command proxy **or** the TeslaBLE
+  module. Tesla's REST charge commands are deprecated and now return
+  `403 "Tesla Vehicle Command Protocol required"` on essentially all vehicles (confirmed
+  even on a 2019 Model 3), so FleetAPI by itself reads data but cannot start/stop charge.
+  See [Driving charging](#driving-charging-proxy-or-ble).
 
 ## Registering your application
 
@@ -99,6 +110,27 @@ If you do set `teslaApiClientSecret`, keep `config.json` readable only by the
 
 Once tokens are stored, TWCManager refreshes them automatically (the refresh token is
 rotated on each refresh and persisted to the settings file).
+
+## Driving charging (proxy or BLE)
+
+Logging in gets you a token and lets TWCManager **read** vehicle state. To actually
+**start, stop and rate-limit charging** - the reason TWCManager exists - you need one of:
+
+- **Tesla Vehicle Command proxy.** Run the
+  [vehicle-command](https://github.com/teslamotors/vehicle-command) HTTP proxy, which
+  signs commands with your app key, and point TWCManager at it with `teslaProxy`
+  (HTTPS URL) and `teslaProxyCert`. TWCManager then sends charge commands through the
+  proxy instead of the deprecated REST endpoints. Partner-account registration and
+  hosting your public key at `/.well-known/appspecific/com.tesla.3p.public-key.pem` are
+  prerequisites of that proxy setup (the same key/domain used for Fleet Telemetry), not
+  handled by TWCManager.
+- **TeslaBLE.** Control charging locally over Bluetooth with no proxy and no cloud
+  command path. See [TeslaBLE](Vehicle_TeslaBLE.md).
+
+Without one of these, charge commands fail with
+`403 "Tesla Vehicle Command Protocol required"` and TWCManager logs a clear error and
+stops retrying (it will still read state via the FleetAPI). FleetAPI data + (proxy or
+BLE) control is the intended, complete configuration.
 
 ## Alternatives to the web login
 

--- a/docs/modules/Vehicle_TeslaAPI.md
+++ b/docs/modules/Vehicle_TeslaAPI.md
@@ -1,0 +1,83 @@
+# Tesla FleetAPI Integration
+
+## Introduction
+
+TWCManager uses the Tesla FleetAPI to read vehicle state (state of charge, location)
+and to start, stop and rate-limit charging for Tesla vehicles you own.
+
+Tesla retired the legacy Owner API, so cloud control now requires you to register
+your own application with Tesla and complete an OAuth login. If you would rather not
+register an application, the [TeslaBLE](Vehicle_TeslaBLE.md) module controls charging
+locally over Bluetooth and needs no Tesla account.
+
+## Prerequisites
+
+- A Tesla account that owns the vehicle(s).
+- An application registered at https://developer.tesla.com (provides a client ID and
+  client secret).
+- For sending commands to vehicles built after 2021, the Tesla Vehicle Command proxy.
+  See [the proxy](https://github.com/teslamotors/vehicle-command) and the `teslaProxy`
+  / `teslaProxyCert` options in config.json. Partner account registration and hosting
+  your public key are part of that proxy setup and are not handled by TWCManager.
+
+## Registering your application
+
+1. Sign in at https://developer.tesla.com and create an application.
+2. Note the generated **client ID** and **client secret**.
+3. Set the **allowed scopes** to include charging control and vehicle data, e.g.
+   `vehicle_device_data`, `vehicle_cmds`, `vehicle_charging_cmds` (plus `openid` and
+   `offline_access`).
+4. Add an **allowed origin** and one or more **redirect URIs**. The redirect URI must
+   match exactly what TWCManager sends. Two options:
+   - Auto-capture: register the callback on your TWCManager instance, e.g.
+     `https://your-twcmanager-host/teslaAccount/callback`. Tesla returns the browser
+     to TWCManager and login completes with no copy/paste.
+   - Paste-back: register any redirect URI you control. After login you copy the URL
+     you were redirected to and paste it into TWCManager.
+
+## Configuration
+
+Set the following in the `config` section of `config.json`:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `teslaApiClientID` | Yes | Client ID of your registered application |
+| `teslaApiClientSecret` | Yes | Client secret of your registered application |
+| `teslaApiRedirectUri` | Yes | Redirect URI, matching one registered on the app |
+| `teslaApiRegion` | No | Account region: `NA` (default), `EU` or `CN` |
+| `teslaApiScope` | No | Override the requested OAuth scopes |
+
+Keep `config.json` readable only by the `twcmanager` user, as it holds the client
+secret.
+
+## Logging in
+
+1. Open the TWCManager web UI. When no token is stored, the home page shows a Tesla
+   login section.
+2. Choose your account region and click **Log in to Tesla**.
+3. Approve access in the Tesla consent page.
+4. Completion:
+   - Auto-capture: if your redirect URI points at this instance, you are returned
+     automatically and the tokens are stored.
+   - Paste-back: copy the full URL you were redirected to and paste it into the box,
+     then click **Save Token**.
+
+Once tokens are stored, TWCManager refreshes them automatically (the refresh token is
+rotated on each refresh and persisted to the settings file).
+
+## Alternatives to the web login
+
+- Manual token entry: the Settings page has a manual API token override if you already
+  hold FleetAPI tokens.
+- [TeslaMate](Vehicle_TeslaMate.md) token sync.
+- [TeslaBLE](Vehicle_TeslaBLE.md) for local, account-free control.
+
+## Troubleshooting
+
+- "Tesla FleetAPI is not configured": one of `teslaApiClientID`,
+  `teslaApiClientSecret` or `teslaApiRedirectUri` is missing.
+- "state mismatch": the login was started too long ago or in another browser session.
+  Start the login again.
+- A Tesla error code on the result page usually indicates a mismatch between the
+  registered redirect URI / scopes and what was requested. Re-check the application
+  settings at developer.tesla.com.

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -178,19 +178,23 @@
         # "openid offline_access vehicle_device_data vehicle_cmds vehicle_location vehicle_charging_cmds"
         #"teslaApiScope": "openid offline_access vehicle_device_data vehicle_cmds vehicle_location vehicle_charging_cmds",
 
-        # Since 2024 the Tesla Vehicle Command protocol is required for all
-        # vehicles manufacturered after 2021. The Tesla Vehicle Command proxy
-        # will automatically fall back to the FleetAPI for older vehicles.
+        # REQUIRED TO DRIVE CHARGING over the FleetAPI. Tesla has deprecated the
+        # REST charge-command endpoints; charge_start/stop/set-rate now return
+        # 403 "Tesla Vehicle Command Protocol required" on essentially all
+        # vehicles (confirmed even on a 2019 Model 3). Without the proxy below,
+        # the FleetAPI login can still READ vehicle state, but cannot start,
+        # stop or rate-limit charging.
         #
-        # TWCManager does not implement the Tesla Vehicle Command protocol.
-        # Instead it relies on the Tesla Vehicle Command proxy which translates
-        # the FleetAPI REST calls if the destination vehicle supports the
-        # new protocol. This requires the URL of the proxy to be set as
-        # "teslaProxy" and the proxy certificate for validation as
-        # "teslaProxyCert".
+        # TWCManager does not implement the Vehicle Command protocol itself; it
+        # relies on the Tesla Vehicle Command proxy, which signs commands with
+        # your app key and forwards them. Set the proxy URL as "teslaProxy" and
+        # its certificate as "teslaProxyCert".
         # See https://github.com/teslamotors/vehicle-command
         #
-        # The URL of the Tesla HTTP Proxy running locally
+        # (Alternatively, the TeslaBLE module drives charging locally over
+        # Bluetooth with no proxy - see docs/modules/Vehicle_TeslaBLE.md.)
+        #
+        # The URL of the Tesla HTTP Proxy
         # "teslaProxy": "https://localhost:4443",
         #
         # Only set "teslaProxyCert" when "teslaProxy" is set.

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -204,6 +204,12 @@
         # data retrieved from the Tesla API to evaluate policy.
         "cloudUpdateInterval": 1800,
 
+        // wakeDelayMins: how long to wait (minutes) before issuing a Fleet API
+        // wake_up command when a vehicle needs to start charging.  During the
+        // delay the car may self-start in response to the TWC power offer.
+        // Increasing this reduces Fleet API usage; set to 0 to wake immediately.
+        //"wakeDelayMins": 3,
+
         # These parameters enable you to specify different charge limits
         # for different charging policies.  The car's 'outside' limit
         # will be restored whenever GPS indicates the car has left home.

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -145,6 +145,29 @@
         # See https://developer.tesla.com/docs/fleet-api#authentication
         #"teslaApiClientID": "client-id-of-registered-app",
 
+        # The client_secret of the app registered with Tesla. Required to
+        # complete the FleetAPI OAuth login from the web UI (Settings -> Tesla
+        # login). Keep config.json readable only by the twcmanager user.
+        #"teslaApiClientSecret": "client-secret-of-registered-app",
+
+        # The redirect URI registered against your Tesla app. It must match
+        # exactly in both the login request and the token exchange. To let
+        # TWCManager capture the login automatically, register and set this to
+        # the callback on this instance, e.g.
+        # "https://your-twcmanager-host/teslaAccount/callback". If TWCManager is
+        # not reachable at the registered URI you can still paste the redirect
+        # URL into the web UI to complete login.
+        #"teslaApiRedirectUri": "https://your-twcmanager-host/teslaAccount/callback",
+
+        # Your Tesla account region: NA, EU or CN. Selects the FleetAPI audience
+        # used during login. Defaults to NA; can also be chosen on the login page.
+        #"teslaApiRegion": "NA",
+
+        # Optional override of the OAuth scopes requested at login. The default
+        # covers charging control and vehicle data:
+        # "openid offline_access vehicle_device_data vehicle_cmds vehicle_charging_cmds"
+        #"teslaApiScope": "openid offline_access vehicle_device_data vehicle_cmds vehicle_charging_cmds",
+
         # Since 2024 the Tesla Vehicle Command protocol is required for all
         # vehicles manufacturered after 2021. The Tesla Vehicle Command proxy
         # will automatically fall back to the FleetAPI for older vehicles.

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -151,13 +151,16 @@
         #"teslaApiClientSecret": "client-secret-of-registered-app",
 
         # The redirect URI registered against your Tesla app. It must match
-        # exactly in both the login request and the token exchange. To let
-        # TWCManager capture the login automatically, register and set this to
-        # the callback on this instance, e.g.
-        # "https://your-twcmanager-host/teslaAccount/callback". If TWCManager is
-        # not reachable at the registered URI you can still paste the redirect
-        # URL into the web UI to complete login.
-        #"teslaApiRedirectUri": "https://your-twcmanager-host/teslaAccount/callback",
+        # exactly in both the login request and the token exchange, and it must
+        # be an HTTPS URL under the public domain you control (the app's allowed
+        # origin) - NOT TWCManager's LAN address.
+        #
+        # Do NOT expose TWCManager to the internet. The redirect URI does not
+        # need to reach TWCManager: after logging in you simply paste the URL
+        # you were redirected to into the web UI (paste-back). Only set this to
+        # a callback that forwards to TWCManager (e.g. via a reverse proxy you
+        # control) if you specifically want the auto-capture flow.
+        #"teslaApiRedirectUri": "https://twc.yourdomain.com/teslaAccount/callback",
 
         # Your Tesla account region: NA, EU or CN. Selects the FleetAPI audience
         # used during login. Defaults to NA; can also be chosen on the login page.

--- a/etc/twcmanager/config.json
+++ b/etc/twcmanager/config.json
@@ -138,17 +138,14 @@
         # you will need to un-comment it to have it take effect.
         #"minChargeLevel": 10,
 
-        # The client_id of the app registered with Tesla. The legacy Owner API
-        # has been retired by Tesla, so registration is now required for all
-        # cloud-based vehicle control via the FleetAPI and Vehicle Command
-        # protocol. Local BLE control (TeslaBLE) does not require this.
+        # The client_id of the app you register at developer.tesla.com. The
+        # legacy Owner API has been retired, so cloud control now requires your
+        # own registered application. When registering, choose the OAuth grant
+        # type "Authorization Code (Third-Party Tokens)" (NOT "Client
+        # Credentials", which is for partner/machine tokens). Local BLE control
+        # (TeslaBLE) does not require this.
         # See https://developer.tesla.com/docs/fleet-api#authentication
         #"teslaApiClientID": "client-id-of-registered-app",
-
-        # The client_secret of the app registered with Tesla. Required to
-        # complete the FleetAPI OAuth login from the web UI (Settings -> Tesla
-        # login). Keep config.json readable only by the twcmanager user.
-        #"teslaApiClientSecret": "client-secret-of-registered-app",
 
         # The redirect URI registered against your Tesla app. It must match
         # exactly in both the login request and the token exchange, and it must
@@ -162,14 +159,24 @@
         # control) if you specifically want the auto-capture flow.
         #"teslaApiRedirectUri": "https://twc.yourdomain.com/teslaAccount/callback",
 
-        # Your Tesla account region: NA, EU or CN. Selects the FleetAPI audience
-        # used during login. Defaults to NA; can also be chosen on the login page.
+        # OPTIONAL/ADVANCED. By default TWCManager logs in using PKCE (the
+        # standard public-client method) and needs NO client secret. Only set
+        # teslaApiClientSecret if you specifically want the client-secret token
+        # exchange; doing so also requires teslaApiRegion below. Keep config.json
+        # readable only by the twcmanager user if you set this.
+        #"teslaApiClientSecret": "client-secret-of-registered-app",
+
+        # Only used when teslaApiClientSecret is set (the secret-based exchange
+        # needs a regional audience). Your Tesla account region: NA, EU or CN.
+        # Not needed for the default PKCE login (the region is derived from the
+        # token). Defaults to NA.
         #"teslaApiRegion": "NA",
 
         # Optional override of the OAuth scopes requested at login. The default
-        # covers charging control and vehicle data:
-        # "openid offline_access vehicle_device_data vehicle_cmds vehicle_charging_cmds"
-        #"teslaApiScope": "openid offline_access vehicle_device_data vehicle_cmds vehicle_charging_cmds",
+        # covers charging control, vehicle data and location (used for home
+        # geofencing):
+        # "openid offline_access vehicle_device_data vehicle_cmds vehicle_location vehicle_charging_cmds"
+        #"teslaApiScope": "openid offline_access vehicle_device_data vehicle_cmds vehicle_location vehicle_charging_cmds",
 
         # Since 2024 the Tesla Vehicle Command protocol is required for all
         # vehicles manufacturered after 2021. The Tesla Vehicle Command proxy

--- a/lib/TWCManager/Control/HTTPControl.py
+++ b/lib/TWCManager/Control/HTTPControl.py
@@ -207,6 +207,14 @@ def CreateHTTPHandlerClass(master):
             self.templateEnv.globals.update(
                 vehicles=master.getModuleByName("TeslaAPI").getCarApiVehicles
             )
+            teslaModule = master.getModuleByName("TeslaAPI")
+            self.templateEnv.globals.update(
+                teslaLogin=(
+                    teslaModule.teslaLoginInfo
+                    if teslaModule
+                    else (lambda: {"configured": False})
+                )
+            )
 
             # Set master object
             self.master = master
@@ -1036,6 +1044,8 @@ def CreateHTTPHandlerClass(master):
                 {"route": "/settings", "tmpl": "settings.html.j2"},
                 {"route": "/settings/homeLocation", "error": "insecure"},
                 {"route": "/settings/save", "error": "insecure"},
+                {"route": "/teslaAccount/saveToken", "error": "insecure"},
+                {"rstart": "/teslaAccount", "tmpl": "main.html.j2"},
                 {"route": "/upgradePrompt", "tmpl": "upgradePrompt.html.j2"},
                 {"rstart": "/vehicleDetail", "tmpl": "vehicleDetail.html.j2"},
                 {"route": "/vehicles", "tmpl": "vehicles.html.j2"},
@@ -1050,6 +1060,11 @@ def CreateHTTPHandlerClass(master):
                 self.template = self.templateEnv.get_template("main.html.j2")
 
                 # Set some values that we use within the template
+                # The Tesla login form is hidden once we hold an API token.
+                teslaapi = master.getModuleByName("TeslaAPI")
+                self.apiAvailable = bool(
+                    teslaapi and teslaapi.getCarApiBearerToken() != ""
+                )
                 self.scheduledAmpsMax = master.getScheduledAmpsMax()
 
                 self.activeAction = master.getModuleByName(
@@ -1060,6 +1075,36 @@ def CreateHTTPHandlerClass(master):
                 page = self.template.render(vars(self))
 
                 self.wfile.write(page.encode("utf-8"))
+                return
+
+            # Tesla FleetAPI login: redirect the browser to the Tesla consent
+            # page, building the authorization URL from configured credentials.
+            if self.url.path == "/teslaAccount/login":
+                teslaapi = master.getModuleByName("TeslaAPI")
+                qs = urllib.parse.parse_qs(self.url.query)
+                region = qs.get("region", [None])[0]
+                loginURL = teslaapi.getLoginURL(region) if teslaapi else ""
+                self.send_response(302)
+                self.send_header(
+                    "Location", loginURL if loginURL else "/teslaAccount/not_configured"
+                )
+                self.end_headers()
+                self.wfile.write("".encode("utf-8"))
+                return
+
+            # Tesla FleetAPI login: auto-capture callback. Tesla redirects the
+            # browser here (when redirect_uri points at this instance) with the
+            # authorization code, which we exchange for tokens.
+            if self.url.path == "/teslaAccount/callback":
+                teslaapi = master.getModuleByName("TeslaAPI")
+                qs = urllib.parse.parse_qs(self.url.query)
+                code = qs.get("code", [None])[0]
+                state = qs.get("state", [None])[0]
+                res = teslaapi.fleetTokenExchange(code, state) if teslaapi else "error"
+                self.send_response(302)
+                self.send_header("Location", "/teslaAccount/" + res)
+                self.end_headers()
+                self.wfile.write("".encode("utf-8"))
                 return
 
             # Match web routes to defined webroutes routing
@@ -1245,6 +1290,21 @@ def CreateHTTPHandlerClass(master):
                     self.send_response(302)
                     self.send_header("Location", "/graphsP")
 
+                self.end_headers()
+                self.wfile.write("".encode("utf-8"))
+                return
+
+            if self.url.path == "/teslaAccount/saveToken":
+                # Paste-back path: the user pastes the redirect URL they were
+                # sent to after logging in; we extract the code and exchange it.
+                res = "error"
+                url = self.getFieldValue("url")
+                teslaapi = master.getModuleByName("TeslaAPI")
+                if teslaapi and url:
+                    res = teslaapi.saveApiToken(url)
+
+                self.send_response(302)
+                self.send_header("Location", "/teslaAccount/" + res)
                 self.end_headers()
                 self.wfile.write("".encode("utf-8"))
                 return

--- a/lib/TWCManager/Control/themes/Default/handle_teslalogin.html.j2
+++ b/lib/TWCManager/Control/themes/Default/handle_teslalogin.html.j2
@@ -2,6 +2,11 @@
   <font color="blue">
     <b>Success, your Tesla FleetAPI tokens have been stored.</b>
   </font>
+  <p>TWCManager can now read your vehicle state. To <b>drive charging</b>
+     (start/stop/rate-limit), you also need the Tesla Vehicle Command proxy
+     (set <code>teslaProxy</code>) or the TeslaBLE module - Tesla's REST charge
+     commands now require the Vehicle Command Protocol. See the
+     <a href="https://github.com/ngardiner/TWCManager/blob/main/docs/modules/Vehicle_TeslaAPI.md#driving-charging-proxy-or-ble" target="_blank">Driving charging</a> docs.</p>
 {% elif url.path == "/teslaAccount/state_mismatch" %}
   <font color='red'>
     <b>Login security check failed (state mismatch). This usually happens if the

--- a/lib/TWCManager/Control/themes/Default/handle_teslalogin.html.j2
+++ b/lib/TWCManager/Control/themes/Default/handle_teslalogin.html.j2
@@ -1,0 +1,41 @@
+{% if url.path == "/teslaAccount/success" %}
+  <font color="blue">
+    <b>Success, your Tesla FleetAPI tokens have been stored.</b>
+  </font>
+{% elif url.path == "/teslaAccount/state_mismatch" %}
+  <font color='red'>
+    <b>Login security check failed (state mismatch). This usually happens if the
+       login was started a while ago or in another session. Please start the
+       login again.</b>
+  </font>
+{% elif url.path == "/teslaAccount/not_configured" %}
+  <font color='red'>
+    <b>Tesla FleetAPI is not configured. Set teslaApiClientID,
+       teslaApiClientSecret and teslaApiRedirectUri in config.json.</b>
+  </font>
+{% elif url.path == "/teslaAccount/response_no_token" %}
+  <font color='red'>
+    <b>The Tesla API did not return an access token. Please try again.</b>
+  </font>
+{% elif url.path == "/teslaAccount/error" %}
+  <font color='red'>
+    <b>An error occurred during Tesla login. Please check the logs and try
+       again.</b>
+  </font>
+{% elif url.path.startswith("/teslaAccount/")
+        and url.path != "/teslaAccount/login"
+        and url.path != "/teslaAccount/callback"
+        and url.path != "/teslaAccount/saveToken" %}
+  <font color='red'>
+    <b>Tesla reported an error: {{ url.path.split('/')[-1] }}. Please try the
+       login again.</b>
+  </font>
+{% endif %}
+
+{% if not master.tokenSyncEnabled()
+      and url.path != "/teslaAccount/success" %}
+      <!-- Show the login form whenever we don't already hold an API token -->
+      {% if not apiAvailable %}
+          {% include 'request_teslalogin.html.j2' %}
+      {% endif %}
+{% endif %}

--- a/lib/TWCManager/Control/themes/Default/main.html.j2
+++ b/lib/TWCManager/Control/themes/Default/main.html.j2
@@ -11,6 +11,7 @@
     <table border='0' padding='0' margin='0' width='100%'>
       <tr width='100%'>
         <td valign='top' width='70%'>
+          {% include 'handle_teslalogin.html.j2' %}
           {% if master.lastSaveFailed %}
              <font color=red>
                <b>We experienced an error trying to save your settings. This means that while your current settings will be retained for the current session, they will not be saved if TWCManager exits. Please check the permissions on /etc/twcmanager/settings.json and try saving your settings again.</b>

--- a/lib/TWCManager/Control/themes/Default/request_teslalogin.html.j2
+++ b/lib/TWCManager/Control/themes/Default/request_teslalogin.html.j2
@@ -1,0 +1,58 @@
+{% set tl = teslaLogin() %}
+<form action='/teslaAccount/saveToken' method='POST'>
+  <p>TWCManager uses the Tesla FleetAPI to start and stop charging, and to
+     control the charge rate, for Tesla vehicles you own.</p>
+
+  {% if not tl.configured %}
+    <p>
+      <b>Tesla FleetAPI is not configured yet.</b> Tesla retired the old Owner
+      API, so cloud control now requires you to register your own application
+      with Tesla. Set <code>teslaApiClientID</code>,
+      <code>teslaApiClientSecret</code> and <code>teslaApiRedirectUri</code> in
+      your <code>config.json</code>, then reload this page.
+    </p>
+    <p>
+      See the
+      <a href="https://github.com/ngardiner/TWCManager/blob/main/docs/modules/Vehicle_TeslaAPI.md" target="_blank">Tesla FleetAPI setup guide</a>.
+      Prefer not to use a cloud account? The
+      <a href="https://github.com/ngardiner/TWCManager/blob/main/docs/modules/Vehicle_TeslaBLE.md" target="_blank">TeslaBLE</a>
+      module controls charging locally over Bluetooth and needs no Tesla login.
+    </p>
+  {% else %}
+    <table>
+      <tr>
+        <td><b>Step 1</b></td>
+        <td>
+          Select your Tesla account region:
+          <select name="region" id="teslaRegion">
+            {% for r in tl.regions %}
+              <option value="{{ r }}" {% if r == tl.region %}selected{% endif %}>{{ r }}</option>
+            {% endfor %}
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td><b>Step 2</b></td>
+        <td>
+          <a href="/teslaAccount/login?region={{ tl.region }}" target="_blank"
+             onclick="this.href='/teslaAccount/login?region=' + document.getElementById('teslaRegion').value;">Log in to Tesla</a>
+          and approve access. If your configured redirect URI points back at
+          this TWCManager instance you will be returned here automatically.
+          Otherwise, copy the full URL you were redirected to and paste it below.
+        </td>
+      </tr>
+      <tr>
+        <td><b>Paste the redirect URL here:</b></td>
+        <td><input name="url" size=70></td>
+      </tr>
+      <tr>
+        <td>
+          {{ addButton(
+              ["save", "Save Token"],
+              "class='btn btn-outline-info' name='save'",
+          )|safe }}
+        </td>
+      </tr>
+    </table>
+  {% endif %}
+</form>

--- a/lib/TWCManager/Control/themes/Default/request_teslalogin.html.j2
+++ b/lib/TWCManager/Control/themes/Default/request_teslalogin.html.j2
@@ -6,10 +6,11 @@
   {% if not tl.configured %}
     <p>
       <b>Tesla FleetAPI is not configured yet.</b> Tesla retired the old Owner
-      API, so cloud control now requires you to register your own application
-      with Tesla. Set <code>teslaApiClientID</code>,
-      <code>teslaApiClientSecret</code> and <code>teslaApiRedirectUri</code> in
-      your <code>config.json</code>, then reload this page.
+      API, so cloud control now requires you to register your own application at
+      developer.tesla.com (grant type <b>Authorization Code (Third-Party
+      Tokens)</b>). Set <code>teslaApiClientID</code> and
+      <code>teslaApiRedirectUri</code> in your <code>config.json</code>, then
+      reload this page. No client secret is needed for the default login.
     </p>
     <p>
       See the
@@ -20,8 +21,9 @@
     </p>
   {% else %}
     <table>
+      {% if not tl.pkce %}
       <tr>
-        <td><b>Step 1</b></td>
+        <td><b>Region</b></td>
         <td>
           Select your Tesla account region:
           <select name="region" id="teslaRegion">
@@ -31,18 +33,19 @@
           </select>
         </td>
       </tr>
+      {% endif %}
       <tr>
-        <td><b>Step 2</b></td>
+        <td><b>Step 1</b></td>
         <td>
           <a href="/teslaAccount/login?region={{ tl.region }}" target="_blank"
-             onclick="this.href='/teslaAccount/login?region=' + document.getElementById('teslaRegion').value;">Log in to Tesla</a>
+             {% if not tl.pkce %}onclick="this.href='/teslaAccount/login?region=' + document.getElementById('teslaRegion').value;"{% endif %}>Log in to Tesla</a>
           and approve access. If your configured redirect URI points back at
           this TWCManager instance you will be returned here automatically.
           Otherwise, copy the full URL you were redirected to and paste it below.
         </td>
       </tr>
       <tr>
-        <td><b>Paste the redirect URL here:</b></td>
+        <td><b>Step 2 - paste the redirect URL:</b></td>
         <td><input name="url" size=70></td>
       </tr>
       <tr>

--- a/lib/TWCManager/Control/themes/Modern/main.html.j2
+++ b/lib/TWCManager/Control/themes/Modern/main.html.j2
@@ -5,6 +5,7 @@
     <table border='0' style="padding='0'; margin='0'; width='100%';">
       <tr style="width='100%';">
         <td style="valign='top'; width='70%';">
+          {% include 'handle_teslalogin.html.j2' %}
           {% if master.lastSaveFailed %}
              <font color=red>
                <b>We experienced an error trying to save your settings. This mea

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -568,20 +568,6 @@ class TWCSlave:
                 # Car is not charging and is not reporting an error state, so
                 # try starting charge via car api.
                 self.master.startCarsCharging(self.currentVIN)
-            elif self.reportedAmpsActual >= 1.0:
-                # At least one plugged in car is successfully charging. We don't
-                # know which car it is, so we must set
-                # vehicle.stopAskingToStartCharging = False on all vehicles such
-                # that if any vehicle is not charging without us calling
-                # car_api_charge(False), we'll try to start it charging again at
-                # least once. This probably isn't necessary but might prevent
-                # some unexpected case from never starting a charge. It also
-                # seems less confusing to see in the output that we always try
-                # to start API charging after the car stops taking a charge.
-                for vehicle in self.master.getModuleByName(
-                    "TeslaAPI"
-                ).getCarApiVehicles():
-                    vehicle.stopAskingToStartCharging = False
 
         self.master.getModulesByType("Interface")[0]["ref"].send(
             bytearray(b"\xfb\xe0")

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1593,28 +1593,30 @@ class CarApiVehicle:
         return False
 
     def is_awake(self):
-        if self.syncSource == "TeslaAPI" or self.syncTimestamp < (
-            time.time() - self.syncTimeout / 4
-        ):
-            now = time.time()
-            # Don't check more often than every 2 minutes
-            if now - self.lastVehicleAwakeTime < 120:
-                return self.lastVehicleAwakeState
-            url = self.carapi.getCarApiBaseURL() + "/" + str(self.VIN)
-            result, response = self.get_car_api(
-                url, checkReady=False, provesOnline=False
-            )
-            awakeState = result and response.get("state", "") == "online"
-            self.lastVehicleAwakeState = awakeState
-            self.lastVehicleAwakeTime = now
-            return awakeState
-        else:
-            return (
-                self.syncState == "online"
-                or self.syncState == "charging"
-                or self.syncState == "updating"
-                or self.syncState == "driving"
-            )
+        if self.syncSource != "TeslaAPI" and self.syncTimestamp > 0:
+            # External sync (e.g. TeslaMate) has provided at least one update.
+            if self.syncState in ("asleep", "offline"):
+                # Car is known to be asleep - trust the sync source and avoid
+                # Fleet API calls that cost money just to confirm it's still asleep.
+                return False
+            if self.syncTimestamp >= (time.time() - self.syncTimeout / 4):
+                # Fresh data and car is not asleep - trust it.
+                return self.syncState in ("online", "charging", "updating", "driving")
+            # Stale data but car was last known active - fall through to API check
+            # in case the sync source dropped while the car was still awake.
+
+        now = time.time()
+        # Don't check more often than every 2 minutes
+        if now - self.lastVehicleAwakeTime < 120:
+            return self.lastVehicleAwakeState
+        url = self.carapi.getCarApiBaseURL() + "/" + str(self.VIN)
+        result, response = self.get_car_api(
+            url, checkReady=False, provesOnline=False
+        )
+        awakeState = result and response.get("state", "") == "online"
+        self.lastVehicleAwakeState = awakeState
+        self.lastVehicleAwakeTime = now
+        return awakeState
 
     def get_car_api(self, url, checkReady=True, provesOnline=True):
         if checkReady and not self.ready():

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -2,8 +2,10 @@ import json
 import logging
 import re
 import requests
+import secrets
 from threading import Thread
 import time
+from urllib.parse import urlencode, urlsplit, parse_qs
 import jwt
 from TWCManager.Logging.LoggerFactory import LoggerFactory
 
@@ -18,6 +20,16 @@ class TeslaAPI:
         "CN": "https://fleet-api.prd.cn.vn.cloud.tesla.cn/api/1/vehicles",
     }
     refreshClientID = ""
+    # FleetAPI OAuth (authorization code) login. Refresh uses fleetRefreshURL.
+    authorizeURL = "https://auth.tesla.com/oauth2/v3/authorize"
+    clientSecret = ""
+    redirectURI = ""
+    region = "NA"
+    scope = (
+        "openid offline_access vehicle_device_data vehicle_cmds vehicle_charging_cmds"
+    )
+    __loginState = None
+    __loginRegion = None
     verifyCert = True
     carApiLastErrorTime = 0
     carApiBearerToken = ""
@@ -71,6 +83,10 @@ class TeslaAPI:
                 self.baseURL = proxyURL + "/api/1/vehicles"
                 self.verifyCert = self.config["config"].get("teslaProxyCert", True)
             self.refreshClientID = self.config["config"].get("teslaApiClientID", "")
+            self.clientSecret = self.config["config"].get("teslaApiClientSecret", "")
+            self.redirectURI = self.config["config"].get("teslaApiRedirectUri", "")
+            self.region = self.config["config"].get("teslaApiRegion", "NA")
+            self.scope = self.config["config"].get("teslaApiScope", self.scope)
             self.minChargeLevel = self.config["config"].get("minChargeLevel", -1)
             self.chargeUpdateInterval = self.config["config"].get(
                 "cloudUpdateInterval", 1800
@@ -1108,6 +1124,112 @@ class TeslaAPI:
             vehicle.errorCount = 0
         self.errorCount = 0
         return True
+
+    def regionAudience(self, region):
+        # The token audience is the regional FleetAPI base URL without the
+        # /api/1/vehicles path suffix used elsewhere in this module.
+        base = self.regionURL.get(region, self.regionURL["NA"])
+        return base.replace("/api/1/vehicles", "")
+
+    def loginConfigured(self):
+        return bool(self.refreshClientID and self.clientSecret and self.redirectURI)
+
+    def teslaLoginInfo(self):
+        # Consumed by the web UI to render the FleetAPI login page.
+        return {
+            "configured": self.loginConfigured(),
+            "client_id": self.refreshClientID,
+            "redirect_uri": self.redirectURI,
+            "regions": list(self.regionURL.keys()),
+            "region": self.region,
+        }
+
+    def getLoginURL(self, region=None):
+        # Build the FleetAPI authorization-code URL and remember the state and
+        # region so the later token exchange uses a matching audience.
+        if not self.loginConfigured():
+            return ""
+        if region not in self.regionURL:
+            region = self.region
+        self.__loginState = secrets.token_urlsafe(16)
+        self.__loginRegion = region
+        params = {
+            "response_type": "code",
+            "client_id": self.refreshClientID,
+            "redirect_uri": self.redirectURI,
+            "scope": self.scope,
+            "state": self.__loginState,
+            "audience": self.regionAudience(region),
+        }
+        return self.authorizeURL + "?" + urlencode(params)
+
+    def fleetTokenExchange(self, code, state):
+        # Exchange an authorization code for FleetAPI tokens. Returns a status
+        # string used by the web UI ("success", "error", or a Tesla error code).
+        if not self.loginConfigured():
+            logger.error("Tesla FleetAPI login is not configured.")
+            return "not_configured"
+        if not code:
+            logger.error("Tesla login: no authorization code provided.")
+            return "error"
+        if not state or state != self.__loginState:
+            logger.error("Tesla login: state mismatch; please retry the login.")
+            return "state_mismatch"
+
+        region = self.__loginRegion or self.region
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        data = {
+            "grant_type": "authorization_code",
+            "client_id": self.refreshClientID,
+            "client_secret": self.clientSecret,
+            "code": code,
+            "audience": self.regionAudience(region),
+            "redirect_uri": self.redirectURI,
+        }
+        # Note: baseURL is intentionally left to setCarApiBearerToken, which sets
+        # it from the token's region only when no teslaProxy is configured.
+
+        req = None
+        try:
+            req = requests.post(self.fleetRefreshURL, headers=headers, data=data)
+            params = json.loads(req.text)
+        except requests.exceptions.RequestException:
+            logger.error("Request Exception during Tesla token exchange.")
+            return "error"
+        except (ValueError, json.decoder.JSONDecodeError):
+            logger.error("Could not parse Tesla token exchange response.")
+            return "error"
+
+        if "error" in params:
+            # Do not log the full response (may echo request detail); log the code.
+            logger.log(
+                logging.INFO2, "Tesla token exchange error: " + str(params["error"])
+            )
+            return params["error"]
+
+        if "access_token" in params and "refresh_token" in params:
+            self.setCarApiBearerToken(params["access_token"])
+            self.setCarApiRefreshToken(params["refresh_token"])
+            self.setCarApiTokenExpireTime(
+                time.time() + params.get("expires_in", 8 * 60 * 60)
+            )
+            self.__loginState = None
+            self.master.queue_background_task({"cmd": "saveSettings"})
+            logger.log(logging.INFO2, "Tesla FleetAPI tokens stored successfully.")
+            return "success"
+
+        logger.error("Tesla token exchange returned no access token.")
+        return "response_no_token"
+
+    def saveApiToken(self, url):
+        # Paste-back path: extract code and state from the redirect URL the user
+        # copied from their browser, then perform the token exchange.
+        if isinstance(url, bytes):
+            url = url.decode("UTF-8")
+        qs = parse_qs(urlsplit(url).query)
+        code = qs.get("code", [None])[0]
+        state = qs.get("state", [None])[0]
+        return self.fleetTokenExchange(code, state)
 
     def setCarApiBearerToken(self, token=None):
         if token:

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -43,6 +43,7 @@ class TeslaAPI:
     __loginVerifier = None
     verifyCert = True
     carApiLastErrorTime = 0
+    wakeDelayMins = 3
     carApiBearerToken = ""
     carApiRefreshToken = ""
     carApiTokenExpireTime = time.time()
@@ -102,6 +103,7 @@ class TeslaAPI:
             self.chargeUpdateInterval = self.config["config"].get(
                 "cloudUpdateInterval", 1800
             )
+            self.wakeDelayMins = cfg.get("wakeDelayMins", 3)
         except KeyError:
             pass
 
@@ -322,9 +324,6 @@ class TeslaAPI:
                         )
                         continue
 
-                    if vehicle.ready():
-                        continue
-
                     # Don't wake a vehicle we already know is not at home;
                     # waking it would drain its battery unnecessarily (closes #466).
                     if not vehicle.atHome and vehicle.lat != 10000:
@@ -336,16 +335,43 @@ class TeslaAPI:
                         )
                         continue
 
-                    if now - vehicle.lastAPIAccessTime <= vehicle.delayNextWakeAttempt:
-                        logger.debug(
-                            "car_api_available returning False because we are still delaying "
-                            + str(vehicle.delayNextWakeAttempt)
-                            + " seconds after the last failed wake attempt."
+                    # Pre-wake delay: on first detection check awake state once,
+                    # then hold wakeDelayMins before sending wake_up.  During the
+                    # hold window no Fleet API calls are made, giving the car a
+                    # chance to self-start via the TWC offer.
+                    if vehicle.firstChargeNeededTime == 0:
+                        if vehicle.ready():
+                            continue
+                        vehicle.firstChargeNeededTime = now
+                        logger.info(
+                            vehicle.name
+                            + ": deferring wake for "
+                            + str(self.wakeDelayMins)
+                            + " minutes"
                         )
                         return False
 
-                    # It's been delayNextWakeAttempt seconds since we last failed to
-                    # wake the car, or it's never been woken. Wake it.
+                    wakeDelaySecs = self.wakeDelayMins * 60
+                    if now - vehicle.firstChargeNeededTime < wakeDelaySecs:
+                        # Still in pre-wake hold window - no API calls.
+                        return False
+
+                    # Pre-wake delay elapsed.  Honour post-wake retry delay
+                    # before issuing another wake command.
+                    if now - vehicle.lastAPIAccessTime <= vehicle.delayNextWakeAttempt:
+                        logger.debug(
+                            "car_api_available returning False - still in "
+                            + str(vehicle.delayNextWakeAttempt)
+                            + "s post-wake delay."
+                        )
+                        return False
+
+                    # Check whether the car woke itself since the last attempt.
+                    if vehicle.ready():
+                        vehicle.firstChargeNeededTime = 0
+                        continue
+
+                    # Car is still not awake.  Send a wake command.
                     apiResponseDict = self.wakeVehicle(vehicle)
 
                     state = "error"
@@ -377,97 +403,24 @@ class TeslaAPI:
                         if vehicle.firstWakeAttemptTime == 0:
                             vehicle.firstWakeAttemptTime = now
 
-                        if state == "asleep" or state == "waking":
+                        # Fleet API wake credits are finite and expensive.
+                        # Regardless of state (asleep/offline/error), wait 30
+                        # minutes before retrying.  Rapid retries don't help:
+                        # asleep cars can take 2+ minutes to come online after
+                        # the first wake_up, and offline cars may not be
+                        # reachable at all until they self-wake.
+                        if state in ("asleep", "waking"):
                             self.resetCarApiLastErrorTime()
-                            if now - vehicle.firstWakeAttemptTime <= 10 * 60:
-                                # http://visibletesla.com has a 'force wakeup' mode
-                                # that sends wake_up messages once every 5 seconds
-                                # 15 times. This generally manages to wake my car if
-                                # it's returning 'asleep' state, but I don't think
-                                # there is any reason for 5 seconds and 15 attempts.
-                                # The car did wake in two tests with that timing,
-                                # but on the third test, it had not entered online
-                                # mode by the 15th wake_up and took another 10+
-                                # seconds to come online. In general, I hear relays
-                                # in the car clicking a few seconds after the first
-                                # wake_up but the car does not enter 'waking' or
-                                # 'online' state for a random period of time. I've
-                                # seen it take over one minute, 20 sec.
-                                #
-                                # I interpret this to mean a car in 'asleep' mode is
-                                # still receiving car API messages and will start
-                                # to wake after the first wake_up, but it may take
-                                # awhile to finish waking up. Therefore, we try
-                                # waking every 30 seconds for the first 10 mins.
-                                vehicle.delayNextWakeAttempt = 30
-                            elif now - vehicle.firstWakeAttemptTime <= 70 * 60:
-                                # Cars in 'asleep' state should wake within a
-                                # couple minutes in my experience, so we should
-                                # never reach this point. If we do, try every 5
-                                # minutes for the next hour.
-                                vehicle.delayNextWakeAttempt = 5 * 60
-                            else:
-                                # Car hasn't woken for an hour and 10 mins. Try
-                                # again in 15 minutes. We'll show an error about
-                                # reaching this point later.
-                                vehicle.delayNextWakeAttempt = 15 * 60
                         elif state == "offline":
                             self.resetCarApiLastErrorTime()
-                            # In any case it can make sense to wait 5 seconds here.
-                            # I had the issue, that the next command was sent too
-                            # fast and only a reboot of the Raspberry resultet in
-                            # possible reconnect to the API (even the Tesla App
-                            # couldn't connect anymore).
+                            # Brief pause to avoid hammering the API on a
+                            # transient connectivity hiccup.
                             time.sleep(5)
-                            if now - vehicle.firstWakeAttemptTime <= 31 * 60:
-                                # A car in offline state is presumably not connected
-                                # wirelessly so our wake_up command will not reach
-                                # it. Instead, the car wakes itself every 20-30
-                                # minutes and waits some period of time for a
-                                # message, then goes back to sleep. I'm not sure
-                                # what the period of time is, so I tried sending
-                                # wake_up every 55 seconds for 16 minutes but the
-                                # car failed to wake.
-                                # Next I tried once every 25 seconds for 31 mins.
-                                # This worked after 19.5 and 19.75 minutes in 2
-                                # tests but I can't be sure the car stays awake for
-                                # 30secs or if I just happened to send a command
-                                # during a shorter period of wakefulness.
-                                vehicle.delayNextWakeAttempt = 25
-
-                                # I've run tests sending wake_up every 10-30 mins to
-                                # a car in offline state and it will go hours
-                                # without waking unless you're lucky enough to hit
-                                # it in the brief time it's waiting for wireless
-                                # commands. I assume cars only enter offline state
-                                # when set to max power saving mode, and even then,
-                                # they don't always enter the state even after 8
-                                # hours of no API contact or other interaction. I've
-                                # seen it remain in 'asleep' state when contacted
-                                # after 16.5 hours, but I also think I've seen it in
-                                # offline state after less than 16 hours, so I'm not
-                                # sure what the rules are or if maybe Tesla contacts
-                                # the car periodically which resets the offline
-                                # countdown.
-                                #
-                                # I've also seen it enter 'offline' state a few
-                                # minutes after finishing charging, then go 'online'
-                                # on the third retry every 55 seconds.  I suspect
-                                # that might be a case of the car briefly losing
-                                # wireless connection rather than actually going
-                                # into a deep sleep.
-                                # 'offline' may happen almost immediately if you
-                                # don't have the charger plugged in.
                         else:
                             # Handle 'error' state.
                             self.updateCarApiLastErrorTime()
-                            if now - vehicle.firstWakeAttemptTime >= 60 * 60:
-                                # Car hasn't woken for over an hour. Try again
-                                # in 15 minutes. We'll show an error about this
-                                # later.
-                                vehicle.delayNextWakeAttempt = 15 * 60
-                            else:
-                                vehicle.delayNextWakeAttempt = 25
+
+                        vehicle.delayNextWakeAttempt = 30 * 60
 
                         if state == "error":
                             logger.info(
@@ -602,10 +555,13 @@ class TeslaAPI:
         now = time.time()
         apiResponseDict = {}
         if not charge:
-            # Whenever we are going to tell vehicles to stop charging, set
-            # vehicle.stopAskingToStartCharging = False on all vehicles.
+            # Whenever we are going to tell vehicles to stop charging, reset
+            # per-vehicle wake state so the next start cycle is fresh.
             for vehicle in self.getCarApiVehicles():
                 vehicle.stopAskingToStartCharging = False
+                vehicle.firstChargeNeededTime = 0
+                vehicle.firstWakeAttemptTime = 0
+                vehicle.delayNextWakeAttempt = 0
 
         if now - self.getLastStartOrStopChargeTime() < 60:
             # Don't start or stop more often than once a minute
@@ -1487,6 +1443,7 @@ class CarApiVehicle:
     VIN = ""
 
     firstWakeAttemptTime = 0
+    firstChargeNeededTime = 0
     lastAPIAccessTime = 0
     delayNextWakeAttempt = 0
     lastLimitAttemptTime = 0

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -103,7 +103,7 @@ class TeslaAPI:
             self.chargeUpdateInterval = self.config["config"].get(
                 "cloudUpdateInterval", 1800
             )
-            self.wakeDelayMins = cfg.get("wakeDelayMins", 3)
+            self.wakeDelayMins = self.config["config"].get("wakeDelayMins", 3)
         except KeyError:
             pass
 
@@ -394,6 +394,7 @@ class TeslaAPI:
                         # I suspect that happens when we happen to query the car
                         # when it periodically awakens for some reason.
                         vehicle.firstWakeAttemptTime = 0
+                        vehicle.firstChargeNeededTime = 0
                         vehicle.delayNextWakeAttempt = 0
                         # Don't alter vehicle.lastAPIAccessTime because
                         # vehicle.ready() uses it to return True if the last wake

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 import json
 import logging
 import re
@@ -20,16 +22,25 @@ class TeslaAPI:
         "CN": "https://fleet-api.prd.cn.vn.cloud.tesla.cn/api/1/vehicles",
     }
     refreshClientID = ""
-    # FleetAPI OAuth (authorization code) login. Refresh uses fleetRefreshURL.
+    # FleetAPI OAuth (authorization code) login. Two variants, auto-selected by
+    # whether a client secret is configured:
+    #   - PKCE / public client (default, no secret): code_challenge, no audience,
+    #     tokens exchanged/refreshed at auth.tesla.com. This is what most
+    #     registered third-party apps use.
+    #   - Confidential client (teslaApiClientSecret set): client_secret + audience,
+    #     tokens exchanged at the regional fleet-auth endpoint.
     authorizeURL = "https://auth.tesla.com/oauth2/v3/authorize"
+    authTokenURL = "https://auth.tesla.com/oauth2/v3/token"
     clientSecret = ""
     redirectURI = ""
     region = "NA"
     scope = (
-        "openid offline_access vehicle_device_data vehicle_cmds vehicle_charging_cmds"
+        "openid offline_access vehicle_device_data vehicle_cmds "
+        "vehicle_location vehicle_charging_cmds"
     )
     __loginState = None
     __loginRegion = None
+    __loginVerifier = None
     verifyCert = True
     carApiLastErrorTime = 0
     carApiBearerToken = ""
@@ -142,7 +153,9 @@ class TeslaAPI:
             "refresh_token": self.getCarApiRefreshToken(),
             "scope": "offline_access",
         }
-        myRefreshURL = self.fleetRefreshURL
+        # Refresh at the same host the token was issued from: auth.tesla.com for
+        # the PKCE/public-client flow, the regional fleet-auth for confidential.
+        myRefreshURL = self.authTokenURL if self.usePKCE() else self.fleetRefreshURL
         req = None
         now = time.time()
         try:
@@ -1125,14 +1138,20 @@ class TeslaAPI:
         self.errorCount = 0
         return True
 
+    def usePKCE(self):
+        # Public-client PKCE flow is used when no client secret is configured.
+        return not bool(self.clientSecret)
+
     def regionAudience(self, region):
-        # The token audience is the regional FleetAPI base URL without the
-        # /api/1/vehicles path suffix used elsewhere in this module.
+        # Confidential-client only: the token audience is the regional FleetAPI
+        # base URL without the /api/1/vehicles path suffix used elsewhere.
         base = self.regionURL.get(region, self.regionURL["NA"])
         return base.replace("/api/1/vehicles", "")
 
     def loginConfigured(self):
-        return bool(self.refreshClientID and self.clientSecret and self.redirectURI)
+        # Both flows need a client id and redirect URI; the secret is optional
+        # (its presence selects the confidential flow).
+        return bool(self.refreshClientID and self.redirectURI)
 
     def teslaLoginInfo(self):
         # Consumed by the web UI to render the FleetAPI login page.
@@ -1140,13 +1159,14 @@ class TeslaAPI:
             "configured": self.loginConfigured(),
             "client_id": self.refreshClientID,
             "redirect_uri": self.redirectURI,
+            "pkce": self.usePKCE(),
             "regions": list(self.regionURL.keys()),
             "region": self.region,
         }
 
     def getLoginURL(self, region=None):
-        # Build the FleetAPI authorization-code URL and remember the state and
-        # region so the later token exchange uses a matching audience.
+        # Build the authorization URL and remember the state (and PKCE verifier /
+        # region) so the later token exchange matches.
         if not self.loginConfigured():
             return ""
         if region not in self.regionURL:
@@ -1159,13 +1179,24 @@ class TeslaAPI:
             "redirect_uri": self.redirectURI,
             "scope": self.scope,
             "state": self.__loginState,
-            "audience": self.regionAudience(region),
         }
+        if self.usePKCE():
+            self.__loginVerifier = secrets.token_urlsafe(64)
+            params["code_challenge"] = (
+                base64.urlsafe_b64encode(
+                    hashlib.sha256(self.__loginVerifier.encode()).digest()
+                )
+                .rstrip(b"=")
+                .decode()
+            )
+            params["code_challenge_method"] = "S256"
+        else:
+            params["audience"] = self.regionAudience(region)
         return self.authorizeURL + "?" + urlencode(params)
 
     def fleetTokenExchange(self, code, state):
-        # Exchange an authorization code for FleetAPI tokens. Returns a status
-        # string used by the web UI ("success", "error", or a Tesla error code).
+        # Exchange an authorization code for tokens. Returns a status string used
+        # by the web UI ("success", "error", or a Tesla error code).
         if not self.loginConfigured():
             logger.error("Tesla FleetAPI login is not configured.")
             return "not_configured"
@@ -1176,22 +1207,29 @@ class TeslaAPI:
             logger.error("Tesla login: state mismatch; please retry the login.")
             return "state_mismatch"
 
-        region = self.__loginRegion or self.region
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         data = {
             "grant_type": "authorization_code",
             "client_id": self.refreshClientID,
-            "client_secret": self.clientSecret,
             "code": code,
-            "audience": self.regionAudience(region),
             "redirect_uri": self.redirectURI,
         }
-        # Note: baseURL is intentionally left to setCarApiBearerToken, which sets
-        # it from the token's region only when no teslaProxy is configured.
+        if self.usePKCE():
+            # Public client: prove possession of the PKCE verifier; no secret,
+            # no audience, exchange at auth.tesla.com.
+            data["code_verifier"] = self.__loginVerifier or ""
+            tokenURL = self.authTokenURL
+        else:
+            # Confidential client: secret + regional audience at fleet-auth.
+            data["client_secret"] = self.clientSecret
+            data["audience"] = self.regionAudience(self.__loginRegion or self.region)
+            tokenURL = self.fleetRefreshURL
+        # baseURL is left to setCarApiBearerToken, which derives the region from
+        # the token's ou_code when no teslaProxy is configured.
 
         req = None
         try:
-            req = requests.post(self.fleetRefreshURL, headers=headers, data=data)
+            req = requests.post(tokenURL, headers=headers, data=data)
             params = json.loads(req.text)
         except requests.exceptions.RequestException:
             logger.error("Request Exception during Tesla token exchange.")
@@ -1214,6 +1252,7 @@ class TeslaAPI:
                 time.time() + params.get("expires_in", 8 * 60 * 60)
             )
             self.__loginState = None
+            self.__loginVerifier = None
             self.master.queue_background_task({"cmd": "saveSettings"})
             logger.log(logging.INFO2, "Tesla FleetAPI tokens stored successfully.")
             return "success"

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -856,13 +856,6 @@ class TeslaAPI:
             logger.log(logging.INFO8, "applyChargeLimit skipped")
             return "error"
 
-        if not self.car_api_available():
-            logger.log(
-                logging.INFO8,
-                "applyChargeLimit return because car_api_available() == False",
-            )
-            return "error"
-
         now = time.time()
         if (
             not checkArrival
@@ -1664,8 +1657,14 @@ class CarApiVehicle:
             self.carapi.updateCarApiLastErrorTime(self)
             return (False, None)
 
-    def update_location(self):
+    def update_location(self, minInterval=0):
         if self.syncSource == "TeslaAPI":
+            if minInterval > 0:
+                # Caller only needs fresh data if older than minInterval seconds.
+                # Set statusDeferral to skip the API call if data is recent enough.
+                now = time.time()
+                if now - self.lastAPIAccessTime < minInterval:
+                    return True
             return self.update_vehicle_data()
 
         else:

--- a/lib/TWCManager/Vehicle/VehiclePriority.py
+++ b/lib/TWCManager/Vehicle/VehiclePriority.py
@@ -73,7 +73,9 @@ class VehiclePriority:
                             ret = module_method(*args, **kwargs)
 
                             # Track success/failure
-                            if ret:
+                            # TeslaAPI returns "success"/"error" strings; treat
+                            # "error" as failure so the priority fallback works.
+                            if ret and ret != "error":
                                 logger.debug(
                                     f"VehiclePriority: {module_name}.{name}() succeeded on attempt {attempt + 1}"
                                 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography<3.4
+cryptography>=2.6
 build
 growattServer==0.1.1
 jinja2>=2.11.2

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description="Controls the charge rate of certain versions of Tesla Wall Connector (TWC) via the built-in Load Sharing protocol.",
     # Dependencies
     install_requires=[
-        "cryptography<3.4",
+        "cryptography>=2.6",
         "growattServer>=1.0.0",
         "jinja2>=2.11.2",
         "ocpp",

--- a/tests/unit/test_teslaapi_fleetlogin.py
+++ b/tests/unit/test_teslaapi_fleetlogin.py
@@ -1,8 +1,11 @@
 """
-Unit tests for the TeslaAPI FleetAPI OAuth login flow.
+Unit tests for the TeslaAPI FleetAPI Authorization Code login flow.
 
-Covers authorization URL construction, login state validation and the
-authorization-code token exchange (including the paste-back path).
+Two variants are auto-selected by whether a client secret is configured:
+  - PKCE / public client (default, no secret): code_challenge, no audience,
+    tokens exchanged at auth.tesla.com.
+  - Confidential client (secret set): client_secret + audience, tokens
+    exchanged at the regional fleet-auth endpoint.
 """
 
 from urllib.parse import urlsplit, parse_qs
@@ -10,16 +13,20 @@ from urllib.parse import urlsplit, parse_qs
 import pytest
 from unittest.mock import Mock
 
-TOKEN_URL = "https://fleet-auth.prd.vn.cloud.tesla.com/oauth2/v3/token"
+PKCE_TOKEN_URL = "https://auth.tesla.com/oauth2/v3/token"
+CONF_TOKEN_URL = "https://fleet-auth.prd.vn.cloud.tesla.com/oauth2/v3/token"
+REDIRECT = "https://twc.example.com/teslaAccount/callback"
 
 
 def make_master(**config_overrides):
-    """Mock master whose .config carries the FleetAPI login settings."""
+    """Mock master whose .config carries the FleetAPI login settings.
+
+    Defaults to the PKCE flow (no client secret); pass teslaApiClientSecret to
+    exercise the confidential flow.
+    """
     cfg = {
         "teslaApiClientID": "my-client-id",
-        "teslaApiClientSecret": "my-client-secret",
-        "teslaApiRedirectUri": "https://twc.example.com/teslaAccount/callback",
-        "teslaApiRegion": "NA",
+        "teslaApiRedirectUri": REDIRECT,
     }
     cfg.update(config_overrides)
 
@@ -30,111 +37,118 @@ def make_master(**config_overrides):
     return master
 
 
-@pytest.fixture
-def teslaapi():
+def new_api(**config_overrides):
     from TWCManager.Vehicle.TeslaAPI import TeslaAPI
 
-    api = TeslaAPI(make_master())
+    api = TeslaAPI(make_master(**config_overrides))
     # Start each test without inherited class-level token state
     api.carApiBearerToken = ""
     api.carApiRefreshToken = ""
     return api
 
 
-class TestLoginURL:
-    def test_login_url_built_correctly(self, teslaapi):
-        url = teslaapi.getLoginURL("NA")
-        split = urlsplit(url)
-        assert split.scheme == "https"
-        assert split.netloc == "auth.tesla.com"
-        assert split.path == "/oauth2/v3/authorize"
+@pytest.fixture
+def pkce_api():
+    return new_api()  # no secret -> PKCE
 
-        qs = parse_qs(split.query)
-        assert qs["response_type"] == ["code"]
-        assert qs["client_id"] == ["my-client-id"]
-        assert qs["redirect_uri"] == ["https://twc.example.com/teslaAccount/callback"]
-        assert qs["audience"] == ["https://fleet-api.prd.na.vn.cloud.tesla.com"]
-        assert "vehicle_charging_cmds" in qs["scope"][0]
-        assert qs["state"][0]  # a state value was generated
-        # State is remembered for the later exchange
-        assert teslaapi._TeslaAPI__loginState == qs["state"][0]
 
-    def test_login_url_region_audience(self, teslaapi):
-        qs = parse_qs(urlsplit(teslaapi.getLoginURL("EU")).query)
-        assert qs["audience"] == ["https://fleet-api.prd.eu.vn.cloud.tesla.com"]
+@pytest.fixture
+def conf_api():
+    return new_api(teslaApiClientSecret="my-client-secret", teslaApiRegion="NA")
 
-    def test_login_url_empty_when_not_configured(self):
-        from TWCManager.Vehicle.TeslaAPI import TeslaAPI
 
-        api = TeslaAPI(make_master(teslaApiClientSecret=""))
+class TestMode:
+    def test_pkce_is_default(self, pkce_api):
+        assert pkce_api.usePKCE() is True
+        info = pkce_api.teslaLoginInfo()
+        assert info["configured"] is True and info["pkce"] is True
+
+    def test_secret_selects_confidential(self, conf_api):
+        assert conf_api.usePKCE() is False
+        assert conf_api.teslaLoginInfo()["pkce"] is False
+
+    def test_not_configured_without_client_id(self):
+        api = new_api(teslaApiClientID="")
         assert api.getLoginURL("NA") == ""
         assert api.teslaLoginInfo()["configured"] is False
+        assert api.fleetTokenExchange("auth-code", "state") == "not_configured"
+
+
+class TestLoginURL:
+    def test_pkce_url_has_challenge_no_audience(self, pkce_api):
+        qs = parse_qs(urlsplit(pkce_api.getLoginURL("NA")).query)
+        assert qs["response_type"] == ["code"]
+        assert qs["client_id"] == ["my-client-id"]
+        assert qs["redirect_uri"] == [REDIRECT]
+        assert qs["code_challenge_method"] == ["S256"]
+        assert qs["code_challenge"][0]
+        assert "audience" not in qs
+        # location scope is needed for home geofencing
+        assert "vehicle_location" in qs["scope"][0]
+        assert "vehicle_charging_cmds" in qs["scope"][0]
+        assert pkce_api._TeslaAPI__loginState == qs["state"][0]
+
+    def test_confidential_url_has_audience_no_challenge(self, conf_api):
+        qs = parse_qs(urlsplit(conf_api.getLoginURL("EU")).query)
+        assert qs["audience"] == ["https://fleet-api.prd.eu.vn.cloud.tesla.com"]
+        assert "code_challenge" not in qs
 
 
 class TestTokenExchange:
-    def test_state_mismatch_rejected(self, teslaapi, requests_mock):
-        adapter = requests_mock.post(TOKEN_URL, json={})
-        teslaapi.getLoginURL("NA")  # sets a known state
-        result = teslaapi.fleetTokenExchange("auth-code", "not-the-state")
-        assert result == "state_mismatch"
+    def test_state_mismatch_rejected(self, pkce_api, requests_mock):
+        adapter = requests_mock.post(PKCE_TOKEN_URL, json={})
+        pkce_api.getLoginURL("NA")
+        assert pkce_api.fleetTokenExchange("auth-code", "wrong") == "state_mismatch"
         assert adapter.call_count == 0
-        assert teslaapi.getCarApiBearerToken() == ""
+        assert pkce_api.getCarApiBearerToken() == ""
 
-    def test_successful_exchange_stores_tokens(self, teslaapi, requests_mock):
+    def test_pkce_exchange_uses_verifier_no_secret(self, pkce_api, requests_mock):
         requests_mock.post(
-            TOKEN_URL,
-            json={
-                "access_token": "ACCESS123",
-                "refresh_token": "REFRESH456",
-                "expires_in": 28800,
-            },
+            PKCE_TOKEN_URL,
+            json={"access_token": "A", "refresh_token": "R", "expires_in": 28800},
         )
-        url = teslaapi.getLoginURL("NA")
-        state = parse_qs(urlsplit(url).query)["state"][0]
+        state = parse_qs(urlsplit(pkce_api.getLoginURL("NA")).query)["state"][0]
+        assert pkce_api.fleetTokenExchange("auth-code", state) == "success"
+        assert pkce_api.getCarApiBearerToken() == "A"
+        assert pkce_api.getCarApiRefreshToken() == "R"
 
-        result = teslaapi.fleetTokenExchange("auth-code", state)
-
-        assert result == "success"
-        assert teslaapi.getCarApiBearerToken() == "ACCESS123"
-        assert teslaapi.getCarApiRefreshToken() == "REFRESH456"
-
-        # The exchange must send the confidential-client fields Tesla requires
         body = parse_qs(requests_mock.last_request.text)
         assert body["grant_type"] == ["authorization_code"]
         assert body["client_id"] == ["my-client-id"]
-        assert body["client_secret"] == ["my-client-secret"]
         assert body["code"] == ["auth-code"]
-        assert body["audience"] == ["https://fleet-api.prd.na.vn.cloud.tesla.com"]
-        assert body["redirect_uri"] == ["https://twc.example.com/teslaAccount/callback"]
-        # State is consumed after a successful exchange
-        assert teslaapi._TeslaAPI__loginState is None
+        assert body["redirect_uri"] == [REDIRECT]
+        assert body["code_verifier"][0]
+        assert "client_secret" not in body
+        assert "audience" not in body
+        # state + verifier consumed
+        assert pkce_api._TeslaAPI__loginState is None
+        assert pkce_api._TeslaAPI__loginVerifier is None
 
-    def test_tesla_error_returned(self, teslaapi, requests_mock):
-        requests_mock.post(TOKEN_URL, json={"error": "invalid_grant"})
-        state = parse_qs(urlsplit(teslaapi.getLoginURL("NA")).query)["state"][0]
-        assert teslaapi.fleetTokenExchange("auth-code", state) == "invalid_grant"
-        assert teslaapi.getCarApiBearerToken() == ""
-
-    def test_not_configured_returns_status(self, requests_mock):
-        from TWCManager.Vehicle.TeslaAPI import TeslaAPI
-
-        api = TeslaAPI(make_master(teslaApiClientSecret=""))
-        assert api.fleetTokenExchange("auth-code", "state") == "not_configured"
-
-    def test_paste_back_path(self, teslaapi, requests_mock):
+    def test_confidential_exchange_uses_secret_audience(self, conf_api, requests_mock):
         requests_mock.post(
-            TOKEN_URL,
-            json={
-                "access_token": "ACCESS123",
-                "refresh_token": "REFRESH456",
-                "expires_in": 28800,
-            },
+            CONF_TOKEN_URL,
+            json={"access_token": "A", "refresh_token": "R", "expires_in": 28800},
         )
-        state = parse_qs(urlsplit(teslaapi.getLoginURL("NA")).query)["state"][0]
-        pasted = (
-            "https://twc.example.com/teslaAccount/callback"
-            "?code=pasted-code&state=" + state
+        state = parse_qs(urlsplit(conf_api.getLoginURL("NA")).query)["state"][0]
+        assert conf_api.fleetTokenExchange("auth-code", state) == "success"
+
+        body = parse_qs(requests_mock.last_request.text)
+        assert body["client_secret"] == ["my-client-secret"]
+        assert body["audience"] == ["https://fleet-api.prd.na.vn.cloud.tesla.com"]
+        assert "code_verifier" not in body
+
+    def test_tesla_error_returned(self, pkce_api, requests_mock):
+        requests_mock.post(PKCE_TOKEN_URL, json={"error": "invalid_grant"})
+        state = parse_qs(urlsplit(pkce_api.getLoginURL("NA")).query)["state"][0]
+        assert pkce_api.fleetTokenExchange("auth-code", state) == "invalid_grant"
+        assert pkce_api.getCarApiBearerToken() == ""
+
+    def test_paste_back_path(self, pkce_api, requests_mock):
+        requests_mock.post(
+            PKCE_TOKEN_URL,
+            json={"access_token": "A", "refresh_token": "R", "expires_in": 28800},
         )
-        assert teslaapi.saveApiToken(pasted) == "success"
-        assert teslaapi.getCarApiBearerToken() == "ACCESS123"
+        state = parse_qs(urlsplit(pkce_api.getLoginURL("NA")).query)["state"][0]
+        pasted = f"{REDIRECT}?code=pasted-code&state={state}"
+        assert pkce_api.saveApiToken(pasted) == "success"
         assert parse_qs(requests_mock.last_request.text)["code"] == ["pasted-code"]

--- a/tests/unit/test_teslaapi_fleetlogin.py
+++ b/tests/unit/test_teslaapi_fleetlogin.py
@@ -1,0 +1,140 @@
+"""
+Unit tests for the TeslaAPI FleetAPI OAuth login flow.
+
+Covers authorization URL construction, login state validation and the
+authorization-code token exchange (including the paste-back path).
+"""
+
+from urllib.parse import urlsplit, parse_qs
+
+import pytest
+from unittest.mock import Mock
+
+TOKEN_URL = "https://fleet-auth.prd.vn.cloud.tesla.com/oauth2/v3/token"
+
+
+def make_master(**config_overrides):
+    """Mock master whose .config carries the FleetAPI login settings."""
+    cfg = {
+        "teslaApiClientID": "my-client-id",
+        "teslaApiClientSecret": "my-client-secret",
+        "teslaApiRedirectUri": "https://twc.example.com/teslaAccount/callback",
+        "teslaApiRegion": "NA",
+    }
+    cfg.update(config_overrides)
+
+    master = Mock()
+    master.config = {"config": cfg, "vehicle": {"teslaAPI": {"enabled": True}}}
+    # tokenSyncEnabled() must be falsey or setCarApiBearerToken refuses the token
+    master.tokenSyncEnabled.return_value = False
+    return master
+
+
+@pytest.fixture
+def teslaapi():
+    from TWCManager.Vehicle.TeslaAPI import TeslaAPI
+
+    api = TeslaAPI(make_master())
+    # Start each test without inherited class-level token state
+    api.carApiBearerToken = ""
+    api.carApiRefreshToken = ""
+    return api
+
+
+class TestLoginURL:
+    def test_login_url_built_correctly(self, teslaapi):
+        url = teslaapi.getLoginURL("NA")
+        split = urlsplit(url)
+        assert split.scheme == "https"
+        assert split.netloc == "auth.tesla.com"
+        assert split.path == "/oauth2/v3/authorize"
+
+        qs = parse_qs(split.query)
+        assert qs["response_type"] == ["code"]
+        assert qs["client_id"] == ["my-client-id"]
+        assert qs["redirect_uri"] == ["https://twc.example.com/teslaAccount/callback"]
+        assert qs["audience"] == ["https://fleet-api.prd.na.vn.cloud.tesla.com"]
+        assert "vehicle_charging_cmds" in qs["scope"][0]
+        assert qs["state"][0]  # a state value was generated
+        # State is remembered for the later exchange
+        assert teslaapi._TeslaAPI__loginState == qs["state"][0]
+
+    def test_login_url_region_audience(self, teslaapi):
+        qs = parse_qs(urlsplit(teslaapi.getLoginURL("EU")).query)
+        assert qs["audience"] == ["https://fleet-api.prd.eu.vn.cloud.tesla.com"]
+
+    def test_login_url_empty_when_not_configured(self):
+        from TWCManager.Vehicle.TeslaAPI import TeslaAPI
+
+        api = TeslaAPI(make_master(teslaApiClientSecret=""))
+        assert api.getLoginURL("NA") == ""
+        assert api.teslaLoginInfo()["configured"] is False
+
+
+class TestTokenExchange:
+    def test_state_mismatch_rejected(self, teslaapi, requests_mock):
+        adapter = requests_mock.post(TOKEN_URL, json={})
+        teslaapi.getLoginURL("NA")  # sets a known state
+        result = teslaapi.fleetTokenExchange("auth-code", "not-the-state")
+        assert result == "state_mismatch"
+        assert adapter.call_count == 0
+        assert teslaapi.getCarApiBearerToken() == ""
+
+    def test_successful_exchange_stores_tokens(self, teslaapi, requests_mock):
+        requests_mock.post(
+            TOKEN_URL,
+            json={
+                "access_token": "ACCESS123",
+                "refresh_token": "REFRESH456",
+                "expires_in": 28800,
+            },
+        )
+        url = teslaapi.getLoginURL("NA")
+        state = parse_qs(urlsplit(url).query)["state"][0]
+
+        result = teslaapi.fleetTokenExchange("auth-code", state)
+
+        assert result == "success"
+        assert teslaapi.getCarApiBearerToken() == "ACCESS123"
+        assert teslaapi.getCarApiRefreshToken() == "REFRESH456"
+
+        # The exchange must send the confidential-client fields Tesla requires
+        body = parse_qs(requests_mock.last_request.text)
+        assert body["grant_type"] == ["authorization_code"]
+        assert body["client_id"] == ["my-client-id"]
+        assert body["client_secret"] == ["my-client-secret"]
+        assert body["code"] == ["auth-code"]
+        assert body["audience"] == ["https://fleet-api.prd.na.vn.cloud.tesla.com"]
+        assert body["redirect_uri"] == ["https://twc.example.com/teslaAccount/callback"]
+        # State is consumed after a successful exchange
+        assert teslaapi._TeslaAPI__loginState is None
+
+    def test_tesla_error_returned(self, teslaapi, requests_mock):
+        requests_mock.post(TOKEN_URL, json={"error": "invalid_grant"})
+        state = parse_qs(urlsplit(teslaapi.getLoginURL("NA")).query)["state"][0]
+        assert teslaapi.fleetTokenExchange("auth-code", state) == "invalid_grant"
+        assert teslaapi.getCarApiBearerToken() == ""
+
+    def test_not_configured_returns_status(self, requests_mock):
+        from TWCManager.Vehicle.TeslaAPI import TeslaAPI
+
+        api = TeslaAPI(make_master(teslaApiClientSecret=""))
+        assert api.fleetTokenExchange("auth-code", "state") == "not_configured"
+
+    def test_paste_back_path(self, teslaapi, requests_mock):
+        requests_mock.post(
+            TOKEN_URL,
+            json={
+                "access_token": "ACCESS123",
+                "refresh_token": "REFRESH456",
+                "expires_in": 28800,
+            },
+        )
+        state = parse_qs(urlsplit(teslaapi.getLoginURL("NA")).query)["state"][0]
+        pasted = (
+            "https://twc.example.com/teslaAccount/callback"
+            "?code=pasted-code&state=" + state
+        )
+        assert teslaapi.saveApiToken(pasted) == "success"
+        assert teslaapi.getCarApiBearerToken() == "ACCESS123"
+        assert parse_qs(requests_mock.last_request.text)["code"] == ["pasted-code"]


### PR DESCRIPTION
Restores a guided in-UI Tesla login, now FleetAPI-correct, following the Owner API removal in #640. Without this, cloud tokens can only be hand-pasted, synced from TeslaMate, or skipped via BLE.

## Flow
- Authorize (browser): `auth.tesla.com/oauth2/v3/authorize` with `response_type=code`, `client_id`, `redirect_uri`, `scope`, `state`, and `audience` (the regional FleetAPI base URL).
- Token exchange (server): form-encoded `authorization_code` POST to `fleet-auth.prd.vn.cloud.tesla.com/oauth2/v3/token` with `client_id` + `client_secret` + `code` + `audience` + `redirect_uri`.
- Two callback options, same exchange code:
  - Auto-capture: register `https://<host>/teslaAccount/callback`; Tesla returns the browser to TWCManager and login completes with no copy/paste.
  - Paste-back: copy the redirect URL and paste it into the web UI (works for LAN-only installs).
- Refresh path was already FleetAPI-correct (`client_id` + `refresh_token`, rotates the refresh token); unchanged.

## Changes
- `TeslaAPI.py`: `getLoginURL`, `fleetTokenExchange` (state validation, form-encoded exchange, token storage), `saveApiToken` (paste parser), `teslaLoginInfo`/`regionAudience` helpers.
- `HTTPControl.py`: `/teslaAccount/login`, `/teslaAccount/callback`, `POST /teslaAccount/saveToken`, `teslaLogin` template global, cheap token-based `apiAvailable` (no live API call).
- Web UI: config-aware Fleet login templates (region picker, login link, paste box), re-included in both themes.
- New config fields: `teslaApiClientSecret`, `teslaApiRedirectUri`, `teslaApiRegion`, `teslaApiScope`.
- New setup guide `docs/modules/Vehicle_TeslaAPI.md`; README pointer; CHANGELOG entry.

## Config
Set `teslaApiClientID`, `teslaApiClientSecret`, `teslaApiRedirectUri` (+ optional `teslaApiRegion`/`teslaApiScope`) in config.json. Registering a developer.tesla.com app and the Vehicle Command proxy / partner registration remain external prerequisites (documented, not automated).

## Tests
8 unit tests (requests-mock): authorize URL construction, region audience, state-mismatch rejection, successful exchange asserting `client_secret`/`audience`/`grant_type`, Tesla error passthrough, paste-back. `test_httpcontrol`/`test_vehicle_priority`/`test_twcslave` still pass.