### PR TITLE
sendCommand might be called with a VIN or a Vehicle

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaBLE.py
+++ b/lib/TWCManager/Vehicle/TeslaBLE.py
@@ -411,6 +411,9 @@ class TeslaBLE:
         Enhanced sendCommand with improved error handling and timeout management.
         Returns command output string or None on failure.
         """
+        # Accept either a VIN string or a vehicle object with a .VIN attribute
+        if hasattr(vin, "VIN"):
+            vin = vin.VIN
         return self._execute_with_retry(self._sendCommand_internal, vin, command, args)
 
     def _sendCommand_internal(self, vin, command, args=None):


### PR DESCRIPTION
Was getting lots of BLE errors like this:

```
Jun 27 19:47:59 twcmanager python3[13451]: 19:47:59 🚗 TeslaBLE 20 BLE command failed for <TWCManager.Vehicle.TeslaAPI.CarApiVehicle object at 0xb3644d20>, retrying in 8s (attempt 3/4)
Jun 27 19:48:07 twcmanager python3[13451]: 19:48:07 🚗 TeslaBLE 40 Vehicle <TWCManager.Vehicle.TeslaAPI.CarApiVehicle object at 0xb3644d20> not found in settings
Jun 27 19:48:07 twcmanager python3[13451]: 19:48:07 🚗 TeslaBLE 40 BLE command failed for <TWCManager.Vehicle.TeslaAPI.CarApiVehicle object at 0xb3644d20> after 4 attempts
Jun 27 19:48:07 twcmanager python3[13451]: 19:48:07 🚗 TeslaBLE 40 Failed to send charging-set-amps command to <TWCManager.Vehicle.TeslaAPI.CarApiVehicle object at 0xb3644d20>
```

Looks like someone's passing the Vehicle directly, rather than extracting the VIN. Normalizing here makes for more idiomatic use elsewhere.