### PR TITLE
Additional success indicators

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaBLE.py
+++ b/lib/TWCManager/Vehicle/TeslaBLE.py
@@ -279,6 +279,11 @@ class TeslaBLE:
             "Command executed successfully",
             "Vehicle responded",
             "Success",
+            # "Already in desired state" responses — car is charging or done; goal achieved
+            "car could not execute command: complete",
+            "car could not execute command: is_charging",
+            "car could not execute command: charging",
+            "car could not execute command: requested",
         ]
 
         # Error indicators for detailed logging


### PR DESCRIPTION
Fixes #649, I think.

But it still reports failed:

Jun 27 20:27:55 twcmanager python3[17868]: Failed to execute command: car could not execute command: complete
Jun 27 20:27:55 twcmanager python3[17868]: 20:27:55 🚗 TeslaBLE 20 Start charging for 5YJ3E1EB9LF539561: success
Jun 27 20:27:57 twcmanager python3[17868]: 20:27:57 🚗 TeslaBLE 30 BLE command failed for vehicle 5YJ3E1EB9LF539561
Jun 27 20:27:57 twcmanager python3[17868]: 20:27:57 🚗 TeslaBLE 20 BLE command result: 0/1 vehicles responded

This appears to be from the ping, which is somewhat inconsistent. Why do we need the ping if we already got a response to the start/stop command?