### PR TITLE
Set non-preferred rate to maximum

### DIFF
--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -79,6 +79,7 @@ class TWCSlave:
         self.TWCID = TWCID
         self.maxAmps = maxAmps
         self.APIcontrol = False
+        self.vehicleRateRaised = False
 
         self.wiringMaxAmps = self.configConfig.get("wiringMaxAmpsPerTWC", 6)
         self.useFlexAmpsToStartCharge = self.configConfig.get(
@@ -861,6 +862,7 @@ class TWCSlave:
             # Control is given to the Tesla API to control Charge Rate
             # We offer the maximum wiring amps from the TWC, and ask the API to control charge rate
             self.APIcontrol = True
+            self.vehicleRateRaised = False
 
             # Call the Tesla API to set the charge rate for vehicle connected to this TWC
             # TODO: Identify vehicle
@@ -890,13 +892,17 @@ class TWCSlave:
             desiredAmpsOffered = self.wiringMaxAmps
 
         else:
-            # If we just switched from API to TWC make sure the car is set to a
-            # high enough charge rate so it is not limiting the TWC control
-            if chargeRateControl == 3 and self.APIcontrol:
+            # TWC is controlling the charge rate here. The car only ever
+            # charges at min(TWC offer, car's own charge rate limit), so make
+            # sure the car isn't left capped below what TWC is about to offer
+            # (e.g. leftover from API control, the Tesla app, or never raised
+            # since startup) before relying on the TWC-side value alone.
+            if not self.vehicleRateRaised:
                 self.vehicleModule.setChargeRate(
                     self.wiringMaxAmps, self.getLastVehicle()
                 )
-                self.APIcontrol = False
+                self.vehicleRateRaised = True
+            self.APIcontrol = False
 
             # We can tell the TWC how much power to use in 0.01A increments, but
             # the car will only alter its power in larger increments (somewhere

--- a/lib/TWCManager/TWCSlave.py
+++ b/lib/TWCManager/TWCSlave.py
@@ -80,6 +80,7 @@ class TWCSlave:
         self.maxAmps = maxAmps
         self.APIcontrol = False
         self.vehicleRateRaised = False
+        self.__vehicleRateRaiseAttemptTime = 0
 
         self.wiringMaxAmps = self.configConfig.get("wiringMaxAmpsPerTWC", 6)
         self.useFlexAmpsToStartCharge = self.configConfig.get(
@@ -863,6 +864,7 @@ class TWCSlave:
             # We offer the maximum wiring amps from the TWC, and ask the API to control charge rate
             self.APIcontrol = True
             self.vehicleRateRaised = False
+            self.__vehicleRateRaiseAttemptTime = 0
 
             # Call the Tesla API to set the charge rate for vehicle connected to this TWC
             # TODO: Identify vehicle
@@ -897,11 +899,15 @@ class TWCSlave:
             # sure the car isn't left capped below what TWC is about to offer
             # (e.g. leftover from API control, the Tesla app, or never raised
             # since startup) before relying on the TWC-side value alone.
-            if not self.vehicleRateRaised:
-                self.vehicleModule.setChargeRate(
+            if not self.vehicleRateRaised and (
+                now - self.__vehicleRateRaiseAttemptTime >= 60
+            ):
+                self.__vehicleRateRaiseAttemptTime = now
+                result = self.vehicleModule.setChargeRate(
                     self.wiringMaxAmps, self.getLastVehicle()
                 )
-                self.vehicleRateRaised = True
+                if result is not False:
+                    self.vehicleRateRaised = True
             self.APIcontrol = False
 
             # We can tell the TWC how much power to use in 0.01A increments, but

--- a/lib/TWCManager/Vehicle/TeslaBLE.py
+++ b/lib/TWCManager/Vehicle/TeslaBLE.py
@@ -344,6 +344,7 @@ class TeslaBLE:
             "Command executed successfully",
             "Vehicle responded",
             "Success",
+            "ok",
         ]
 
         output_lower = output.lower()
@@ -530,22 +531,19 @@ class TeslaBLE:
                 )
                 return None
             elif return_code != 0:
+                output = stderr.decode("utf-8") if stderr else ""
                 logger.warning(
-                    f"BLE command '{command}' failed with return code {return_code}"
+                    f"BLE command '{command}' failed with return code {return_code}: {output}"
                 )
+                return None
 
             output = stderr.decode("utf-8") if stderr else ""
-
-            # Log full output when command fails, truncate for success
-            if return_code != 0:
-                logger.warning(f"BLE command full error output: {output}")
-            else:
-                logger.debug(
-                    f"BLE command output: {output[:200]}..."
-                    if len(output) > 200
-                    else output
-                )
-            return output
+            logger.debug(
+                f"BLE command output: {output[:200]}..."
+                if len(output) > 200
+                else output
+            )
+            return output or "ok"
 
         except Exception as e:
             logger.error(f"sendCommand exception: {e}")


### PR DESCRIPTION
The Settings option allows choosing to control the rate with *either* API/BLE to set what the car pulls *or* TWC rate commands to control what the car is offered. However, the reality is that the true charging rate is the minimum of the two. If you want to reduce the rate, you can obviously reduce either; but if you want to raise the rate you need to make sure both go up.

Both directions now covered in TWCSlave.py:

- API/BLE control mode (2/3<6A): already forced TWC offer to wiringMaxAmps (untouched).
- TWC control mode (1, or 3≥6A): now raises car's own charge-rate limit to wiringMaxAmps via vehicleModule.setChargeRate once per control-mode entry (tracked with new self.vehicleRateRaised flag, reset when switching into API control), so car doesn't stay capped by a stale lower limit from prior API control, Tesla app, or startup default.

Net effect: whichever side isn't the active controller gets bumped to max, so min(TWC offer, car limit) always equals the intended target rather than silently ceiling at whatever the non-preferred side happened to be left at.