### PR TITLE
Hook already_satisfied further down in the loop

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaBLE.py
+++ b/lib/TWCManager/Vehicle/TeslaBLE.py
@@ -529,22 +529,29 @@ class TeslaBLE:
                     f"BLE command '{command}' timed out after {self.commandTimeout}s"
                 )
                 return None
-            elif return_code != 0:
+            output = stderr.decode("utf-8") if stderr else ""
+
+            if return_code != 0:
+                if self._is_already_satisfied(output):
+                    # Car rejected the command because it's already in the
+                    # desired state. That's a success, not something to
+                    # retry - retrying would just get the same rejection.
+                    logger.debug(
+                        f"BLE command '{command}' already satisfied: {output[:200]}"
+                    )
+                    return output
+
                 logger.warning(
                     f"BLE command '{command}' failed with return code {return_code}"
                 )
-
-            output = stderr.decode("utf-8") if stderr else ""
-
-            # Log full output when command fails, truncate for success
-            if return_code != 0:
                 logger.warning(f"BLE command full error output: {output}")
-            else:
-                logger.debug(
-                    f"BLE command output: {output[:200]}..."
-                    if len(output) > 200
-                    else output
-                )
+                return None
+
+            logger.debug(
+                f"BLE command output: {output[:200]}..."
+                if len(output) > 200
+                else output
+            )
             return output
 
         except Exception as e:


### PR DESCRIPTION
The already_satified version that was in the merged piece only checked after all the retries have failed. This moves the check inside the retries, causing the attempt to succeed without additional loops.