### PR TITLE
fix: actually start the TeslaMate token resync timer

### DIFF
--- a/lib/TWCManager/Vehicle/TeslaMateVehicle.py
+++ b/lib/TWCManager/Vehicle/TeslaMateVehicle.py
@@ -80,8 +80,17 @@ class TeslaMateVehicle(TelmetryBase):
         if self.syncTokens:
             self.doSyncTokens(True)
 
-            # After initial sync, set a timer to continue to sync the tokens every hour
-            resync = threading.Timer(3600, self.doSyncTokens)
+            # After initial sync, keep resyncing the tokens every hour
+            self.scheduleTokenResync()
+
+    def scheduleTokenResync(self):
+        resync = threading.Timer(3600, self.resyncTokens)
+        resync.daemon = True
+        resync.start()
+
+    def resyncTokens(self):
+        self.doSyncTokens()
+        self.scheduleTokenResync()
 
     def decrypt_data(self, encrypted_data):
         """


### PR DESCRIPTION
The hourly resync Timer was constructed but never started (and not stored), so token-sync mode only ever synced once at startup despite the comment claiming an hourly refresh. Start it, and have it reschedule itself so resyncs keep happening indefinitely.

(Noticed incidentally while fixing something else; I don't use this path myself, and it might not be relevant with the switch to Fleet API while TeslaMate hasn't yet.)