### PR TITLE
Storm Watch silently degrading on stale Fleet API token

### DIFF
--- a/lib/TWCManager/EMS/TeslaPowerwall2.py
+++ b/lib/TWCManager/EMS/TeslaPowerwall2.py
@@ -237,6 +237,7 @@ class TeslaPowerwall2:
 
     def getStormWatch(self):
         carapi = self.master.getModuleByName("TeslaAPI")
+        carapi.refreshTokenIfNeeded()
         token = carapi.getCarApiBearerToken()
         expiry = carapi.getCarApiTokenExpireTime()
         baseURL = carapi.getCarApiBaseURL()
@@ -300,12 +301,17 @@ class TeslaPowerwall2:
                         bodyjson = r.json()
                         lastData = bodyjson["response"]
                     except Exception as e:
-                        if r.status_code == 403:
+                        if hasattr(e, "response") and e.response is not None and e.response.status_code == 403:
                             logger.warn(
                                 "Error fetching Powerwall cloud data; does your API token have energy_device_data scope?"
                             )
                         else:
                             logger.warning(f"Error fetching Powerwall data: {e}")
+            else:
+                logger.log(
+                    logging.INFO8,
+                    "Skipping Storm Watch check; Tesla API token unavailable or expired.",
+                )
 
             self.lastFetch[key] = (now, lastData)
         return lastData

--- a/lib/TWCManager/TWCManager.py
+++ b/lib/TWCManager/TWCManager.py
@@ -935,6 +935,15 @@ while True:
         # slave TWC, repeat the query
         master.retryVINQuery()
 
+        # Periodically refresh the Tesla Fleet API token even if no vehicle
+        # command has run recently, so read-only features like Storm Watch
+        # don't rely on a charge/wake command to keep it alive.
+        if (time.time() - master.lastTeslaTokenRefreshCheck) > (60 * 5):
+            master.lastTeslaTokenRefreshCheck = time.time()
+            carapi = master.getModuleByName("TeslaAPI")
+            if carapi:
+                carapi.refreshTokenIfNeeded()
+
         ########################################################################
         # See if there's an incoming message on the input interface.
 

--- a/lib/TWCManager/TWCMaster.py
+++ b/lib/TWCManager/TWCMaster.py
@@ -32,6 +32,7 @@ class TWCMaster:
     generationValues = {}
     lastkWhMessage = time.time()
     lastkWhPoll = 0
+    lastTeslaTokenRefreshCheck = 0
     lastSaveFailed = 0
     lastTWCResponseMsg = None
     lastUpdateCheck = 0

--- a/lib/TWCManager/Vehicle/TeslaAPI.py
+++ b/lib/TWCManager/Vehicle/TeslaAPI.py
@@ -203,6 +203,20 @@ class TeslaAPI:
 
         return False
 
+    def refreshTokenIfNeeded(self):
+        # Proactively refresh the bearer token if it's missing or close to
+        # expiry. Called both from car_api_available() (ahead of vehicle
+        # commands) and from read-only callers such as Storm Watch, which
+        # otherwise have no other path that keeps the token alive.
+        now = time.time()
+        if not self.master.tokenSyncEnabled() and (
+            self.getCarApiBearerToken() == ""
+            or self.getCarApiTokenExpireTime() - now < 60 * 60
+        ):
+            if self.getCarApiRefreshToken() != "":
+                logger.log(logging.INFO8, "Attempting token refresh")
+                self.apiRefresh()
+
     def car_api_available(self, charge=None, applyLimit=None):
         now = time.time()
         needSleep = False
@@ -234,13 +248,7 @@ class TeslaAPI:
             )
 
         # Authenticate to Tesla API
-        if not self.master.tokenSyncEnabled() and (
-            self.getCarApiBearerToken() == ""
-            or self.getCarApiTokenExpireTime() - now < 60 * 60
-        ):
-            if self.getCarApiRefreshToken() != "":
-                logger.log(logging.INFO8, "Attempting token refresh")
-                self.apiRefresh()
+        self.refreshTokenIfNeeded()
 
         if self.getCarApiBearerToken() != "":
             if self.getVehicleCount() < 1:


### PR DESCRIPTION
Storm Watch (TeslaPowerwall2.getStormWatch()) only ever read the Fleet API bearer token/expiry passively — it never triggered a refresh itself, and the only refresh path in the codebase (TeslaAPI.car_api_available()) was called exclusively from vehicle-command code (charge, wake, apply limit). Any deployment where nothing sends those commands — e.g. relying on BLE for local vehicle control never refreshed the token, so Storm Watch quietly went stale and cached an empty result for up to 30 minutes at a time with zero logging.

Fix: extracted the refresh-if-stale check out of car_api_available() into a standalone TeslaAPI.refreshTokenIfNeeded(), called it directly from getStormWatch(), and added a periodic call to it in the main loop (every 5 minutes) independent of any vehicle command.

(Also fixed a latent UnboundLocalError in the exception handler (referenced r.status_code when the request itself could throw before r was ever assigned) and added a debug-level log line for the previously-silent skip path.)